### PR TITLE
Wayland: hand frameless window move and resize to the compositor

### DIFF
--- a/ichalaunch/ui/main_window.py
+++ b/ichalaunch/ui/main_window.py
@@ -16,6 +16,7 @@ from PySide6.QtGui import (
     QFontMetrics,
     QGuiApplication,
     QIcon,
+    QMouseEvent,
     QPainter,
     QPainterPath,
     QPixmap,
@@ -221,6 +222,34 @@ def _pixmap_opaque_bottom(pix: QPixmap) -> int:
             if img.pixelColor(x, y).alpha() > 16:
                 return y + 1
     return h
+
+
+# Resolved once on first use: a platform name cannot change inside a process,
+# and this is consulted on every mouse move during a drag.
+_SYSTEM_WINDOW_MOVE: bool | None = None
+
+
+def _use_system_window_move() -> bool:
+    """True on Wayland, where a client may not position its own window.
+
+    Wayland has no protocol for setting a top-level's global position, so
+    ``QWidget.move()`` on the window is discarded and ``setGeometry()`` cannot
+    move an origin: the frameless window looks frozen, and dragging the left
+    or top edge resizes from the wrong side. The compositor-side equivalents
+    are ``QWindow.startSystemMove`` and ``startSystemResize``.
+
+    False on Windows and X11, where the existing code path is correct.
+    """
+    global _SYSTEM_WINDOW_MOVE
+    if _SYSTEM_WINDOW_MOVE is None:
+        # platformName() does not raise before the application exists; it
+        # answers "xcb" regardless of the real session, so asking early and
+        # caching that would disable this silently and permanently.
+        if QGuiApplication.instance() is None:
+            return False
+        name = QGuiApplication.platformName() or ""
+        _SYSTEM_WINDOW_MOVE = name.lower().startswith("wayland")
+    return _SYSTEM_WINDOW_MOVE
 
 
 def _resolve_theme_texture(bundled_name: str, external: Path) -> Path | None:
@@ -1374,6 +1403,9 @@ class MainWindow(QMainWindow):
         self._live_workers: set[Worker] = set()
         self._latest_launcher_release: LauncherReleaseInfo | None = None
         self._drag_pos: QPoint | None = None
+        # Wayland only: a press landed on chrome and the compositor drag
+        # starts if the pointer actually moves. See _use_system_window_move.
+        self._system_move_pending = False
         self._checking_addons = False
         self._checking_mods = False
         self._check_addon_pct = 0
@@ -1764,6 +1796,10 @@ class MainWindow(QMainWindow):
             self._clamp_on_screen()
 
     def _clamp_on_screen(self) -> None:
+        if _use_system_window_move():
+            # move() is discarded on Wayland, so there is nothing this can do;
+            # keeping a window reachable is the compositor's job there.
+            return
         avail = self._available_geo()
         geo = self.frameGeometry()
         x = min(max(geo.x(), avail.left()), avail.right() - geo.width() + 1)
@@ -1981,11 +2017,91 @@ class MainWindow(QMainWindow):
             w = w.parentWidget()
         return False
 
+    def _release_pointer_after_handoff(self, target, event) -> None:
+        """Tell the pressed widget the button is up, once the compositor has it.
+
+        qtwayland delivers the release of a compositor-run drag to a null
+        surface, so the widget that saw the press keeps its pressed and
+        hovered look for good. Qt has fixed and un-fixed this more than once
+        (QTBUG-97037), so post the release rather than assume; a duplicate
+        release is harmless. This is what FramelessHelper, Telegram Desktop
+        and Chromium's Ozone backend all do at the same point.
+        """
+        if not isinstance(target, QWidget):
+            return
+        QApplication.postEvent(
+            target,
+            QMouseEvent(
+                QEvent.Type.MouseButtonRelease,
+                QPointF(event.position()),
+                QPointF(event.globalPosition()),
+                Qt.MouseButton.LeftButton,
+                Qt.MouseButton.NoButton,
+                Qt.KeyboardModifier.NoModifier,
+            ),
+        )
+
+    def _compositor_owns_window_state(self) -> bool:
+        """True while the compositor may refuse a move or resize outright.
+
+        xdg-shell lets the server ignore both requests for a maximized or
+        fullscreen toplevel, and neither Qt nor the protocol reports the
+        refusal, so the only way not to eat the click is to not ask.
+        """
+        state = self.windowState()
+        return bool(
+            state & (Qt.WindowState.WindowMaximized | Qt.WindowState.WindowFullScreen)
+        )
+
+    def _start_system_move(self) -> bool:
+        """Ask the compositor to drag the window.
+
+        True means the platform made the request, not that the compositor
+        honoured it: there is no acknowledgement in the protocol, and the
+        Wayland backend returns true whenever the toplevel is initialised.
+        """
+        handle = self.windowHandle()
+        if handle is None:
+            return False
+        try:
+            return bool(handle.startSystemMove())
+        except (RuntimeError, TypeError):
+            return False
+
+    def _start_system_resize(self, edges: tuple[bool, bool, bool, bool]) -> bool:
+        """Ask the compositor to resize from *edges*. See _start_system_move."""
+        left, right, top, bottom = edges
+        qedges = Qt.Edge(0)  # falsy when no edge was hit
+        if left:
+            qedges |= Qt.Edge.LeftEdge
+        if right:
+            qedges |= Qt.Edge.RightEdge
+        if top:
+            qedges |= Qt.Edge.TopEdge
+        if bottom:
+            qedges |= Qt.Edge.BottomEdge
+        if not qedges:
+            return False
+        handle = self.windowHandle()
+        if handle is None:
+            return False
+        try:
+            return bool(handle.startSystemResize(qedges))
+        except (RuntimeError, TypeError):
+            return False
+
     def _begin_window_drag(self, global_pos: QPoint) -> None:
-        self._drag_pos = global_pos - self.frameGeometry().topLeft()
         self._resize_edges = None
         self._resize_origin = None
         self._resize_geo = None
+        if _use_system_window_move():
+            # Arm only. The compositor drag starts on the first movement, not
+            # here: asking on the press would consume a plain click on the
+            # chrome, and _drag_pos stays None so the move() path is dormant.
+            self._system_move_pending = not self._compositor_owns_window_state()
+            self._drag_pos = None
+            return
+        self._drag_pos = global_pos - self.frameGeometry().topLeft()
 
     def eventFilter(self, obj, event):
         """Edge-resize on border; drag window from non-interactive chrome."""
@@ -2000,6 +2116,23 @@ class MainWindow(QMainWindow):
                 pos = self.mapFromGlobal(event.globalPosition().toPoint())
                 edges = self._hit_resize_edges(pos)
                 if any(edges) and not isinstance(obj, QSizeGrip):
+                    # Hand the resize over instead of grabbing the mouse: on
+                    # Wayland the compositor takes the pointer, so a grab
+                    # taken here would never see its own release. Unlike the
+                    # drag this stays on the press, which is where Qt's own
+                    # QSizeGrip does it — a resize border has no click to
+                    # protect.
+                    if _use_system_window_move():
+                        self._drag_pos = None
+                        self._resize_edges = None
+                        self._resize_origin = None
+                        self._resize_geo = None
+                        self._system_move_pending = False
+                        if self._compositor_owns_window_state():
+                            return super().eventFilter(obj, event)
+                        self._start_system_resize(edges)
+                        self._release_pointer_after_handoff(obj, event)
+                        return True
                     self._resize_edges = edges
                     self._resize_origin = event.globalPosition().toPoint()
                     self._resize_geo = QRect(self.geometry())
@@ -2010,6 +2143,11 @@ class MainWindow(QMainWindow):
                     self._begin_window_drag(event.globalPosition().toPoint())
                     # Do not consume — labels/panels still get the press; move is tracked below
             elif et == QEvent.Type.MouseMove:
+                if self._system_move_pending and event.buttons() & Qt.MouseButton.LeftButton:
+                    self._system_move_pending = False
+                    self._start_system_move()
+                    self._release_pointer_after_handoff(obj, event)
+                    return True
                 if self._resize_edges is not None and self._resize_origin is not None and self._resize_geo is not None:
                     self._apply_edge_resize(event.globalPosition().toPoint())
                     return True
@@ -2030,6 +2168,10 @@ class MainWindow(QMainWindow):
                     pos = self.mapFromGlobal(event.globalPosition().toPoint())
                     self._update_resize_cursor(self._hit_resize_edges(pos))
                     return True
+                if self._system_move_pending:
+                    # Pressed and released without moving: a plain click, and
+                    # the widget under it has already had both events.
+                    self._system_move_pending = False
                 if self._drag_pos is not None:
                     self._drag_pos = None
                     self._clamp_on_screen()
@@ -2038,6 +2180,12 @@ class MainWindow(QMainWindow):
         return super().eventFilter(obj, event)
 
     def _apply_edge_resize(self, global_pos: QPoint) -> None:
+        if _use_system_window_move():
+            # setGeometry() cannot move an origin on Wayland, so a left- or
+            # top-edge drag would resize from the wrong side. Stated here as
+            # well as at the call sites: this is the arithmetic that would be
+            # wrong, and it should not depend on state set three frames away.
+            return
         if self._resize_edges is None or self._resize_origin is None or self._resize_geo is None:
             return
         delta = global_pos - self._resize_origin
@@ -2079,6 +2227,19 @@ class MainWindow(QMainWindow):
             pos = event.position().toPoint()
             edges = self._hit_resize_edges(pos)
             if any(edges):
+                if _use_system_window_move():
+                    self._drag_pos = None
+                    self._resize_edges = None
+                    self._resize_origin = None
+                    self._resize_geo = None
+                    self._system_move_pending = False
+                    if self._compositor_owns_window_state():
+                        super().mousePressEvent(event)
+                        return
+                    self._start_system_resize(edges)
+                    self._release_pointer_after_handoff(self, event)
+                    event.accept()
+                    return
                 self._resize_edges = edges
                 self._resize_origin = event.globalPosition().toPoint()
                 self._resize_geo = QRect(self.geometry())
@@ -2092,6 +2253,12 @@ class MainWindow(QMainWindow):
         super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event):
