### PR TITLE
Stop Pink Herbs detecting on patch-J, which it never installs.

### DIFF
--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -867,9 +867,7 @@
     "detect": {
       "data_mpq": [
         "patch-H.mpq",
-        "Patch-H.mpq",
-        "patch-J.mpq",
-        "Patch-J.mpq"
+        "Patch-H.mpq"
       ]
     },
     "source": {


### PR DESCRIPTION
The pink_herbs catalog entry detected on both patch-H.mpq and patch-J.mpq, but
source.filename and destination are both Data/patch-H.mpq. Detection is OR-any
(installer._mod_installed), while install and removal only ever touch the
destination, so patch-J was matched but never owned.

Two visible symptoms: any unrelated Data/patch-J.mpq made Pink Herbs report as
installed when it was not, and a leftover patch-J flipped it back to
"installed" immediately after removal.

pink_herbs was the only catalog entry whose detect list spanned two different
patch letters -- every other mpq_file entry lists case variants of one letter.
Dropping the patch-J entries makes detection match ownership.

---
Verified: merges clean onto `1b67b86` (0 conflicts via `git merge-tree`), and the full smoke suite passes on Linux with this branch stacked on `linux-smoke-permissions-guard` (#6). Plain master still cannot finish the suite on Linux without #6.