### PR TITLE
Check for 32-bit Vulkan before recommending DXVK on Linux

### DIFF
--- a/ichalaunch/core/gpu_compat.py
+++ b/ichalaunch/core/gpu_compat.py
@@ -1,10 +1,25 @@
-"""Lightweight GPU / Vulkan suitability checks for DXVK on Windows."""
+"""Lightweight GPU / Vulkan suitability checks for DXVK.
+
+Windows asks WMI for adapter names and matches them against known-bad
+hardware. Linux cannot be answered that way, because a DRM driver name
+says nothing about whether DXVK will load, so it checks what actually
+decides the question there.
+
+WOW 1.12 IS A 32-BIT EXECUTABLE, so DXVK's ``d3d9.dll`` is 32-bit and
+loads a 32-bit Vulkan driver. A machine with flawless 64-bit Vulkan and no
+lib32 drivers is the common failure, and no amount of name matching can
+see it.
+"""
 
 from __future__ import annotations
 
+import json
+import os
 import re
 import subprocess
+import sys
 from functools import lru_cache
+from pathlib import Path
 
 # Patterns that almost certainly cannot run DXVK/Vulkan usefully.
 _BAD_GPU_RE = re.compile(
@@ -39,9 +54,225 @@ def _creationflags() -> int:
     return 0
 
 
+# --- Linux: the 32-bit Vulkan pre-flight ---------------------------------
+
+# The loader honours an explicit manifest list in the environment, and when
+# one is set it replaces the search path rather than adding to it.
+_ICD_ENV_VARS = ("VK_DRIVER_FILES", "VK_ICD_FILENAMES")
+
+# Where a 32-bit driver lands. Distros disagree and several of these alias
+# one another, so hits are deduplicated by resolved path. /usr/lib is listed
+# because it is the 32-bit directory on Fedora-family layouts (/usr/lib64
+# holds the 64-bit ones); elsewhere it is 64-bit and the ELF class check
+# rejects it, which costs one five-byte read.
+_LIB32_DIRS = (
+    "/usr/lib32",
+    "/usr/lib/i386-linux-gnu",
+    "/lib32",
+    "/usr/lib",
+)
+
+_LIB32_HINT = (
+    "Install the 32-bit Vulkan packages for your card:\n"
+    "  Arch     lib32-vulkan-icd-loader, plus lib32-vulkan-radeon,\n"
+    "           lib32-vulkan-intel or lib32-nvidia-utils\n"
+    "  Debian   libvulkan1:i386, plus mesa-vulkan-drivers:i386\n"
+    "  Fedora   vulkan-loader.i686, plus mesa-vulkan-drivers.i686"
+)
+
+
+def _is_elf32(path: Path) -> bool:
+    """True when *path* is an ELF object built for 32-bit (ELFCLASS32)."""
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(5)
+    except OSError:
+        return False
+    return head[:4] == b"\x7fELF" and head[4:5] == b"\x01"
+
+
+def _icd_manifest_dirs() -> tuple[Path, ...]:
+    """Vulkan ICD manifest directories, in the loader's own search order."""
+    home = Path.home()
+
+    def _env_dir(var: str, fallback: str) -> str:
+        return os.environ.get(var) or str(home / fallback)
+
+    roots = [
+        _env_dir("XDG_CONFIG_HOME", ".config"),
+        "/etc/xdg",
+        "/etc",
+        _env_dir("XDG_DATA_HOME", ".local/share"),
+    ]
+    data_dirs = os.environ.get("XDG_DATA_DIRS") or "/usr/local/share:/usr/share"
+    roots.extend(d for d in data_dirs.split(os.pathsep) if d)
+
+    out: list[Path] = []
+    seen: set[str] = set()
+    for root in roots:
+        d = Path(root).expanduser() / "vulkan" / "icd.d"
+        key = str(d)
+        if key not in seen:
+            seen.add(key)
+            out.append(d)
+    return tuple(out)
+
+
+def _icd_manifest_files() -> tuple[Path, ...]:
+    """Every ICD manifest the loader would read."""
+    for var in _ICD_ENV_VARS:
+        raw = os.environ.get(var, "")
+        explicit = [Path(p) for p in raw.split(os.pathsep) if p]
+        if explicit:
+            return tuple(p for p in explicit if p.is_file())
+
+    out: list[Path] = []
+    seen: set[str] = set()
+    for d in _icd_manifest_dirs():
+        try:
+            entries = sorted(d.glob("*.json"))
+        except OSError:
+            continue
+        for entry in entries:
+            key = str(entry)
+            if key not in seen:
+                seen.add(key)
+                out.append(entry)
+    return tuple(out)
+
+
+def _icd_library_candidates(manifest: Path) -> tuple[Path, ...]:
+    """Where the driver library named by *manifest* might live, 32-bit first.
+
+    A manifest usually names a bare soname and is shared between both
+    architectures, so the 32-bit copy is the same file name under a lib32
+    directory. Absolute and manifest-relative forms are also honoured, for
+    the distros that ship a separate 32-bit manifest.
+    """
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return ()
+    icd = data.get("ICD")
+    lib = ((icd or {}).get("library_path") or "").strip() if isinstance(icd, dict) else ""
+    if not lib:
+        return ()
+
+    out: list[Path] = [Path(d) / Path(lib).name for d in _LIB32_DIRS]
+    if os.path.isabs(lib):
+        out.append(Path(lib))
+    elif "/" in lib:
+        out.append(manifest.parent / lib)
+    return tuple(out)
+
+
+@lru_cache(maxsize=1)
+def find_vulkan_loader_32bit() -> str | None:
+    """The 32-bit Vulkan loader, if this machine has one."""
+    for d in _LIB32_DIRS:
+        cand = Path(d) / "libvulkan.so.1"
+        if _is_elf32(cand):
+            return str(cand)
+    return None
+
+
+@lru_cache(maxsize=1)
+def find_vulkan_icds_32bit() -> tuple[str, ...]:
+    """Resolved 32-bit Vulkan driver libraries, at most one per manifest."""
+    found: list[str] = []
+    seen: set[str] = set()
+    for manifest in _icd_manifest_files():
+        for ref in _icd_library_candidates(manifest):
+            try:
+                real = str(ref.resolve())
+            except OSError:
+                continue
+            if real in seen or not _is_elf32(Path(real)):
+                continue
+            seen.add(real)
+            found.append(real)
+            break
+    return tuple(found)
+
+
+def _drm_adapter_names() -> tuple[str, ...]:
+    """Display adapters from sysfs: driver name and PCI id, no external tools."""
+    try:
+        cards = sorted(Path("/sys/class/drm").glob("card[0-9]*"))
+    except OSError:
+        return ()
+    names: list[str] = []
+    for card in cards:
+        if "-" in card.name:
+            continue  # card0-DP-1 and friends are connectors, not adapters
+        try:
+            text = (card / "device" / "uevent").read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        driver = pci = ""
+        for line in text.splitlines():
+            key, _sep, value = line.partition("=")
+            if key == "DRIVER":
+                driver = value.strip()
+            elif key == "PCI_ID":
+                pci = value.strip()
+        if not driver:
+            continue
+        label = f"{driver} [{pci}]" if pci else driver
+        if label not in names:
+            names.append(label)
+    return tuple(names)
+
+
+def _assess_dxvk_linux() -> tuple[str, tuple[str, ...], str]:
+    """DXVK suitability on Linux: can a 32-bit d3d9.dll reach a Vulkan driver?"""
+    gpus = query_gpu_names()
+    joined = " · ".join(gpus) if gpus else "no display adapter reported"
+    icds = find_vulkan_icds_32bit()
+    loader = find_vulkan_loader_32bit()
+
+    if icds and loader:
+        return (
+            "ok",
+            gpus,
+            f"Detected: {joined}\n\n32-bit Vulkan is installed, so VanillaFixes + DXVK "
+            "should work.",
+        )
+
+    if icds and not loader:
+        # Proton's Steam Linux Runtime carries a loader of its own, so this is
+        # worth mentioning and not worth blocking on.
+        return (
+            "warn",
+            gpus,
+            f"Detected: {joined}\n\nA 32-bit Vulkan driver is installed but the 32-bit "
+            "Vulkan loader (libvulkan.so.1) is not. Proton usually supplies one, so "
+            "DXVK will probably still run.\n\n" + _LIB32_HINT,
+        )
+
+    if not _icd_manifest_files():
+        return (
+            "warn",
+            gpus,
+            f"Detected: {joined}\n\nNo Vulkan drivers were found on this system. "
+            "VanillaFixes + DXVK needs Vulkan; regular VanillaFixes does not.",
+        )
+
+    return (
+        "bad",
+        gpus,
+        f"Detected: {joined}\n\nVulkan is installed, but only for 64-bit programs. "
+        "WoW 1.12 is a 32-bit executable, so DXVK needs a 32-bit Vulkan driver and "
+        "will fail to start without one. Use regular VanillaFixes, or install the "
+        "32-bit packages.\n\n" + _LIB32_HINT,
+    )
+
+
 @lru_cache(maxsize=1)
 def query_gpu_names() -> tuple[str, ...]:
-    """Return display adapter names from WMI (Windows). Empty on failure."""
+    """Display adapter names: WMI on Windows, sysfs elsewhere. Empty on failure."""
+    if sys.platform != "win32":
+        return _drm_adapter_names()
     try:
         proc = subprocess.run(
             ["wmic", "path", "win32_VideoController", "get", "name"],
@@ -64,20 +295,8 @@ def query_gpu_names() -> tuple[str, ...]:
         return ()
 
 
-def assess_dxvk_gpu() -> tuple[str, tuple[str, ...], str]:
-    """Assess DXVK suitability.
-
-    Returns ``(level, gpu_names, message)`` where *level* is ``ok``, ``warn``, or ``bad``.
-    """
-    gpus = query_gpu_names()
-    if not gpus:
-        return (
-            "warn",
-            gpus,
-            "Could not detect your graphics card. VanillaFixes + DXVK needs a GPU with "
-            "working Vulkan drivers. If unsure, try regular VanillaFixes first.",
-        )
-
+def _assess_by_name(gpus: tuple[str, ...]) -> tuple[str, tuple[str, ...], str] | None:
+    """Verdict from the adapter name alone, or None when no pattern matches."""
     joined = " · ".join(gpus)
     for name in gpus:
         if _BAD_GPU_RE.search(name):
@@ -97,7 +316,37 @@ def assess_dxvk_gpu() -> tuple[str, tuple[str, ...], str]:
                 "DXVK can work but regular VanillaFixes is often more reliable on integrated "
                 "or low-end hardware.",
             )
+    return None
 
+
+def assess_dxvk_gpu() -> tuple[str, tuple[str, ...], str]:
+    """Assess DXVK suitability.
+
+    Returns ``(level, gpu_names, message)`` where *level* is ``ok``, ``warn``, or ``bad``.
+
+    The two platforms ask different questions. Windows matches the adapter
+    name against hardware known to do Vulkan badly. Linux checks whether a
+    32-bit Vulkan driver exists at all, which is what decides it there; the
+    name table cannot help, because a DRM driver is called "amdgpu" or
+    "i915" and never carries the marketing string those patterns match.
+    """
+    if sys.platform != "win32":
+        return _assess_dxvk_linux()
+
+    gpus = query_gpu_names()
+    if not gpus:
+        return (
+            "warn",
+            gpus,
+            "Could not detect your graphics card. VanillaFixes + DXVK needs a GPU with "
+            "working Vulkan drivers. If unsure, try regular VanillaFixes first.",
+        )
+
+    by_name = _assess_by_name(gpus)
+    if by_name is not None:
+        return by_name
+
+    joined = " · ".join(gpus)
     return (
         "ok",
         gpus,

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1040,6 +1040,18 @@ def test_detect_game_ravencraft_subfolder():
 def test_assess_dxvk_gpu():
     from ichalaunch.core import gpu_compat
 
+    # The name table is the Windows verdict, so off Windows it is exercised
+    # directly: assess_dxvk_gpu() answers a different question there, and a
+    # DRM driver name never carries a string these patterns could match.
+    if sys.platform != "win32":
+        bad = gpu_compat._assess_by_name(("Intel(R) HD Graphics 4000",))
+        assert bad is not None and bad[0] == "bad", bad
+        assert "Intel" in bad[1][0]
+        assert gpu_compat._assess_by_name(("NVIDIA GeForce RTX 3070",)) is None
+        assert gpu_compat._assess_by_name(("amdgpu [1002:13C0]",)) is None
+        print("OK assess dxvk gpu (name table only, off Windows)")
+        return
+
     orig = gpu_compat.query_gpu_names
     try:
         gpu_compat.query_gpu_names = lambda: ("Intel(R) HD Graphics 4000",)
@@ -3898,6 +3910,83 @@ def test_linux_proton_launch_resolution():
     print("OK linux proton launch resolution")
 
 
+def test_linux_dxvk_vulkan_preflight():
+    """DXVK suitability on Linux turns on 32-bit Vulkan, not on the GPU name.
+
+    Drives a fake ICD layout so the verdict does not depend on whatever the
+    machine running the suite happens to have installed.
+    """
+    if sys.platform == "win32":
+        print("OK linux dxvk vulkan pre-flight (skipped on Windows)")
+        return
+
+    import os
+
+    from ichalaunch.core import gpu_compat
+
+    def _elf(path: Path, bits: int) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"\x7fELF" + (b"\x01" if bits == 32 else b"\x02") + b"\0" * 59)
+
+    def _verdict(manifests, lib32_dir):
+        gpu_compat._LIB32_DIRS = (str(lib32_dir),)
+        os.environ["VK_DRIVER_FILES"] = os.pathsep.join(str(m) for m in manifests)
+        gpu_compat.find_vulkan_icds_32bit.cache_clear()
+        gpu_compat.find_vulkan_loader_32bit.cache_clear()
+        return gpu_compat._assess_dxvk_linux()[0]
+
+    real_dirs = gpu_compat._LIB32_DIRS
+    real_env = os.environ.get("VK_DRIVER_FILES")
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            lib32 = root / "lib32"
+            manifest = root / "icd.d" / "radeon_icd.json"
+            manifest.parent.mkdir(parents=True)
+            # A bare soname, shared between both architectures -- the common
+            # case, and the reason a manifest's own path proves nothing.
+            manifest.write_text(json.dumps({"ICD": {"library_path": "libvulkan_radeon.so"}}))
+
+            # Vulkan installed for 64-bit only: DXVK cannot load at all.
+            _elf(root / "lib64" / "libvulkan_radeon.so", 64)
+            lib32.mkdir()
+            assert _verdict([manifest], lib32) == "bad"
+
+            # A 32-bit driver but no 32-bit loader: Proton usually carries one.
+            _elf(lib32 / "libvulkan_radeon.so", 32)
+            assert _verdict([manifest], lib32) == "warn"
+
+            # Both present.
+            _elf(lib32 / "libvulkan.so.1", 32)
+            assert _verdict([manifest], lib32) == "ok"
+
+            # A 64-bit library in a lib32 directory is still 64-bit.
+            _elf(lib32 / "libvulkan_radeon.so", 64)
+            assert _verdict([manifest], lib32) == "bad"
+
+            # No drivers at all is a softer message: nothing to repair.
+            assert _verdict([root / "nope.json"], lib32) == "warn"
+
+            assert gpu_compat._is_elf32(lib32 / "libvulkan.so.1")
+            assert not gpu_compat._is_elf32(root / "lib64" / "libvulkan_radeon.so")
+            assert not gpu_compat._is_elf32(root / "absent.so")
+    finally:
+        gpu_compat._LIB32_DIRS = real_dirs
+        os.environ.pop("VK_DRIVER_FILES", None)
+        if real_env is not None:
+            os.environ["VK_DRIVER_FILES"] = real_env
+        gpu_compat.find_vulkan_icds_32bit.cache_clear()
+        gpu_compat.find_vulkan_loader_32bit.cache_clear()
+
+    # The bug this replaces: on Linux wmic does not exist, so every machine
+    # was told its graphics card could not be detected.
+    level, _gpus, message = gpu_compat.assess_dxvk_gpu()
+    assert level in {"ok", "warn", "bad"}
+    assert "Could not detect your graphics card" not in message
+
+    print("OK linux dxvk vulkan pre-flight")
+
+
 def main():
     import ichalaunch.config.settings as settings_mod
 
@@ -3975,6 +4064,7 @@ def _run_smoke_tests():
     test_prepare_for_launch_syncs_dlls_txt()
     test_client_exe_probe_is_case_insensitive()
     test_linux_proton_launch_resolution()
+    test_linux_dxvk_vulkan_preflight()
     test_prepare_for_launch_clears_data_readonly()
     test_plan_missing_installs_dxvk()
     test_play_prep_plans_remove()


### PR DESCRIPTION
Ticking DXVK on Linux always warned "Could not detect your graphics
card". gpu_compat asks WMI for adapter names by running wmic, which does
not exist off Windows, so query_gpu_names() caught OSError and returned
an empty tuple, and assess_dxvk_gpu() read that as "unknown hardware".
Every Linux user saw the same dialog, on the platform where DXVK is the
normal way to run the client.

Rewriting it as a name check would not help. A DRM driver is called
"amdgpu" or "i915" and never carries the marketing string those patterns
match, and the name would not answer the question anyway. WoW 1.12 is a
32-bit executable, so DXVK's d3d9.dll is 32-bit and loads a 32-bit Vulkan
driver -- and a machine with flawless 64-bit Vulkan and no lib32 drivers
is the failure that actually happens. It is invisible to a name table and
it is the one worth catching, because DXVK cannot start without it.

So on Linux the pre-flight now reads the Vulkan ICD manifests the loader
itself would read, resolves each driver library by name in the lib32
directories, and tests the ELF class byte. Verdicts:

  32-bit driver and loader        ok
  driver but no 32-bit loader     warn (Proton usually supplies one)
  no Vulkan drivers at all        warn
  Vulkan present, 64-bit only     bad, and the message names the packages

Adapter names come from /sys/class/drm rather than an external tool, so
nothing new has to be installed for the check to run. Measured at 0.16 ms
cold on a two-GPU machine, and the results are cached like the WMI ones.

Windows is untouched. The name matching moved into a helper so both
platforms can reach it, and the Windows verdict was compared against the
old implementation across 19 adapter-name cases with no differences.

---
Verified: merged onto v1.2.7 (`4a91850`) together with #6 (which the suite needs to finish on Linux at all), the full smoke suite passes on Linux (CachyOS, Python 3.14). Windows behavior compared against the old implementation across 19 adapter-name cases with no differences.
