### PR TITLE
Do not offer the launcher self-update where it cannot be applied

### DIFF
--- a/ichalaunch/ui/main_window.py
+++ b/ichalaunch/ui/main_window.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from pathlib import Path
 
@@ -1762,6 +1763,13 @@ class MainWindow(QMainWindow):
         self.addons.preload_rows()
 
     def _launcher_update_pending(self) -> bool:
+        # Applying an update means replacing the running executable, which
+        # apply_windows_self_replace refuses to do anywhere but Windows. So
+        # reporting one elsewhere turns PLAY into UPDATE, sends the user
+        # through a download that cannot be applied, and leaves the game
+        # unlaunchable from that button for good.
+        if os.name != "nt":
+            return False
         info = self._latest_launcher_release
         return bool(info and info.update_available)
 


### PR DESCRIPTION
On Linux the PLAY button turns into UPDATE and there's no way back.

`_check_launcher_update` runs at startup and again on a timer, and it isn't kept in check by the "check for updates on startup" setting. Once a release exists, `_launcher_update_pending` returns true, PLAY becomes UPDATE, and clicking it downloads the Windows `.exe` and then fails with "Automatic launcher replace is only supported on Windows". The game can't be started from that button any more, and there's no way to dismiss it — the state is recomputed on every refresh, so it comes straight back.

`_launcher_update_pending` is the single gate in front of the button text, the nav badge and the click handler, so one check there covers all three.

On Windows `os.name` is `"nt"` and nothing changes at all.

Happy to do this differently if you'd rather Linux users still saw a notification that a new version exists — I just didn't want to add UI to your launcher without asking. This is the smallest change that stops the game being unlaunchable.  Cheers.