+        if self._system_move_pending and event.buttons() & Qt.MouseButton.LeftButton:
+            self._system_move_pending = False
+            self._start_system_move()
+            self._release_pointer_after_handoff(self, event)
+            event.accept()
+            return
         if self._resize_edges is not None and self._resize_origin is not None and self._resize_geo is not None:
             if event.buttons() & Qt.MouseButton.LeftButton:
                 self._apply_edge_resize(event.globalPosition().toPoint())
@@ -2106,6 +2273,7 @@ class MainWindow(QMainWindow):
         super().mouseMoveEvent(event)
 
     def mouseReleaseEvent(self, event):
+        self._system_move_pending = False
         was_moving = self._drag_pos is not None or self._resize_edges is not None
         if self._resize_edges is not None:
             self.releaseMouse()

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -4792,6 +4792,190 @@ def test_linux_dxvk_vulkan_preflight():
     print("OK linux dxvk vulkan pre-flight")
 
 
+def test_wayland_window_move_and_resize_handoff():
+    """On Wayland the compositor gets the drag; everywhere else nothing changes.
+
+    Drives MainWindow's methods against a stub rather than building the real
+    window: the point is which branch runs, and no compositor is available
+    under the offscreen platform anyway.
+    """
+    from PySide6.QtCore import QEvent, QPoint, QPointF, QRect, Qt
+    from PySide6.QtGui import QMouseEvent
+    from PySide6.QtWidgets import QApplication, QWidget
+
+    from ichalaunch.ui import main_window as mw
+
+    app = QApplication.instance() or QApplication([])
+
+    def _press(x=400, y=300):
+        return QMouseEvent(
+            QEvent.Type.MouseButtonPress,
+            QPointF(x, y),
+            QPointF(x, y),
+            Qt.MouseButton.LeftButton,
+            Qt.MouseButton.LeftButton,
+            Qt.KeyboardModifier.NoModifier,
+        )
+
+    class _Handle:
+        def __init__(self, move_ok=True, resize_ok=True):
+            self.move_ok = move_ok
+            self.resize_ok = resize_ok
+            self.moves = 0
+            self.resizes = 0
+            self.edges = None
+
+        def startSystemMove(self):
+            self.moves += 1
+            return self.move_ok
+
+        def startSystemResize(self, edges):
+            self.resizes += 1
+            self.edges = edges
+            return self.resize_ok
+
+    class _Win:
+        """Just enough MainWindow for the methods under test."""
+
+        def __init__(self, handle, state=Qt.WindowState.WindowNoState):
+            self._handle = handle
+            self._state = state
+            self._drag_pos = "stale"
+            self._resize_edges = "stale"
+            self._resize_origin = "stale"
+            self._resize_geo = "stale"
+            self._system_move_pending = "stale"
+            self.handle_lookups = 0
+
+        def windowHandle(self):
+            self.handle_lookups += 1
+            return self._handle
+
+        def windowState(self):
+            return self._state
+
+        def frameGeometry(self):
+            return QRect(100, 50, 800, 600)
+
+        _start_system_move = mw.MainWindow._start_system_move
+        _start_system_resize = mw.MainWindow._start_system_resize
+        _begin_window_drag = mw.MainWindow._begin_window_drag
+        _apply_edge_resize = mw.MainWindow._apply_edge_resize
+        _compositor_owns_window_state = mw.MainWindow._compositor_owns_window_state
+        _release_pointer_after_handoff = mw.MainWindow._release_pointer_after_handoff
+
+    real_guard = mw._use_system_window_move
+    real_cache = mw._SYSTEM_WINDOW_MOVE
+    real_qgui = mw.QGuiApplication
+    try:
+        mw._use_system_window_move = lambda: True
+
+        # --- edge tuples map to the right compositor edges ---------------
+        for edges, expected in {
+            (True, False, False, False): Qt.Edge.LeftEdge,
+            (False, True, False, False): Qt.Edge.RightEdge,
+            (False, False, True, False): Qt.Edge.TopEdge,
+            (False, False, False, True): Qt.Edge.BottomEdge,
+            (True, False, True, False): Qt.Edge.LeftEdge | Qt.Edge.TopEdge,
+            (False, True, False, True): Qt.Edge.RightEdge | Qt.Edge.BottomEdge,
+        }.items():
+            h = _Handle()
+            assert _Win(h)._start_system_resize(edges) is True, edges
+            assert h.edges == expected, (edges, h.edges, expected)
+
+        # No edge at all is not a resize, and costs nothing to discover.
+        h = _Handle()
+        w = _Win(h)
+        assert w._start_system_resize((False, False, False, False)) is False
+        assert h.resizes == 0 and w.handle_lookups == 0
+
+        # --- a press ARMS the drag; it does not start it ------------------
+        # Starting on the press would consume a plain click on the chrome.
+        h = _Handle()
+        w = _Win(h)
+        w._begin_window_drag(QPoint(400, 300))
+        assert h.moves == 0, "the compositor must not be asked on the press"
+        assert w._system_move_pending is True
+        assert w._drag_pos is None
+        assert w._resize_edges is None and w._resize_origin is None
+        assert w._resize_geo is None
+
+        # A maximized or fullscreen toplevel may be refused silently, so it
+        # is never asked and the press keeps its normal meaning.
+        for state in (Qt.WindowState.WindowMaximized, Qt.WindowState.WindowFullScreen):
+            w = _Win(_Handle(), state=state)
+            w._begin_window_drag(QPoint(400, 300))
+            assert w._system_move_pending is False, state
+
+        # --- the synthetic release reaches the widget that saw the press --
+        class _Spy(QWidget):
+            def __init__(self):
+                super().__init__()
+                self.releases = 0
+
+            def mouseReleaseEvent(self, event):
+                self.releases += 1
+
+        spy = _Spy()
+        _Win(_Handle())._release_pointer_after_handoff(spy, _press())
+        app.processEvents()
+        assert spy.releases == 1, "the pressed widget must be told the button is up"
+
+        # --- no window handle yet: no crash, nothing claimed --------------
+        assert _Win(None)._start_system_move() is False
+        assert _Win(None)._start_system_resize((True, False, False, False)) is False
+
+        # --- the manual resize arithmetic never runs on Wayland -----------
+        w = _Win(_Handle())
+        w._resize_edges = (True, False, False, False)
+        w._resize_origin = QPoint(0, 0)
+        w._resize_geo = QRect(0, 0, 900, 700)
+        w._apply_edge_resize(QPoint(40, 0))  # would call setGeometry, which the stub lacks
+
+        # --- off Wayland the compositor is never consulted ----------------
+        mw._use_system_window_move = lambda: False
+        h = _Handle()
+        w = _Win(h)
+        w._begin_window_drag(QPoint(400, 300))
+        assert h.moves == 0, "startSystemMove must not run off Wayland"
+        assert w.handle_lookups == 0, "windowHandle must not even be read off Wayland"
+        assert w._system_move_pending == "stale", "the Wayland flag must be left alone"
+        assert w._drag_pos == QPoint(300, 250)
+    finally:
+        mw._use_system_window_move = real_guard
+        mw.QGuiApplication = real_qgui
+        mw._SYSTEM_WINDOW_MOVE = real_cache
+
+    # --- the guard itself --------------------------------------------------
+    # platformName() answers "xcb" before the application exists rather than
+    # raising, so asking early and caching would disable this permanently and
+    # silently. Nothing may be memoized until there is an instance.
+    class _NoApp:
+        @staticmethod
+        def instance():
+            return None
+
+        @staticmethod
+        def platformName():
+            raise AssertionError("platformName must not be read without an instance")
+
+    try:
+        mw._SYSTEM_WINDOW_MOVE = None
+        mw.QGuiApplication = _NoApp
+        assert mw._use_system_window_move() is False
+        assert mw._SYSTEM_WINDOW_MOVE is None, "a pre-application answer must not be cached"
+
+        mw.QGuiApplication = real_qgui
+        assert mw._use_system_window_move() is False
+        assert mw._SYSTEM_WINDOW_MOVE is False
+    finally:
+        mw.QGuiApplication = real_qgui
+        mw._SYSTEM_WINDOW_MOVE = real_cache
+
+    print("OK wayland window move/resize handoff")
+
+
+
 def main():
     import ichalaunch.config.settings as settings_mod
 
