### PR TITLE
Make the patch-9 reacquire atomic so a failed download cannot destroy the good copy.

### DIFF
--- a/ichalaunch/mods/stock_patch.py
+++ b/ichalaunch/mods/stock_patch.py
@@ -7,6 +7,7 @@ separate, explicit download from the share host — never started silently.
 
 from __future__ import annotations
 
+import os
 import shutil
 import tempfile
 from dataclasses import dataclass
@@ -222,7 +223,17 @@ def reacquire_stock_patch9(
     source = stock_patch9_source(url)
     source["expected_size"] = expected
 
-    with tempfile.TemporaryDirectory(prefix="ichalaunch-patch9-") as td:
+    # Stage inside Data/ so the final swap is a same-filesystem rename rather
+    # than a ~483 MiB copy. Also keeps the download off /tmp, which is tmpfs
+    # (i.e. RAM) on most Linux setups.
+    try:
+        staging_dir: str | None = str(dest.parent)
+    except Exception:  # pragma: no cover - defensive
+        staging_dir = None
+
+    with tempfile.TemporaryDirectory(
+        prefix="ichalaunch-patch9-", dir=staging_dir
+    ) as td:
         work = Path(td)
         artifact = _download_source(source, work, progress)
         if not isinstance(artifact, Path) or not artifact.is_file():
@@ -238,8 +249,32 @@ def reacquire_stock_patch9(
             )
         if dest.exists():
             ensure_data_writable(dest, game)
-            dest.unlink()
-        shutil.copy2(artifact, dest)
+        # Atomic swap: the old patch survives until the new one is fully in
+        # place. os.replace() is atomic on the same filesystem, so a crash or a
+        # full disk can no longer leave a truncated patch-9 behind -- which is
+        # the exact state the Reacquire button exists to repair.
+        try:
+            os.replace(artifact, dest)
+        except OSError:
+            # Different filesystem (e.g. staging fell back to the default
+            # tempdir): stage beside the destination, then swap.
+            part = dest.with_name(dest.name + ".part")
+            try:
+                if part.exists():
+                    part.unlink()
+                shutil.copy2(artifact, part)
+                staged = part.stat().st_size
+                if staged != got:
+                    raise RuntimeError(
+                        f"Staged patch-9 is {staged} bytes; expected {got}"
+                    )
+                os.replace(part, dest)
+            finally:
+                if part.exists():
+                    try:
+                        part.unlink()
+                    except OSError:
+                        pass
         ensure_data_writable(dest, game)
         invalidate_dir_listing(dest.parent)
         log.info("Reacquired official %s (%s bytes) -> %s", dest.name, got, dest)


### PR DESCRIPTION
reacquire_stock_patch9() unlinked Data/patch-9.mpq and then copied ~483 MiB
into place from a tempdir on another filesystem. A crash, a full disk or a
killed process partway through the copy left a truncated patch-9 and no
original to fall back on -- which is precisely the state the Reacquire button
exists to repair.

Two changes:

- Stage inside Data/ by passing dir= to TemporaryDirectory, so the final swap
  is a same-filesystem rename instead of a half-gigabyte copy. This also keeps
  the download off /tmp, which is tmpfs (RAM) on most Linux systems -- 483 MiB
  of it on machines that may not have it to spare.

- Replace unlink-then-copy2 with os.replace(), which is atomic on one
  filesystem: the old patch stays intact until the new one is fully in place.
  If staging still lands on a different filesystem, fall back to copying to
  patch-9.mpq.part beside the destination, verifying the staged size, and
  swapping that in -- the original is never removed before a verified
  replacement exists.

The pre-existing size check validated the temp artifact; the fallback path now
also verifies the bytes that actually land next to the destination.

Full smoke suite passes on Linux (stacked on the smoke-permissions guard, since
plain master cannot finish the suite on Linux).

---
Verified: merges clean onto `1b67b86` (0 conflicts via `git merge-tree`), and the full smoke suite passes on Linux with this branch stacked on `linux-smoke-permissions-guard` (#6). Plain master still cannot finish the suite on Linux without #6.