### PR TITLE
Identify a hand-installed patch-T or patch-L variant by its size, not by guesswork

### DIFF
--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -586,6 +586,7 @@
     },
     "kind": "mpq_file",
     "destination": "Data/patch-L.mpq",
+    "size_bytes": 37330631,
     "dependencies": [
       "vanilla_helpers",
       "hd_patch_a"
@@ -614,6 +615,7 @@
     },
     "kind": "mpq_file",
     "destination": "Data/patch-L.mpq",
+    "size_bytes": 53272447,
     "dependencies": [
       "vanilla_helpers",
       "hd_patch_a"
@@ -742,6 +744,7 @@
     },
     "kind": "mpq_file",
     "destination": "Data/patch-T.mpq",
+    "size_bytes": 499342621,
     "dependencies": [
       "vanilla_helpers",
       "hd_patch_a",
@@ -771,6 +774,7 @@
     },
     "kind": "mpq_file",
     "destination": "Data/patch-T.mpq",
+    "size_bytes": 541957195,
     "dependencies": [
       "vanilla_helpers",
       "hd_patch_a",

--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -359,12 +359,63 @@ def _is_alternate_hd_variant(mod_id: str) -> bool:
     return mod_id.endswith("_less_thicc") or mod_id.endswith("_ultra")
 
 
+def _variant_on_disk_by_size(
+    a: str,
+    b: str,
+    game_path: Path,
+    catalog: dict[str, dict[str, Any]],
+) -> str | None:
+    """Which of two exclusive variants the file on disk actually is, by its size.
+
+    Variants that share a destination cannot be told apart by filename: both
+    patch-T tiers install Data/patch-T.mpq, and so do both patch-L bodies. A
+    file the launcher installed itself is identified by its install record, but
+    a hand-installed one has no record and was previously attributed by
+    guesswork -- which lands on the wrong tier for anyone who downloaded Ultra
+    Base from the publisher directly.
+
+    Their published sizes differ, so an exact length match names the variant.
+    This is checked BEFORE the install record on purpose: swapping the file by
+    hand after installing through the launcher leaves the record stale, and the
+    bytes on disk are what the game will actually load.
+
+    Returns None whenever the answer is not unambiguous -- sizes missing, sizes
+    equal, destinations different, file unreadable, or a length matching
+    neither -- so every existing tie-break path still runs.
+    """
+    mod_a, mod_b = catalog.get(a) or {}, catalog.get(b) or {}
+    size_a, size_b = mod_a.get("size_bytes"), mod_b.get("size_bytes")
+    if not size_a or not size_b or size_a == size_b:
+        return None
+    dest = mod_a.get("destination")
+    if not dest or mod_b.get("destination") != dest:
+        return None
+    found = resolve_ci(game_path, dest)
+    if found is None:
+        return None
+    try:
+        actual = found.stat().st_size
+    except OSError:
+        return None
+    if actual == size_a:
+        return a
+    if actual == size_b:
+        return b
+    return None
+
+
 def _pick_exclusive_detect_winner(
     a: str,
     b: str,
     desired: dict[str, bool],
+    *,
+    game_path: Path | None = None,
 ) -> str:
     """Pick which conflicting mod id should read as installed when both match disk."""
+    if game_path is not None:
+        by_size = _variant_on_disk_by_size(a, b, game_path, mod_catalog_map())
+        if by_size is not None:
+            return by_size
     installed = settings.installed_mods
     a_rec, b_rec = a in installed, b in installed
     if a_rec and not b_rec:
@@ -393,6 +444,8 @@ def _pick_exclusive_detect_winner(
 def _reconcile_exclusive_variants_detected(
     state: dict[str, bool],
     desired: dict[str, bool] | None = None,
+    *,
+    game_path: Path | None = None,
 ) -> dict[str, bool]:
     """Shared install artifacts can mark multiple conflict siblings as present."""
     out = dict(state)
@@ -407,7 +460,9 @@ def _reconcile_exclusive_variants_detected(
             seen.add(pair)
             if not (out.get(mid) and out.get(conf)):
                 continue
-            winner = _pick_exclusive_detect_winner(mid, conf, desired)
+            winner = _pick_exclusive_detect_winner(
+                mid, conf, desired, game_path=game_path
+            )
             loser = conf if winner == mid else mid
             out[loser] = False
     return out
@@ -1239,6 +1294,7 @@ def detect_actual_state(game_path: Path) -> dict[str, bool]:
     reconciled = _reconcile_exclusive_variants_detected(
         _reconcile_vf_dxvk_detected(state),
         desired=settings.desired_mods,
+        game_path=game_path,
     )
     _backfill_detected_installed_mods(reconciled)
     _refresh_unverified_mod_flags(game_path, reconciled)

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1297,6 +1297,76 @@ def test_hd_patch_lt_exclusive_planning():
     print("OK hd patch L/T exclusive planning")
 
 
+def test_hd_variant_identified_by_size_on_disk():
+    """A hand-installed patch-T/L variant is identified by its size, not guessed.
+
+    Both patch-T tiers install Data/patch-T.mpq and both patch-L bodies install
+    Data/patch-L.mpq, so filename detection matches both. When the launcher
+    installed the file its install record settles it, but a file downloaded from
+    the publisher by hand has no record and used to be attributed by fallback --
+    which lands on the standard tier even when Ultra Base is what is on disk.
+    That matters because patch-U depends on the ultra base specifically.
+    """
+    import tempfile as _tf
+
+    from ichalaunch.config import settings as settings_mod
+    from ichalaunch.core.filesystem import clear_fs_caches
+    from ichalaunch.mods import installer as I
+
+    catalog = I.mod_catalog_map()
+    sizes = {mid: (catalog[mid] or {}).get("size_bytes")
+             for mid in ("hd_patch_t", "hd_patch_t_ultra",
+                         "hd_patch_l", "hd_patch_l_less_thicc")}
+    # The catalog must carry a distinct size for each side of both pairs, or
+    # this whole mechanism silently degrades to the old guess.
+    assert all(sizes.values()), sizes
+    assert sizes["hd_patch_t"] != sizes["hd_patch_t_ultra"], sizes
+    assert sizes["hd_patch_l"] != sizes["hd_patch_l_less_thicc"], sizes
+
+    keys = ("installed_mods", "desired_mods")
+    saved = {k: settings_mod.settings.get(k) for k in keys}
+    try:
+        def winner(pair, dest, size, record):
+            a, b = pair
+            settings_mod.settings.set("installed_mods", record)
+            settings_mod.settings.set("desired_mods", {})
+            with _tf.TemporaryDirectory() as td:
+                game = Path(td)
+                (game / "Data").mkdir()
+                with open(game / "Data" / dest, "wb") as fh:
+                    fh.truncate(size)          # sparse; never writes 500 MB
+                clear_fs_caches()
+                out = I._reconcile_exclusive_variants_detected(
+                    {a: True, b: True}, game_path=game)
+            return a if out[a] else (b if out[b] else None)
+
+        T = ("hd_patch_t", "hd_patch_t_ultra")
+        L = ("hd_patch_l", "hd_patch_l_less_thicc")
+
+        # No install record at all: the bytes on disk decide.
+        assert winner(T, "patch-T.mpq", sizes["hd_patch_t_ultra"], {}) == "hd_patch_t_ultra"
+        assert winner(T, "patch-T.mpq", sizes["hd_patch_t"], {}) == "hd_patch_t"
+        assert winner(L, "patch-L.mpq", sizes["hd_patch_l_less_thicc"], {}) == "hd_patch_l_less_thicc"
+        assert winner(L, "patch-L.mpq", sizes["hd_patch_l"], {}) == "hd_patch_l"
+
+        # A record left stale by a hand swap does not outrank the file itself.
+        assert winner(T, "patch-T.mpq", sizes["hd_patch_t_ultra"],
+                      {"hd_patch_t": {}}) == "hd_patch_t_ultra"
+        assert winner(T, "patch-T.mpq", sizes["hd_patch_t"],
+                      {"hd_patch_t_ultra": {}}) == "hd_patch_t"
+
+        # A size matching neither variant must fall through to the old
+        # behaviour rather than resolving to nothing.
+        assert winner(T, "patch-T.mpq", 4096,
+                      {"hd_patch_t_ultra": {}}) == "hd_patch_t_ultra"
+        assert winner(T, "patch-T.mpq", 4096, {}) == "hd_patch_t"
+    finally:
+        for k, v in saved.items():
+            settings_mod.settings.set(k, v)
+
+    print("OK hd variant identified by size on disk")
+
+
 def test_hd_patch_exclusive_variant_swap():
     """Switching L/T MPQ siblings must plan reinstall, not a silent no-op."""
     from ichalaunch.config.settings import settings as s
@@ -8668,6 +8738,7 @@ def _run_smoke_tests():
     test_dxvk_detect_plan_clean()
     test_hd_patch_lt_exclusive_planning()
     test_hd_patch_exclusive_variant_swap()
+    test_hd_variant_identified_by_size_on_disk()
     test_hd_patch_both_desired_reconciled()
     test_backfill_installed_mods_on_detect()
     test_resolve_launch_exe()


### PR DESCRIPTION
Both patch-T tiers install Data/patch-T.mpq and both patch-L bodies install
Data/patch-L.mpq, so filename detection matches both members of each pair and
something has to break the tie. When the launcher installed the file its own
install record settles it correctly. When the user downloaded the file from
Project Reforged directly -- which their download page invites, with two
buttons on one card and no warning about which is which -- there is no record,
and the tie fell through to a fallback that resolves to the standard tier.

That is the wrong guess in the direction that matters. patch-U declares
hd_patch_t_ultra as a dependency, because the publisher specifies Ultra Base
underneath the ultra tier and the mismatched pair is a documented-unsupported
combination. A user with Ultra Base on disk was being reported as running
standard, so nothing downstream could see that the pair was already correct --
or, with the tiers the other way round, that it was not.

The four variants have distinct published sizes, so an exact length match names
the file:

  patch-T standard      499,342,621
  patch-T ultra base    541,957,195
  patch-L regular        37,330,631
  patch-L less thicc     53,272,447

_variant_on_disk_by_size() is consulted before the install record on purpose.
Swapping the file by hand after installing through the launcher leaves the
record stale, and the bytes on disk are what the game actually loads. It
returns None whenever the answer is not unambiguous -- size missing from the
catalog, sizes equal, destinations different, file unreadable, or a length
matching neither -- so every existing tie-break path still runs untouched, and
a catalog entry without size_bytes behaves exactly as it does today.

The lookup goes through resolve_ci, so a tree holding Data/patch-t.mpq is found
on Linux rather than read as absent.

game_path is threaded through _reconcile_exclusive_variants_detected as a
keyword defaulting to None; the desired-state caller in
reconcile_exclusive_desired_mods is unchanged and still tie-breaks the old way,
since it is reasoning about intent rather than about a file.

test_hd_variant_identified_by_size_on_disk covers both pairs in both
directions, a stale record overridden by the file, and two fall-through cases
that must not regress.