### PR TITLE
catalog: add buhfur/Prat-Turtle

### DIFF
--- a/ichalaunch/data/addons.json
+++ b/ichalaunch/data/addons.json
@@ -7552,5 +7552,12 @@
     "source": "manual",
     "folder": "SurpriseMe",
     "installable": true
+  },
+  {
+    "name": "Prat-Turtle",
+    "repo": "https://github.com/buhfur/Prat-Turtle",
+    "category": "General",
+    "source": "community",
+    "folder": "Prat-Turtle"
   }
 ]


### PR DESCRIPTION
## Summary
- Adds [buhfur/Prat-Turtle](https://github.com/buhfur/Prat-Turtle) to `ichalaunch/data/addons.json` (`source: community`).
- Opened from catalog suggestion issue #12 (label `catalog-approved`).

## Maintainer
- Review the entry, then **merge this PR** to publish on `master`.
- Closing the issue alone does not update the catalog.

Closes #12