### PR TITLE
Linux: launch the client through umu-launcher

### DIFF
--- a/ichalaunch/config/settings.py
+++ b/ichalaunch/config/settings.py
@@ -57,6 +57,11 @@ def settings_path() -> Path:
 
 DEFAULTS: dict[str, Any] = {
     "game_path": "",
+    # Linux launch. Empty proton path means "resolve and then pin".
+    "linux_umu_path": "",
+    "linux_proton_path": "",
+    "linux_use_latest_proton": False,
+    "linux_wineprefix": "",
     "addons_path": "",
     "vanillafixes_enabled": True,
     "minimize_on_launch": False,

--- a/ichalaunch/core/process.py
+++ b/ichalaunch/core/process.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Any, Callable
@@ -313,8 +314,15 @@ def wow_exe_running() -> bool:
 def launch_exe(path: Path, cwd: Path | None = None) -> subprocess.Popen:
     if not path.exists():
         raise FileNotFoundError(str(path))
+    workdir = cwd or path.parent
+    if sys.platform != "win32":
+        # A Windows PE cannot be exec'd here: it needs Proton, and the
+        # supported way to drive Proton outside Steam is umu-launcher.
+        from ichalaunch.game.proton import launch_windows_exe
+
+        return launch_windows_exe(path, workdir)
     return subprocess.Popen(
         [str(path)],
-        cwd=str(cwd or path.parent),
+        cwd=str(workdir),
         shell=False,
     )

--- a/ichalaunch/game/launcher.py
+++ b/ichalaunch/game/launcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -233,7 +234,7 @@ def launch_exe_note(game_path: Path, exe: Path) -> str | None:
     return None
 
 
-def launch_game() -> None:
+def launch_game() -> subprocess.Popen | None:
     game = detect_game()
     if not game:
         raise FileNotFoundError("Game not installed / path not set")
@@ -244,7 +245,9 @@ def launch_game() -> None:
     note = launch_exe_note(game, exe)
     if note:
         log.info("Launch note: %s", note)
-    launch_exe(exe, cwd=game)
+    # Returned rather than discarded: on Linux the caller has to watch this
+    # for an early non-zero exit, which is the only sign the launch failed.
+    return launch_exe(exe, cwd=game)
 
 
 def gofile_content_id(url: str) -> str | None:

--- a/ichalaunch/game/proton.py
+++ b/ichalaunch/game/proton.py
@@ -1,0 +1,253 @@
+"""Launching a Windows game executable on Linux, via umu-launcher.
+
+Windows runs the client directly; everywhere else it needs Proton, and the
+supported way to drive Proton outside Steam is umu-launcher, which ships
+Valve's own Steam Linux Runtime. This module locates umu-run and a Proton
+build; it does not download or bundle either.
+
+PINNING IS THE DEFAULT. ``PROTONPATH=GE-Proton`` asks umu for the *latest*
+build, which would silently move a working install onto an untested runtime.
+The first successful resolution is therefore written back to settings as an
+absolute path, and honoured from then on. Tracking latest is opt-in.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from ichalaunch.config.settings import appdata_root, settings
+from ichalaunch.core.logging_setup import log
+
+# Where Steam-family installs keep third-party compatibility tools. Probed
+# blind rather than by distro: no launcher branches on distro, and several of
+# these alias the same directory (~/.steam/root and ~/.steam/steam commonly
+# resolve to ~/.local/share/Steam), which is why results are deduplicated by
+# device+inode rather than by string.
+_COMPAT_DIR = "compatibilitytools.d"
+_STEAM_ROOTS = (
+    "~/.steam/root",
+    "~/.steam/steam",
+    "~/.steam",
+    "~/.local/share/Steam",
+    "~/.var/app/com.valvesoftware.Steam/data/Steam",
+    "~/snap/steam/common/.local/share/Steam",
+    "/usr/share/steam",
+)
+
+UMU_MISSING_MSG = (
+    "umu-run was not found. Install umu-launcher (package 'umu-launcher' on "
+    "Arch; a COPR on Fedora; a release from Open-Wine-Components on GitHub "
+    "elsewhere), or set a full path in Settings."
+)
+PROTON_MISSING_MSG = (
+    "No Proton build was found. Install one with ProtonUp-Qt, or via Steam, "
+    "so that it appears under a compatibilitytools.d folder."
+)
+
+
+def find_umu_run() -> Path | None:
+    """umu-run on PATH, then the usual per-user install location."""
+    configured = (settings.get("linux_umu_path") or "").strip()
+    if configured:
+        p = Path(configured).expanduser()
+        if p.is_file() and os.access(p, os.X_OK):
+            return p
+        raise FileNotFoundError(
+            f"The umu-run path set in Settings is not a runnable file:\n{p}"
+        )
+    found = shutil.which("umu-run")
+    if found:
+        return Path(found)
+    fallback = Path.home() / ".local/bin/umu-run"
+    return fallback if fallback.is_file() else None
+
+
+def _is_proton_build(d: Path) -> bool:
+    """A compatibility tool umu will actually accept.
+
+    umu refuses any PROTONPATH without a toolmanifest.vdf, so accepting a
+    directory on the strength of its 'proton' script alone gets that build
+    pinned and then rejected on every launch from then on.
+    """
+    return (d / "toolmanifest.vdf").is_file()
+
+
+def discover_proton_builds() -> list[Path]:
+    """Every Proton build on disk, newest-looking first, deduplicated."""
+    roots: list[Path] = []
+    for raw in _STEAM_ROOTS:
+        roots.append(Path(raw).expanduser() / _COMPAT_DIR)
+    for extra in (os.environ.get("STEAM_EXTRA_COMPAT_TOOLS_PATHS") or "").split(":"):
+        if extra.strip():
+            roots.append(Path(extra.strip()).expanduser())
+
+    seen: set[tuple[int, int]] = set()
+    builds: list[Path] = []
+    for root in roots:
+        try:
+            st = root.stat()
+        except OSError:
+            continue
+        if (st.st_dev, st.st_ino) in seen:
+            continue
+        seen.add((st.st_dev, st.st_ino))
+        try:
+            entries = sorted(root.iterdir())
+        except OSError:
+            continue
+        for d in entries:
+            if d.is_dir() and _is_proton_build(d):
+                builds.append(d)
+    builds.sort(key=_version_key, reverse=True)
+    return builds
+
+
+def _version_key(path: Path) -> tuple[int, list[int], str]:
+    """Sort newest-first by the numbers in the name.
+
+    A build whose name carries no digits -- 'Proton-GE Latest', which some
+    launchers materialise as a real directory -- sorts last, so automatic
+    selection never lands on a moving target.
+    """
+    nums = [int(n) for n in re.findall(r"\d+", path.name)]
+    # Shorter name wins a numeric tie, so 'GE-Proton10-34 (copy)' never
+    # outranks 'GE-Proton10-34'.
+    return (1 if nums else 0, nums, -len(path.name), path.name.lower())
+
+
+def resolve_proton_path() -> Path | None:
+    """The Proton build to use, pinning the choice the first time it is made."""
+    pinned = (settings.get("linux_proton_path") or "").strip()
+    if pinned and not settings.get("linux_use_latest_proton", False):
+        p = Path(pinned).expanduser()
+        if _is_proton_build(p):
+            return p
+        # Say which build vanished rather than silently substituting another.
+        log.warning("Pinned Proton build is missing: %s", p)
+
+    builds = discover_proton_builds()
+    if not builds:
+        return None
+    chosen = builds[0]
+    if not settings.get("linux_use_latest_proton", False):
+        try:
+            settings.set("linux_proton_path", str(chosen))
+        except OSError as exc:
+            # The pin is a convenience; a settings write failure must not
+            # stop a launch that would otherwise work.
+            log.warning("Could not pin Proton build: %s", exc)
+        else:
+            log.info("Pinned Proton build: %s", chosen)
+    return chosen
+
+
+def wineprefix_for(game_dir: Path) -> Path:
+    """Launcher-owned prefix, so no assumption is made about the user's layout."""
+    configured = (settings.get("linux_wineprefix") or "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return appdata_root() / "prefixes" / game_dir.name
+
+
+def build_launch_command(exe: Path, cwd: Path) -> tuple[list[str], dict[str, str]]:
+    """argv and environment for running *exe* under umu. Raises if unusable."""
+    umu = find_umu_run()
+    if umu is None:
+        raise FileNotFoundError(UMU_MISSING_MSG)
+    proton = resolve_proton_path()
+    if proton is None:
+        raise FileNotFoundError(PROTON_MISSING_MSG)
+
+    prefix = wineprefix_for(cwd)
+    try:
+        prefix.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Could not create the Wine prefix at:\n{prefix}\n\n{exc}\n\n"
+            "Pick a writable location in Settings."
+        ) from exc
+
+    env = dict(os.environ)
+    # A launch has to be reproducible, so drop the variables that would
+    # silently choose a different runtime or a different set of DLLs than the
+    # one being pinned. UMU_NO_PROTON replaces Proton outright, PROTON_VERB
+    # can turn the launch into a no-wait shim, and WINEDLLOVERRIDES would
+    # fight the DLL chain the client ships (DXVK's d3d9 among them).
+    for name in (
+        "LD_PRELOAD",
+        "PROTON_NO_ESYNC",
+        "PROTON_NO_FSYNC",
+        "PROTON_USE_WINED3D",
+        "PROTON_VERB",
+        "SDL_VIDEODRIVER",
+        "STEAM_COMPAT_CLIENT_INSTALL_PATH",
+        "STEAM_COMPAT_DATA_PATH",
+        "UMU_NO_PROTON",
+        "UMU_RUNTIME_UPDATE",
+        "WINEDLLOVERRIDES",
+    ):
+        env.pop(name, None)
+
+    env.update({
+        "WINEPREFIX": str(prefix),
+        "PROTONPATH": str(proton),
+        "GAMEID": "umu-default",
+        "STORE": "none",
+    })
+    return [str(umu), str(exe)], env
+
+
+def launch_log_path() -> Path:
+    """Where umu's own output is kept, so a failed launch can be explained."""
+    return appdata_root() / "logs" / "umu-launch.log"
+
+
+def launch_log_tail(limit: int = 1200) -> str:
+    """The end of the last launch log, for showing the user what went wrong."""
+    try:
+        data = launch_log_path().read_bytes()[-limit:]
+    except OSError:
+        return ""
+    return data.decode("utf-8", "replace").strip()
+
+
+def launch_windows_exe(exe: Path, cwd: Path) -> subprocess.Popen:
+    argv, env = build_launch_command(exe, cwd)
+    log.info("Launching via umu: %s (proton=%s)", exe, env.get("PROTONPATH"))
+
+    # umu reports a bad Proton build, an unusable prefix or a failed runtime
+    # download on stderr, which goes nowhere a windowed launcher can show. Send
+    # it to a file rather than a pipe: nothing here drains a pipe, and umu is
+    # chatty enough on first run to fill one and stall the child behind it.
+    sink = None
+    try:
+        path = launch_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        sink = path.open("wb")
+    except OSError as exc:
+        log.warning("Could not open the umu launch log (%s); output is lost", exc)
+
+    try:
+        if sink is None:
+            return subprocess.Popen(argv, cwd=str(cwd), env=env, shell=False)
+        return subprocess.Popen(
+            argv,
+            cwd=str(cwd),
+            env=env,
+            shell=False,
+            stdout=sink,
+            stderr=subprocess.STDOUT,
+        )
+    finally:
+        if sink is not None:
+            # The child holds its own descriptor; this one has done its job.
+            sink.close()
+
+
+def is_linux() -> bool:
+    return sys.platform != "win32"

--- a/ichalaunch/ui/main_window.py
+++ b/ichalaunch/ui/main_window.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 import time
 from pathlib import Path
 
@@ -42,6 +44,12 @@ from PySide6.QtWidgets import (
 )
 
 from ichalaunch.ui.widgets import dialogs as themed
+
+# How long a launched client is watched for an early failure, and how often.
+# Long enough to catch umu refusing a Proton build or an unusable prefix,
+# short enough that a working launch is not held up noticeably.
+_LAUNCH_GRACE_S = 8.0
+_LAUNCH_POLL_MS = 250
 
 _RESIZE_MARGIN = 6
 _CORNER_RADIUS = 14
@@ -2324,16 +2332,65 @@ class MainWindow(QMainWindow):
                     self._fail_play_launch("Launch cancelled")
                     return
             self._show_play_launch_progress("Launching game…")
-            launch_game()
-            self.status_lbl.setText("Game launched")
-            themed.close_open_themed_dialogs(self)
-            if settings.get("close_on_launch"):
-                self.close()
-            elif settings.get("minimize_on_launch"):
-                self.showMinimized()
+            proc = launch_game()
+            if proc is not None and os.name != "nt":
+                self._watch_launch(proc)
+                return
+            self._launch_succeeded()
         except Exception as exc:  # noqa: BLE001
             self._fail_play_launch(f"Launch failed: {str(exc)[:80]}")
             themed.error(self, "Launch failed", str(exc))
+
+    def _launch_succeeded(self) -> None:
+        self.status_lbl.setText("Game launched")
+        themed.close_open_themed_dialogs(self)
+        if settings.get("close_on_launch"):
+            self.close()
+        elif settings.get("minimize_on_launch"):
+            self.showMinimized()
+
+    def _watch_launch(self, proc: subprocess.Popen) -> None:
+        """Give the child a moment to fail before calling the launch a success.
+
+        Windows runs the client directly, so Popen returning means it started.
+        Elsewhere it runs under umu, which exits non-zero when the Proton build,
+        the prefix or the runtime is unusable -- and does so a second or two
+        later, with its reasons in a log file rather than on any terminal. The
+        window used to close on the line after Popen, so a launch that failed
+        looked exactly like one that worked.
+
+        Polled from a timer rather than waited on, because this runs on the GUI
+        thread. Nothing is treated as failure except an early non-zero exit.
+        """
+        from ichalaunch.game.proton import launch_log_tail
+
+        deadline = time.monotonic() + _LAUNCH_GRACE_S
+        self._show_play_launch_progress(
+            "Launching game… first run may download the Steam Linux Runtime"
+        )
+
+        def check() -> None:
+            code = proc.poll()
+            if code is None:
+                if time.monotonic() < deadline:
+                    QTimer.singleShot(_LAUNCH_POLL_MS, check)
+                else:
+                    self._launch_succeeded()
+                return
+            if code == 0:
+                self._launch_succeeded()
+                return
+            tail = launch_log_tail()
+            log.warning("Launch exited early with code %s", code)
+            self._fail_play_launch(f"Launch failed (exit code {code})")
+            themed.error(
+                self,
+                "Launch failed",
+                f"The game exited immediately, with code {code}.\n\n"
+                + (tail or "No output was captured from the launch."),
+            )
+
+        QTimer.singleShot(_LAUNCH_POLL_MS, check)
 
     def _offer_permission_fix(
         self,

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -3087,6 +3087,72 @@ def test_themed_dialog_flags_and_close():
     close_open_themed_dialogs(root)
     assert not dlg.isVisible()
     print("OK themed dialog flags and close")
+def test_linux_proton_launch_resolution():
+    """Proton discovery, pin-by-default, and command assembly.
+
+    Uses a stub settings object throughout: resolving a build PINS it, and a
+    test must never write into the user's real configuration.
+    """
+    if sys.platform == "win32":
+        print("OK linux proton launch resolution (skipped on Windows)")
+        return
+
+    import os
+
+    from ichalaunch.game import proton
+
+    class _Stub:
+        def __init__(self, d):
+            self.d = dict(d)
+
+        def get(self, k, default=None):
+            return self.d.get(k, default)
+
+        def set(self, k, v):
+            self.d[k] = v
+
+    real = proton.settings
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            tools = root / "compatibilitytools.d"
+            for name in ("GE-Proton9-20", "GE-Proton10-34", "Proton-GE Latest", "notatool"):
+                (tools / name).mkdir(parents=True)
+            for name in ("GE-Proton9-20", "GE-Proton10-34", "Proton-GE Latest"):
+                (tools / name / "toolmanifest.vdf").write_text("x")
+
+            proton.settings = _Stub({"linux_proton_path": "", "linux_wineprefix": "",
+                                     "linux_use_latest_proton": False, "linux_umu_path": ""})
+            os.environ["STEAM_EXTRA_COMPAT_TOOLS_PATHS"] = str(tools)
+            try:
+                builds = [b.name for b in proton.discover_proton_builds()
+                          if str(b).startswith(str(tools))]
+            finally:
+                os.environ.pop("STEAM_EXTRA_COMPAT_TOOLS_PATHS", None)
+
+            # A directory without a manifest is not a Proton build.
+            assert "notatool" not in builds, builds
+            # Numeric names sort newest-first; a digit-less name never wins
+            # automatic selection, because it is a moving target.
+            assert builds[0] == "GE-Proton10-34", builds
+            assert builds.index("GE-Proton9-20") < builds.index("Proton-GE Latest"), builds
+
+            # Pinning: the resolved build is written back and then honoured.
+            stub = proton.settings
+            stub.set("linux_proton_path", str(tools / "GE-Proton9-20"))
+            assert proton.resolve_proton_path().name == "GE-Proton9-20"
+
+            # A missing umu-run is a clear error, not a traceback.
+            stub.set("linux_umu_path", str(root / "no-such-umu"))
+            try:
+                proton.build_launch_command(root / "WoW.exe", root)
+                raise AssertionError("expected FileNotFoundError")
+            except FileNotFoundError as exc:
+                assert "umu-run" in str(exc), str(exc)
+    finally:
+        proton.settings = real
+
+    print("OK linux proton launch resolution")
 
 
 def main():
@@ -3159,6 +3225,7 @@ def _run_smoke_tests():
     test_vanillafixes_preserves_dlls_txt()
     test_apply_desired_state_restores_dlls_txt()
     test_prepare_for_launch_syncs_dlls_txt()
+    test_linux_proton_launch_resolution()
     test_prepare_for_launch_clears_data_readonly()
     test_plan_missing_installs_dxvk()
     test_play_prep_plans_remove()


### PR DESCRIPTION
IchaLaunch will happily install a client on Linux that it then can't start.  Good times.

`WoW.exe` is a Windows PE, so `subprocess.Popen` on it just fails. This routes non-Windows launches through [umu-launcher](https://github.com/Open-Wine-Components/umu-launcher), which is the supported way to drive Proton outside Steam and ships Valve's own Steam Linux Runtime. Nothing is bundled and nothing is downloaded by the launcher — if umu or Proton isn't installed, it says which one and where to get it.

**Finding Proton.** Builds are picked up from the usual `compatibilitytools.d` locations and deduplicated by device and inode, because `~/.steam/root`, `~/.steam/steam` and `~/.local/share/Steam` are usually the same directory and a string comparison lists every build three times. A directory only counts as a build if it has a `toolmanifest.vdf`, which is what umu itself requires — accepting one because it has a `proton` script would pin a build umu then refuses on every launch afterwards.

**Pinning is the default.** The first build chosen is written back as an absolute path, so a Proton release later on can't quietly move a working install onto a runtime nobody has tested. Following the newest build is opt-in. A name with no version number in it never wins automatic selection, and a shorter name wins a tie so a backup copy can't outrank the build it was copied from.

**Failed launches used to be invisible.** On Windows, Popen returning means the game started. Under umu the process exits a second or two later when the Proton build or the prefix is unusable, and it explains why on stderr — which goes nowhere in a windowed app. The launcher closed on the next line, so a failed launch looked exactly like a working one. Now umu's output is captured to a log, the process is polled from a timer for a few seconds, and an early non-zero exit shows a dialog quoting what umu actually said. The progress line also mentions that a first run may download the Steam Linux Runtime, which takes several minutes and otherwise looks like a hang.

The environment is also scrubbed of variables that would silently pick a different runtime or different DLLs than the one being pinned — `UMU_NO_PROTON` replaces Proton entirely, `PROTON_VERB` can turn the launch into a shim that doesn't wait, and `WINEDLLOVERRIDES` would fight the DLL chain the client ships. All good things to know in advance.

The Windows path is untouched — it reaches the same success handler the old code ran inline. The new test skips itself on Windows.
