### PR TITLE
Let the smoke suite finish on Linux

### DIFF
--- a/smoke_test.py
+++ b/smoke_test.py
@@ -3162,6 +3162,7 @@ def test_game_permissions_scan_and_fix():
         (game / "WoW.exe").write_bytes(b"MZ")
         for name in ("Data", "WTF", "Interface"):
             (game / name).mkdir()
+        # Target selection is platform-neutral and is checked everywhere.
         targets = iter_game_permission_targets(game)
         assert (game / "WoW.exe") not in targets
         assert game in targets
@@ -3169,6 +3170,25 @@ def test_game_permissions_scan_and_fix():
 
         scan = scan_game_permissions(game)
         assert not scan.has_issues, scan.issues
+
+        if sys.platform != "win32":
+            # Read-only attributes and ACLs are a Windows concept, and both
+            # entry points say so by returning early. Pin that contract rather
+            # than skipping: a read-only Data/ must stay quiet here, because a
+            # POSIX mode bit is not the problem this feature exists to fix.
+            data_dir = game / "Data"
+            os.chmod(data_dir, stat.S_IREAD)
+            try:
+                assert not scan_game_permissions(game).has_issues
+                fix = fix_game_permissions(game)
+                assert not fix.fixes
+                assert any("only supported on windows" in w.lower() for w in fix.warnings), (
+                    fix.warnings
+                )
+            finally:
+                os.chmod(data_dir, stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC)
+            print("OK game permissions scan/fix (no-op off Windows)")
+            return
 
         data = game / "Data"
         os.chmod(data, stat.S_IREAD)
@@ -3209,6 +3229,19 @@ def test_game_permissions_protected_path():
         (game / "WoW.exe").write_bytes(b"MZ")
         (game / "Data").mkdir()
         os.chmod(game / "Data", stat.S_IREAD)
+
+        if sys.platform != "win32":
+            # No protected-location concept off Windows; the repair path still
+            # has to decline politely instead of pretending it fixed something.
+            try:
+                assert not scan_game_permissions(game).has_issues
+                fix = fix_game_permissions(game)
+                assert not fix.fixes
+                assert fix.warnings
+            finally:
+                os.chmod(game / "Data", stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC)
+            print("OK game permissions protected path (no-op off Windows)")
+            return
 
         scan = scan_game_permissions(game)
         assert scan.protected_path


### PR DESCRIPTION
## Let the smoke suite finish on Linux

smoke_test.py is a bare-assert script, so the first failure aborts
everything after it. On Linux the run died at
test_game_permissions_scan_and_fix, 75 tests in, and the last 13 never
executed -- including every test added since v1.2.0.

The product was right all along: scan_game_permissions and
fix_game_permissions both return early when sys.platform != "win32",
because read-only attributes and ACLs are a Windows concept. Only the
two tests were unguarded, asserting Windows behaviour on every platform.

Rather than skip them off Windows, this pins the documented no-op: a
read-only Data/ must produce no issues and no fixes, and the repair
path must warn that it only works on Windows. The platform-neutral
half, iter_game_permission_targets, keeps running everywhere.

Nothing above the guards changed, so a Windows run is byte-for-byte
what it was. On Linux the suite now reports "All smoke tests passed."

## Pin the client-zip watch-dir test to a temp home

client_watch_dirs() only returns folders that exist, so asserting it
found something depended on the running account having a Downloads or
Desktop folder. On a container or a fresh Linux login it returns
nothing and the suite aborts right there -- before everything after
it, the permissions guards included.

The discovery logic was never wrong; only the test's premise was. It
builds its own home now: a temp folder holding Downloads/ and Desktop/,
with HOME and USERPROFILE pointed at it -- POSIX expands ~ through the
first, Windows through the second -- both restored in a finally that
runs before any assertion, so a failure cannot leak the environment
into the rest of the run. It then asserts those exact paths came back
rather than substring-matching, and still tolerates the real account's
shell folders showing up alongside them on Windows.

Also covers the extra= parameter and its .ichalaunch subfolder, which
nothing exercised before.

---
Verified: with this branch merged onto v1.2.7 (`4a91850`), the full smoke suite passes on Linux (CachyOS, Python 3.14). A plain v1.2.7 checkout currently aborts at `test_game_permissions_scan_and_fix` on Linux, 75 tests in, with 13 tests never reached.
