### PR TITLE
Keep an existing realmlist.wtf as .bak instead of destroying it

### DIFF
--- a/ichalaunch/game/client_install.py
+++ b/ichalaunch/game/client_install.py
@@ -89,8 +89,44 @@ def bundled_realmlist() -> Path:
     return data_file("realmlist.wtf")
 
 
+def _preserve_existing_realmlist(dest: Path, payload: bytes) -> bool:
+    """Keep an existing realmlist.wtf as .bak / .bak2 / .bak3 before replacing it.
+
+    A hand-edited realmlist is the user's own work and used to be destroyed
+    without warning. A numbered copy beside the original costs a few bytes and
+    leaves the old contents somewhere they can be found.
+
+    Returns True when the caller may go ahead and write.
+    """
+    try:
+        if not dest.is_file():
+            return True
+        if dest.read_bytes() == payload:
+            # Already what we would write -- do not manufacture a backup of it.
+            return False
+    except OSError as exc:
+        log.warning("Could not read %s: %s", dest, exc)
+        return False
+
+    for n in range(1, 100):
+        spare = dest.with_suffix(".bak" if n == 1 else f".bak{n}")
+        if spare.exists():
+            continue
+        try:
+            shutil.copy2(dest, spare)
+        except OSError as exc:
+            # Never trade the user's realmlist for a failed backup.
+            log.warning("Could not preserve %s (%s); leaving it alone", dest, exc)
+            return False
+        log.info("Preserved existing realmlist -> %s", spare)
+        return True
+
+    log.warning("Too many realmlist backups beside %s; leaving it alone", dest)
+    return False
+
+
 def apply_bundled_realmlist(game_root: Path) -> None:
-    """Overwrite realmlist.wtf in the game home (and any copies in the tree)."""
+    """Write the bundled realmlist.wtf, keeping any existing one as .bak."""
     src = bundled_realmlist()
     if not src.is_file():
         log.warning("Bundled realmlist.wtf missing at %s", src)
@@ -98,12 +134,16 @@ def apply_bundled_realmlist(game_root: Path) -> None:
     payload = src.read_bytes()
     targets = {game_root / "realmlist.wtf"}
     try:
-        for found in game_root.rglob("realmlist.wtf"):
-            if found.is_file():
+        # Matched case-insensitively: clients ship both realmlist.wtf and
+        # RealmList.wtf, and only Windows treats those as the same file.
+        for found in game_root.rglob("*.wtf"):
+            if found.name.lower() == "realmlist.wtf" and found.is_file():
                 targets.add(found)
     except OSError:
         pass
     for dest in targets:
+        if not _preserve_existing_realmlist(dest, payload):
+            continue
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(payload)
         log.info("Wrote realmlist.wtf -> %s", dest)


### PR DESCRIPTION
I'm running IchaLaunch on CachyOS Linux (arch-based gaming distro like SteamOS), and I lost a realmlist.wtf file that I'd edited by hand.

If you point the launcher at a client you already have, `apply_bundled_realmlist` overwrites `realmlist.wtf` in the game folder **and every other copy it can find** by walking the whole tree. There's no prompt and no warning. This isn't Linux-specific — it happens on Windows too, any time someone re-selects their existing client folder.

This keeps the old one instead of destroying it. Each file that's about to be replaced is backed up first as `realmlist.bak`, then `.bak2`, `.bak3` and so on, so nothing is lost and the guts of these text files are sitting right there if someone needs them.

A few details that seemed worth getting right:

- If the file already matches what would be written byte-for-byte, then no backup is made. Otherwise re-selecting your folder a few times buries the one backup that mattered under identical copies.
- It copies rather than renames, so there's never a moment where `realmlist.wtf` doesn't exist.
- If the backup itself can't be written, it leaves the original alone rather than overwriting it. Losing the file because the rescue failed would be worse than the original bug.

I also made the filename match case-insensitively. Clients ship `Data/enUS/RealmList.wtf` as well, and on Linux the current `rglob("realmlist.wtf")` doesn't see it at all.

Tested both spellings, repeated runs, and the read-only case where the backup can't be created.
