### PR TITLE
Resolve game paths case-insensitively outside Windows

### DIFF
--- a/ichalaunch/core/filesystem.py
+++ b/ichalaunch/core/filesystem.py
@@ -205,6 +205,52 @@ def extract_zip(
     return dest
 
 
+def resolve_ci(base: Path, rel: str | Path) -> Path | None:
+    """Resolve *rel* under *base*, falling back to a case-insensitive match.
+
+    Windows and macOS resolve paths case-insensitively, so code written there
+    can name ``Data/patch-A.MPQ`` and reach a file stored as ``DATA/patch-a.mpq``.
+    On Linux that lookup simply misses, and callers that read the miss as "not
+    present" silently skip their work. The exact path is tried first, so this
+    costs nothing whenever the case already agrees -- which is always, on the
+    platforms that do not need it.
+
+    Returns None when no component matches, in any case.
+    """
+    exact = base / rel
+    if exact.exists():
+        return exact
+    parts = [part for part in Path(rel).parts if part not in ("", ".")]
+    return _resolve_ci_parts(base, parts)
+
+
+def _resolve_ci_parts(current: Path, parts: list[str]) -> Path | None:
+    """Walk *parts* under *current*, trying every casing that could match.
+
+    Taking the first folded match per component and committing to it is not
+    enough: a tree holding both Data/ and data/ can keep the wanted file in
+    either, so a component that matches must still be abandoned when the rest
+    of the path is not under it. Exact case is tried first at every level, so
+    a directory that matches outright is never passed over for one that
+    merely folds to the same name.
+    """
+    if not parts:
+        return current
+    head, rest = parts[0], parts[1:]
+    try:
+        entries = sorted(current.iterdir(), key=lambda c: c.name)
+    except OSError:
+        return None
+    folded = head.lower()
+    candidates = [c for c in entries if c.name == head]
+    candidates += [c for c in entries if c.name != head and c.name.lower() == folded]
+    for candidate in candidates:
+        found = _resolve_ci_parts(candidate, rest)
+        if found is not None:
+            return found
+    return None
+
+
 def ensure_writable(path: Path | str) -> None:
     """Clear the Windows read-only bit so overwrites can succeed."""
     try:
@@ -217,11 +263,15 @@ def ensure_writable(path: Path | str) -> None:
 
 
 def _is_under_data(path: Path, game_path: Path) -> bool:
+    # Compared a component at a time rather than against a literal "Data",
+    # because the path being tested has usually come back from resolve_ci and
+    # so carries the casing the disk actually uses -- data/, DATA/ and Data/
+    # all name the game's own folder.
     try:
-        path.resolve().relative_to((game_path / "Data").resolve())
-        return True
+        rel = Path(path).resolve().relative_to(Path(game_path).resolve())
     except ValueError:
         return False
+    return bool(rel.parts) and rel.parts[0].lower() == "data"
 
 
 def ensure_data_writable(path: Path | str, game_path: Path | str) -> None:

--- a/ichalaunch/game/client_install.py
+++ b/ichalaunch/game/client_install.py
@@ -27,6 +27,7 @@ from ichalaunch.core.paths import data_file
 from ichalaunch.core.process import download_bytes_cb, download_file, status_only, zip_url_from_html
 from ichalaunch.game.launcher import (
     CLIENT_ZIP_MIRRORS,
+    has_wow_exe,
     GAME_DOWNLOAD_URL,
     GOFILE_EXPECTED_SIZE,
     GOFILE_FILE_ID,
@@ -121,10 +122,10 @@ def wow_exe_here(picked: Path) -> Path | None:
     """
     picked = Path(picked)
     try:
-        if (picked / "WoW.exe").is_file():
+        if has_wow_exe(picked):
             return picked
         home = ravencraft_home_for(picked)
-        if home != picked and (home / "WoW.exe").is_file():
+        if home != picked and has_wow_exe(home):
             return home
     except OSError:
         return None
@@ -1122,7 +1123,7 @@ def _extract_client(
     target.mkdir(parents=True, exist_ok=True)
     extract_zip(zip_path, target, progress=progress)
     unwrap_to_ravencraft(target)
-    game = target if (target / "WoW.exe").is_file() else find_wow_exe_dir(target)
+    game = target if has_wow_exe(target) else find_wow_exe_dir(target)
     if game is None:
         raise RuntimeError(
             f"WoW.exe was not found after extracting into {target}. "
@@ -1130,7 +1131,7 @@ def _extract_client(
         )
     if game.resolve() != target.resolve():
         settle_ravencraft_home(dest, game)
-        game = target if (target / "WoW.exe").is_file() else find_wow_exe_dir(target)
+        game = target if has_wow_exe(target) else find_wow_exe_dir(target)
         if game is None:
             raise RuntimeError(
                 f"WoW.exe was not found after extracting into {target}. "
@@ -1141,8 +1142,8 @@ def _extract_client(
         set_status("Writing realmlist.wtf…")
     elif progress:
         progress("Writing realmlist.wtf…")
-    apply_bundled_realmlist(target if (target / "WoW.exe").is_file() else game)
-    home = target if (target / "WoW.exe").is_file() else game
+    apply_bundled_realmlist(target if has_wow_exe(target) else game)
+    home = target if has_wow_exe(target) else game
     commit_game_home(home)
     _log_post_install_permissions(home)
     cleanup_client_zip(dest, zip_path, watch_dirs=watch_dirs)

--- a/ichalaunch/game/launcher.py
+++ b/ichalaunch/game/launcher.py
@@ -8,7 +8,12 @@ from pathlib import Path
 from typing import Any
 
 from ichalaunch.config.settings import settings
-from ichalaunch.core.filesystem import is_protected_path, listed_basenames, name_present
+from ichalaunch.core.filesystem import (
+    is_protected_path,
+    listed_basenames,
+    name_present,
+    resolve_ci,
+)
 from ichalaunch.core.logging_setup import log
 from ichalaunch.core.process import launch_exe
 
@@ -35,16 +40,39 @@ GAME_DOWNLOAD_NOTE = (
 )
 
 
+CLIENT_EXE_NAME = "WoW.exe"
+# Case-insensitive glob for the same name: one rglob pass, no slower than the
+# literal it replaces.
+_CLIENT_EXE_GLOB = "[Ww][Oo][Ww].[Ee][Xx][Ee]"
+_VF_EXE_NAME = "VanillaFixes.exe"
+_VF_EXE_GLOB = "[Vv][Aa][Nn][Ii][Ll][Ll][Aa][Ff][Ii][Xx][Ee][Ss].[Ee][Xx][Ee]"
+
+
+def wow_exe_in(directory: Path | str) -> Path | None:
+    """The client executable inside *directory*, whatever its case.
+
+    Clients ship this as both ``WoW.exe`` (1.12-era) and ``Wow.exe`` (3.3.5-era).
+    On Windows either spelling resolves to the same file; on Linux they are
+    different files, so a literal check makes half of them invisible.
+    """
+    found = resolve_ci(Path(directory), CLIENT_EXE_NAME)
+    return found if found is not None and found.is_file() else None
+
+
+def has_wow_exe(directory: Path | str) -> bool:
+    return wow_exe_in(directory) is not None
+
+
 def detect_game(path: str | Path | None = None) -> Path | None:
     """Return the folder that contains WoW.exe (game root or ``…/RavenCraft``)."""
     p = Path(path or settings.game_path or "")
     if not p or not str(p):
         return None
     try:
-        if (p / "WoW.exe").is_file():
+        if has_wow_exe(p):
             return p
         nested = p / _GAME_HOME_SUBDIR
-        if nested != p and (nested / "WoW.exe").is_file():
+        if nested != p and has_wow_exe(nested):
             return nested
     except OSError:
         return None
@@ -55,10 +83,12 @@ def resolve_vanilla_fixes_exe(game_path: Path) -> Path | None:
     """Return VanillaFixes.exe under *game_path* (root or one nested folder)."""
     game_path = Path(game_path)
     listing = listed_basenames(game_path)
-    if name_present(game_path, "VanillaFixes.exe", listing):
-        return game_path / "VanillaFixes.exe"
+    if name_present(game_path, _VF_EXE_NAME, listing):
+        # name_present matches case-insensitively, so ask the disk which
+        # spelling it actually holds rather than assuming this one.
+        return resolve_ci(game_path, _VF_EXE_NAME) or (game_path / _VF_EXE_NAME)
     try:
-        for vf in game_path.rglob("VanillaFixes.exe"):
+        for vf in game_path.rglob(_VF_EXE_GLOB):
             if vf.is_file():
                 return vf
     except OSError:
@@ -126,7 +156,7 @@ def discover_game_path_near_launcher() -> Path | None:
         if resolved in seen:
             continue
         seen.add(resolved)
-        if (resolved / "WoW.exe").is_file():
+        if has_wow_exe(resolved):
             return resolved
     return None
 
@@ -204,7 +234,9 @@ def vf_disk_hint_line(game_path: Path) -> str:
 
 def resolve_launch_exe(game_path: Path) -> Path:
     use_vf = bool(settings.get("vanillafixes_enabled", True))
-    wow = game_path / "WoW.exe"
+    # Fall back to the literal name so the caller still gets a path to report
+    # in its "missing" error rather than None.
+    wow = wow_exe_in(game_path) or (game_path / CLIENT_EXE_NAME)
     vf = resolve_vanilla_fixes_exe(game_path)
     if use_vf and vf is not None:
         return vf
@@ -294,17 +326,17 @@ def find_wow_exe_dir(root: Path) -> Path | None:
         base = root
     if not base.exists():
         return None
-    if (base / "WoW.exe").is_file():
+    if has_wow_exe(base):
         return base
     try:
         children = [c for c in base.iterdir() if c.name not in (".ichalaunch",)]
     except OSError:
         return None
     dirs = [c for c in children if c.is_dir()]
-    if len(dirs) == 1 and (dirs[0] / "WoW.exe").is_file():
+    if len(dirs) == 1 and has_wow_exe(dirs[0]):
         return dirs[0]
     try:
-        for wow in base.rglob("WoW.exe"):
+        for wow in base.rglob(_CLIENT_EXE_GLOB):
             if wow.is_file():
                 return wow.parent
     except OSError:

--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -28,6 +28,7 @@ from ichalaunch.addons.github import (
 from ichalaunch.config.settings import settings
 from ichalaunch.core.backup import create_backup
 from ichalaunch.core.filesystem import (
+    PermissionScanResult,
     copy_file_tolerant,
     copy_tree,
     ensure_data_writable,
@@ -37,15 +38,16 @@ from ichalaunch.core.filesystem import (
     is_lock_or_av_error,
     listed_basenames,
     name_present,
-    PermissionScanResult,
     read_dlls_txt,
-    scan_game_permissions,
     remove_path_strict,
+    resolve_ci,
     safe_remove,
     sanitize_filename,
+    scan_game_permissions,
     update_dlls_txt,
 )
 from ichalaunch.core.logging_setup import log
+from ichalaunch.game.launcher import wow_exe_in
 from ichalaunch.core.process import download_bytes, download_bytes_cb, download_file, google_drive_url, status_only
 from ichalaunch.game.launcher import (
     detect_game,
@@ -1714,7 +1716,11 @@ def install_mod(mod_id: str, progress: ProgressCb | None = None, *, prefer_lates
         create_backup(
             game,
             f"before_{mod_id}",
-            [game / "WoW.exe", game / "dlls.txt", game / "VanillaFixes.exe"],
+            [
+                wow_exe_in(game) or (game / "WoW.exe"),
+                game / "dlls.txt",
+                game / "VanillaFixes.exe",
+            ],
         )
     except OSError as exc:
         log.warning("Pre-install backup for %s skipped: %s", mod_id, exc)
@@ -1764,13 +1770,15 @@ def install_mod(mod_id: str, progress: ProgressCb | None = None, *, prefer_lates
             )
             if not vt:
                 raise FileNotFoundError("vanilla-tweaks.exe not found in archive")
-            wow = game / "WoW.exe"
+            wow = wow_exe_in(game) or (game / "WoW.exe")
             if not (game / "WoW-OriginalBackup.exe").exists():
                 _install_copy(wow, game / "WoW-OriginalBackup.exe", game_path=game)
             # Run patcher; creates WoW_tweaked.exe next to WoW.exe
             status_only(progress, "Patching WoW.exe with Vanilla Tweaks...")
             subprocess.run([str(vt), str(wow)], cwd=str(game), check=True)
-            tweaked = game / "WoW_tweaked.exe"
+            tweaked = game / f"{wow.stem}_tweaked.exe"
+            if not tweaked.exists() and wow.stem != "WoW":
+                tweaked = game / "WoW_tweaked.exe"
             if tweaked.exists():
                 wow.unlink(missing_ok=True)
                 tweaked.rename(wow)
@@ -1902,7 +1910,7 @@ def install_mod(mod_id: str, progress: ProgressCb | None = None, *, prefer_lates
                 if f.is_file():
                     _install_copy(f, dest / f.name, game_path=game)
             # apply glue signature skip patch (vanilla 1.12.1)
-            wow = game / "WoW.exe"
+            wow = wow_exe_in(game) or (game / "WoW.exe")
             if wow.exists():
                 if not (game / "WoW-OriginalBackup.exe").exists():
                     _install_copy(wow, game / "WoW-OriginalBackup.exe", game_path=game)
@@ -2039,7 +2047,7 @@ def remove_mod(mod_id: str, progress: ProgressCb | None = None) -> None:
     if kind == "exe_patch":
         backup = game / "WoW-OriginalBackup.exe"
         if backup.exists():
-            _install_copy(backup, game / "WoW.exe", game_path=game)
+            _install_copy(backup, wow_exe_in(game) or (game / "WoW.exe"), game_path=game)
         return
 
     if kind == "mpq_file":
@@ -2208,7 +2216,15 @@ def _ensure_enabled_data_writable(game: Path) -> tuple[list[str], list[str]]:
             continue
         for rel in _mod_owned_paths(mod):
             if rel.startswith("data/"):
-                check_path(game / rel)
+                # _mod_owned_paths lowercases for comparison, so `rel` is a
+                # COMPARISON key and not a real filename. On Windows the two are
+                # interchangeable; on Linux "data/patch-a.mpq" does not name the
+                # file stored as "Data/patch-A.mpq", check_path's is_file() guard
+                # returned early, and the read-only bit was never cleared -- with
+                # no warning either, because the warning also sits past the guard.
+                resolved = resolve_ci(game, rel)
+                if resolved is not None:
+                    check_path(resolved)
         if mod.get("kind") == "glue_autologin":
             glue = game / "Data" / "Interface" / "GlueXML"
             for name in ("AutoLogin.lua", "AutoLogin.xml"):

--- a/ichalaunch/ui/main_window.py
+++ b/ichalaunch/ui/main_window.py
@@ -191,6 +191,7 @@ from ichalaunch.game.launcher import (
     GAME_DOWNLOAD_URL,
     GOFILE_FILE_NAME,
     ensure_game_path_from_launcher,
+    has_wow_exe,
     is_installed,
     launch_game,
     validate_install_location,
@@ -2586,7 +2587,7 @@ class MainWindow(QMainWindow):
             return
         if is_protected_path(path):
             themed.warning(self, "Protected location", protected_location_guidance(path))
-        if not (Path(path) / "WoW.exe").exists():
+        if not has_wow_exe(Path(path)):
             themed.warning(self, "Not a game folder", "WoW.exe was not found in that folder.")
             return
         settings.game_path = path

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -3087,6 +3087,39 @@ def test_themed_dialog_flags_and_close():
     close_open_themed_dialogs(root)
     assert not dlg.isVisible()
     print("OK themed dialog flags and close")
+def test_client_exe_probe_is_case_insensitive():
+    """3.3.5-era clients ship "Wow.exe"; 1.12-era ship "WoW.exe".
+
+    On Windows both spellings reach the same file, so a literal check passed
+    there and made half the clients invisible on Linux.
+    """
+    from ichalaunch.core.filesystem import resolve_ci
+    from ichalaunch.game.launcher import has_wow_exe, wow_exe_in
+
+    for spelling in ("WoW.exe", "Wow.exe", "WOW.EXE"):
+        with tempfile.TemporaryDirectory() as td:
+            game = Path(td)
+            (game / spelling).write_bytes(b"MZ")
+            assert has_wow_exe(game), f"{spelling} not found"
+            assert wow_exe_in(game).name == spelling
+
+    with tempfile.TemporaryDirectory() as td:
+        game = Path(td)
+        (game / "NotAGame.exe").write_bytes(b"MZ")
+        assert not has_wow_exe(game)
+        assert wow_exe_in(game) is None
+
+    # resolve_ci: exact hit, case-corrected hit, and a genuine miss.
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        (base / "Data").mkdir()
+        (base / "Data" / "patch-A.mpq").write_bytes(b"mpq")
+        assert resolve_ci(base, "Data/patch-A.mpq") is not None
+        found = resolve_ci(base, "data/patch-a.mpq")
+        assert found is not None and found.name == "patch-A.mpq"
+        assert resolve_ci(base, "data/absent.mpq") is None
+
+    print("OK client exe probe is case-insensitive")
 
 
 def main():
@@ -3159,6 +3192,7 @@ def _run_smoke_tests():
     test_vanillafixes_preserves_dlls_txt()
     test_apply_desired_state_restores_dlls_txt()
     test_prepare_for_launch_syncs_dlls_txt()
+    test_client_exe_probe_is_case_insensitive()
     test_prepare_for_launch_clears_data_readonly()
     test_plan_missing_installs_dxvk()
     test_play_prep_plans_remove()


### PR DESCRIPTION
NTFS is case-insensitive, so code can ask for `WoW.exe` and still open a client that ships `Wow.exe`. On Linux those are two different files, and the launcher misses half of them.  Ermhergherd.  Linux is so sensitive! ;)

`detect_game`, `find_wow_exe_dir` and `resolve_launch_exe` all check the literal name, so a 3.3.5-era client is simply invisible — the launcher can't see it and won't launch it.  This is done because some users might have multiple versions of WoW installed, some wotlk, some vanilla, etc.

The same assumption breaks clearing read-only files under `Data/`. `_mod_owned_paths` returns lowercased strings for use as comparison keys, and `_ensure_enabled_data_writable` uses them as real filenames; the lookup misses, `check_path` returns at its `is_file` guard, and the fix silently never runs. No warning is logged either, because that sits past the same guard. **This is what makes `test_prepare_for_launch_clears_data_readonly` fail on Linux** — and since `smoke_test.py` is a plain script of asserts, that failure aborts the run, so everything after it never executes at all.  Joy!

`resolve_ci` tries the exact path first and only falls back to a case-insensitive search, so on Windows the behaviour and the cost are unchanged. The fallback backtracks rather than committing to the first match per component — a tree with both `Data/` and `data/` can hold the wanted file under either, so a component that matches still has to be abandoned when the rest of the path isn't beneath it. Without that, a file that exists resolves to `None`.

Two other places kept a literal spelling and failed quietly:

- The pre-install backup — the only rollback a mod install has — listed `game / "WoW.exe"`, and `create_backup` skips a path that isn't there without comment. On a `Wow.exe` client the client was left out of its own backup. rofl.
- vanilla-tweaks names its output after its input, so patching `Wow.exe` produces `Wow_tweaked.exe`. Looking only for `WoW_tweaked.exe` found nothing, the patch was dropped in silence, and the mod was still recorded as installed. Many/most users will have this addon or will at some point.

While rebasing onto v1.1.0 I also routed `resolve_vanilla_fixes_exe` through `resolve_ci` — `name_present` matches case-insensitively but hands back a lowercased path, and the function then returns a hardcoded `VanillaFixes.exe`.