@@ -4909,6 +5093,7 @@ def _run_smoke_tests():
     test_client_cat_nav_update_alert_badge()
     test_chrome_buttons_clear_metal_tr()
     test_play_stays_right_when_progress_hidden()
+    test_wayland_window_move_and_resize_handoff()
     print("\nAll smoke tests passed.")
 
 


### PR DESCRIPTION
## Wayland: hand frameless window move and resize to the compositor

Dragging the window did nothing on Wayland, and dragging the left or top
edge resized from the wrong side.

Wayland has no protocol for a client to set its own top-level's global
position. QWidget.move() is discarded and setGeometry() cannot move an
origin, so a frameless window that positions itself -- which is the only
way a frameless window can be moved -- appears frozen. The compositor-side
equivalents are QWindow.startSystemMove and startSystemResize, which is
how GTK, SDL, Chromium's Ozone backend, Telegram Desktop, FramelessHelper
and Qt's own QSizeGrip all handle this.

Four sites reach the window origin, and the load-bearing one is the app
level event filter, not the widget's own handlers: presses land on child
widgets, so the filter consumes them and mousePressEvent never runs. All
four are covered: _begin_window_drag, the eventFilter press branch, the
mousePressEvent branch, and _apply_edge_resize itself.

THE DRAG STARTS ON THE FIRST MOVEMENT, NOT ON THE PRESS. Asking on the
press consumes a plain click on the chrome, and Chromium reverted exactly
that shape for breaking double-click maximize on both Wayland and X11
(commit 207ba78, issue 40923864); GTK4's gtkwindowhandle.c and
FramelessHelper both gate the move behind movement too. It costs nothing:
wl_pointer.motion carries no serial, so the seat still holds the press
serial while the button is down. Resize stays on the press, which is
where QSizeGrip does it -- a 6px border has no click to protect.

A SYNTHETIC RELEASE IS POSTED once the compositor has the pointer.
qtwayland delivers the real release to a null surface, so the widget that
saw the press keeps its pressed and hovered look for good (QTBUG-97037,
fixed and un-fixed across 6.5 to 6.8). FramelessHelper, Telegram and
Chromium all post one at the same point; a duplicate is harmless.

Maximized and fullscreen toplevels are not asked at all. xdg-shell lets
the server ignore move and resize in those states and reports nothing
either way -- the Wayland backend returns true whenever the toplevel is
initialised -- so declining to ask is the only way not to eat the click.

No manual fallback when the compositor does not act. There is nothing to
fall back to, and arming the old path would call grabMouse() for a release
that never comes, holding the grab for the life of the process.

The platform check is resolved once and cached, since it is consulted on
every pointer move during a drag. It gates on QGuiApplication.instance()
rather than catching an exception: platformName() does not raise before
the application exists, it answers "xcb" whatever the real session is, so
an early call would have cached False and disabled all of this silently.

X11 is deliberately excluded even though QXcbWindow implements both calls.
It returns false without _NET_WM_MOVERESIZE, QTBUG-69716 is still open,
and Qt itself excludes xcb from its own platform size grip. The manual
path already works there.

Windows is untouched. The guard short-circuits before any handle is read,
and the v1.2.3 drag and resize bodies were run against the new ones with
it false: identical state across four drag positions, identical geometry
from the edge-resize arithmetic, and windowHandle() never even consulted.

Not verifiable headlessly, and worth a look on a real session: whether
minimum and maximum sizes clamp correctly during a compositor-run resize.

## Stop the Wayland guard test from asserting the host platform

The guard block restored the real QGuiApplication and asserted
_use_system_window_move() was False. That is only true when the session
running the suite is not Wayland -- so the test for a Wayland feature
could not pass on Wayland. On this KDE Wayland desktop it failed at
exactly the point the guard was working correctly.

It was also weaker than it looked. Asserting only the False answer meant
a guard hardwired to return False would satisfy it; the branch the whole
change exists to take was never covered.

Both directions are stubbed now: a platform name of "xcb" must answer
False and cache False, "wayland-egl" must answer True and cache True --
the prefix is what is tested, not an exact string -- and a cached answer
must survive the platform name changing underneath it, which pins the
read-once contract. Nothing above the guard block changed.

---
Verified: merged onto v1.2.7 (`4a91850`) together with #6 (which the suite needs to finish on Linux at all), the full smoke suite passes on Linux (CachyOS, Python 3.14, KDE Wayland). Windows is untouched — the guard short-circuits before any handle is read.
