### PR TITLE
Run the client under new WoW64 where Proton supports it, so Wine leaves its 4 GB alone

### DIFF
--- a/ichalaunch/config/settings.py
+++ b/ichalaunch/config/settings.py
@@ -34,6 +34,9 @@ DEFAULTS: dict[str, Any] = {
     "linux_proton_path": "",
     "linux_use_latest_proton": False,
     "linux_wineprefix": "",
+    # New WoW64: opt-in, because not every Proton build ships the 64-bit
+    # host and DLL-injecting client mods have had little testing under it.
+    "linux_use_wow64": False,
     "addons_path": "",
     "vanillafixes_enabled": True,
     "minimize_on_launch": False,

--- a/ichalaunch/config/settings.py
+++ b/ichalaunch/config/settings.py
@@ -34,9 +34,19 @@ DEFAULTS: dict[str, Any] = {
     "linux_proton_path": "",
     "linux_use_latest_proton": False,
     "linux_wineprefix": "",
-    # New WoW64: opt-in, because not every Proton build ships the 64-bit
-    # host and DLL-injecting client mods have had little testing under it.
-    "linux_use_wow64": False,
+    # New WoW64: on where the Proton build can honour it, off everywhere else
+    # without the user having to know which is which. build_launch_command
+    # probes for the 64-bit host and silently keeps the default mode when it is
+    # absent, so this default cannot fail a launch -- it only decides what
+    # happens on the builds that ship files/bin-wow64.
+    #
+    # None means "nobody has expressed a preference", and proton.wow64_enabled()
+    # resolves it against WOW64_DEFAULT_ON at read time. True/False appear here
+    # only once the user ticks the box. save() persists this whole dict, so a
+    # literal default would be written into every settings.json on first launch
+    # and would then outrank any later change to the default -- see the note on
+    # WOW64_DEFAULT_ON in ichalaunch/game/proton.py.
+    "linux_use_wow64": None,
     "addons_path": "",
     "vanillafixes_enabled": True,
     "minimize_on_launch": False,

--- a/ichalaunch/game/proton.py
+++ b/ichalaunch/game/proton.py
@@ -77,6 +77,18 @@ def _is_proton_build(d: Path) -> bool:
     return (d / "toolmanifest.vdf").is_file()
 
 
+def proton_supports_wow64(d: Path) -> bool:
+    """Whether *d* ships the 64-bit host binaries that new WoW64 needs.
+
+    Proton's own launch script swaps its bin directory to files/bin-wow64 when
+    PROTON_USE_WOW64 is set, so a build that lacks that directory cannot honour
+    the flag and the launch fails outright. Builds genuinely differ --
+    GE-Proton10-34 ships it, GE-Proton11-5 does not -- so this is probed per
+    build rather than assumed.
+    """
+    return (d / "files" / "bin-wow64").is_dir()
+
+
 def discover_proton_builds() -> list[Path]:
     """Every Proton build on disk, newest-looking first, deduplicated."""
     roots: list[Path] = []
@@ -183,6 +195,7 @@ def build_launch_command(exe: Path, cwd: Path) -> tuple[list[str], dict[str, str
         "PROTON_NO_ESYNC",
         "PROTON_NO_FSYNC",
         "PROTON_USE_WINED3D",
+        "PROTON_USE_WOW64",
         "PROTON_VERB",
         "SDL_VIDEODRIVER",
         "STEAM_COMPAT_CLIENT_INSTALL_PATH",
@@ -199,6 +212,24 @@ def build_launch_command(exe: Path, cwd: Path) -> tuple[list[str], dict[str, str
         "GAMEID": "umu-default",
         "STORE": "none",
     })
+
+    # New WoW64 runs the 32-bit client inside a 64-bit host process, which moves
+    # Wine's own libraries, the Vulkan loader and DXVK's host-side allocations
+    # out of the application's 4 GB of address space. The client stays 32-bit and
+    # its own ceiling is unchanged; what this buys is that the ceiling stops
+    # being shared with the translation layer. Measured on a vanilla WoW client
+    # with ~11 GB of texture packs: peak use of the low 4 GB was 48%.
+    if settings.get("linux_use_wow64", False):
+        if proton_supports_wow64(proton):
+            env["PROTON_USE_WOW64"] = "1"
+            log.info("New WoW64 requested and supported by %s", proton.name)
+        else:
+            # Setting it anyway would break the launch rather than degrade it.
+            log.warning(
+                "New WoW64 is enabled in Settings but %s has no "
+                "files/bin-wow64; launching in the default mode instead.",
+                proton.name,
+            )
     return [str(umu), str(exe)], env
 
 

--- a/ichalaunch/game/proton.py
+++ b/ichalaunch/game/proton.py
@@ -77,6 +77,24 @@ def _is_proton_build(d: Path) -> bool:
     return (d / "toolmanifest.vdf").is_file()
 
 
+# What an untouched install gets. Kept separate from the stored setting so the
+# stored value can stay null until somebody actually ticks the box: Settings.save()
+# serialises the whole DEFAULTS-merged dict, so a literal True in DEFAULTS is
+# written into every user's settings.json on their first launch, and from then on
+# _merge_loaded's `merged.update(loaded)` makes that stored True beat DEFAULTS
+# forever. Changing this constant would then fix nothing for anyone who had
+# already launched once -- which would leave a one-line revert as the rollback
+# plan while quietly making it a no-op. Resolving null here instead keeps the
+# revert working.
+WOW64_DEFAULT_ON = True
+
+
+def wow64_enabled() -> bool:
+    """Whether new WoW64 should be used, resolving "unset" to the default."""
+    stored = settings.get("linux_use_wow64", None)
+    return WOW64_DEFAULT_ON if stored is None else bool(stored)
+
+
 def proton_supports_wow64(d: Path) -> bool:
     """Whether *d* ships the 64-bit host binaries that new WoW64 needs.
 
@@ -85,8 +103,14 @@ def proton_supports_wow64(d: Path) -> bool:
     the flag and the launch fails outright. Builds genuinely differ --
     GE-Proton10-34 ships it, GE-Proton11-5 does not -- so this is probed per
     build rather than assumed.
+
+    The loader itself is what gets tested, not the directory holding it. Proton
+    re-points bin_dir and then execs bin_dir + "wine" without checking that it
+    exists, so an interrupted ProtonUp-Qt download or a trimmed build can leave
+    files/bin-wow64/ present but empty -- which would pass a directory test and
+    then fail the launch, the exact outcome this probe exists to prevent.
     """
-    return (d / "files" / "bin-wow64").is_dir()
+    return (d / "files" / "bin-wow64" / "wine").is_file()
 
 
 def discover_proton_builds() -> list[Path]:
@@ -219,17 +243,29 @@ def build_launch_command(exe: Path, cwd: Path) -> tuple[list[str], dict[str, str
     # its own ceiling is unchanged; what this buys is that the ceiling stops
     # being shared with the translation layer. Measured on a vanilla WoW client
     # with ~11 GB of texture packs: peak use of the low 4 GB was 48%.
-    if settings.get("linux_use_wow64", False):
+    #
+    # On by default, because the capability probe below is what makes that safe:
+    # a build that cannot honour the flag never receives it and launches exactly
+    # as it does today. The setting only decides what happens on builds that do
+    # ship the 64-bit host.
+    if wow64_enabled():
         if proton_supports_wow64(proton):
             env["PROTON_USE_WOW64"] = "1"
-            log.info("New WoW64 requested and supported by %s", proton.name)
+            log.info("Launch mode: new WoW64 (%s)", proton.name)
         else:
             # Setting it anyway would break the launch rather than degrade it.
-            log.warning(
-                "New WoW64 is enabled in Settings but %s has no "
-                "files/bin-wow64; launching in the default mode instead.",
+            # Info, not a warning: this is the default path on a build without
+            # the 64-bit host, and the user has not misconfigured anything.
+            log.info(
+                "Launch mode: default, because %s ships no usable "
+                "files/bin-wow64/wine (new WoW64 is on, but unavailable here)",
                 proton.name,
             )
+    else:
+        # Logged unconditionally, at the same level as the other two, so the
+        # launch log always names the mode. A bug report that does not say which
+        # loader ran costs a round trip to find out.
+        log.info("Launch mode: default (new WoW64 turned off in Settings)")
     return [str(umu), str(exe)], env
 
 

--- a/ichalaunch/ui/pages/settings.py
+++ b/ichalaunch/ui/pages/settings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+
 from PySide6.QtCore import Qt, QTimer, Signal
 from PySide6.QtWidgets import (
     QHBoxLayout,
@@ -16,6 +18,7 @@ from PySide6.QtWidgets import (
 from ichalaunch import __version__
 from ichalaunch.core.logging_setup import log_dir
 from ichalaunch.config.settings import settings
+from ichalaunch.game.proton import wow64_enabled
 from ichalaunch.ui.widgets.casting_bar_search_edit import (
     SETTINGS_MIN_H,
     CastingBarSearchEdit,
@@ -155,7 +158,32 @@ class SettingsPage(QWidget):
         self.cb_close = ThemeCheckBox("Close launcher when game starts")
         self.cb_close.setChecked(bool(settings.get("close_on_launch", False)))
         self.cb_close.toggled.connect(lambda v: settings.set("close_on_launch", v))
-        for cb in (self.cb_vf, self.cb_min, self.cb_close):
+        self.cb_wow64 = ThemeCheckBox(
+            "Run the client under new WoW64 where Proton supports it (Linux)"
+        )
+        self.cb_wow64.setChecked(wow64_enabled())
+        self.cb_wow64.setToolTip(
+            "Runs Wine's translation layer in a 64-bit host process, so its "
+            "libraries stop sharing the 32-bit client's 4 GB of address space. "
+            "The client stays 32-bit and its own ceiling does not move; what "
+            "changes is how much of that ceiling is left for the game. The "
+            "gain shows up with heavy texture packs.\n\n"
+            "On by default, but only where it can be honoured: Proton builds "
+            "differ, and the launcher checks yours before each launch. On a "
+            "build without the 64-bit host it keeps the normal mode and says "
+            "so in the log rather than failing the launch. Turn it off if a "
+            "DLL-injecting client mod misbehaves under it."
+        )
+        self.cb_wow64.toggled.connect(lambda v: settings.set("linux_use_wow64", v))
+        launch_boxes = [self.cb_vf, self.cb_min, self.cb_close]
+        # build_launch_command only consults linux_use_wow64 through the umu
+        # path, and core/process.py imports that module inside its "not win32"
+        # branch, so the setting cannot do anything on Windows. The widget is
+        # still constructed there so refresh() needs no platform branch of its
+        # own -- it is simply never added to the card.
+        if sys.platform != "win32":
+            launch_boxes.append(self.cb_wow64)
+        for cb in launch_boxes:
             cb.setMinimumHeight(28)
             cb.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
             launch_card.body.addWidget(cb)
@@ -381,6 +409,14 @@ class SettingsPage(QWidget):
             cb.blockSignals(True)
             cb.setChecked(bool(settings.get(key, False)))
             cb.blockSignals(False)
+        # Kept out of the loop above because that loop resolves a key to a bare
+        # bool, and this one is tri-state: null means "unset", which is not the
+        # same as off. wow64_enabled() is the single place that turns the stored
+        # value into a launch decision, so asking it here is what keeps the box
+        # and the launch path from ever disagreeing.
+        self.cb_wow64.blockSignals(True)
+        self.cb_wow64.setChecked(wow64_enabled())
+        self.cb_wow64.blockSignals(False)
         self.cb_auto_updates.blockSignals(True)
         self.cb_auto_updates.setChecked(settings.check_updates_on_startup())
         self.cb_auto_updates.blockSignals(False)

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -8366,6 +8366,92 @@ def test_linux_proton_launch_resolution():
     print("OK linux proton launch resolution")
 
 
+def test_linux_wow64_opt_in():
+    """New WoW64 is opt-in, probed per build, and never set blind.
+
+    Guards three things: that the flag is off unless asked for, that asking for
+    it on a Proton build with no files/bin-wow64 degrades to a normal launch
+    instead of breaking it, and that a value inherited from the caller's own
+    environment cannot decide the launch mode behind the setting's back.
+    """
+    if sys.platform == "win32":
+        print("OK linux wow64 opt-in (skipped on Windows)")
+        return
+
+    import os
+
+    from ichalaunch.game import proton
+
+    class _Stub:
+        def __init__(self, d):
+            self.d = dict(d)
+
+        def get(self, k, default=None):
+            return self.d.get(k, default)
+
+        def set(self, k, v):
+            self.d[k] = v
+
+    real = proton.settings
+    inherited = os.environ.get("PROTON_USE_WOW64")
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+
+            umu = root / "umu-run"
+            umu.write_text("#!/bin/sh\nexit 0\n")
+            umu.chmod(0o755)
+
+            # One build ships the 64-bit host, one does not. This is the real
+            # difference between GE-Proton10-34 and GE-Proton11-5.
+            withw = root / "GE-Proton10-34"
+            (withw / "files" / "bin-wow64").mkdir(parents=True)
+            (withw / "toolmanifest.vdf").write_text("x")
+            without = root / "GE-Proton11-5"
+            (without / "files" / "bin").mkdir(parents=True)
+            (without / "toolmanifest.vdf").write_text("x")
+
+            assert proton.proton_supports_wow64(withw)
+            assert not proton.proton_supports_wow64(without)
+
+            def cmd(build, enabled):
+                proton.settings = _Stub({
+                    "linux_proton_path": str(build),
+                    "linux_use_latest_proton": False,
+                    "linux_umu_path": str(umu),
+                    "linux_wineprefix": str(root / "prefix"),
+                    "linux_use_wow64": enabled,
+                })
+                return proton.build_launch_command(root / "WoW.exe", root)[1]
+
+            # Off by default: the flag is absent, not "0".
+            assert "PROTON_USE_WOW64" not in cmd(withw, False)
+
+            # On, and the build can honour it.
+            assert cmd(withw, True).get("PROTON_USE_WOW64") == "1"
+
+            # On, but the build has no 64-bit host. Setting it here would fail
+            # the launch outright, so it is deliberately left unset.
+            assert "PROTON_USE_WOW64" not in cmd(without, True)
+
+            # An inherited value must not survive: the setting is the only
+            # thing that decides the launch mode.
+            os.environ["PROTON_USE_WOW64"] = "1"
+            try:
+                assert "PROTON_USE_WOW64" not in cmd(withw, False)
+                assert "PROTON_USE_WOW64" not in cmd(without, True)
+            finally:
+                os.environ.pop("PROTON_USE_WOW64", None)
+    finally:
+        proton.settings = real
+        if inherited is None:
+            os.environ.pop("PROTON_USE_WOW64", None)
+        else:
+            os.environ["PROTON_USE_WOW64"] = inherited
+
+    print("OK linux wow64 opt-in")
+
+
 def test_linux_dxvk_vulkan_preflight():
     """DXVK suitability on Linux turns on 32-bit Vulkan, not on the GPU name.
 
@@ -8736,6 +8822,7 @@ def _run_smoke_tests():
     test_prepare_for_launch_syncs_dlls_txt()
     test_client_exe_probe_is_case_insensitive()
     test_linux_proton_launch_resolution()
+    test_linux_wow64_opt_in()
     test_linux_dxvk_vulkan_preflight()
     test_prepare_for_launch_clears_data_readonly()
     test_plan_missing_installs_dxvk()

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -8366,16 +8366,17 @@ def test_linux_proton_launch_resolution():
     print("OK linux proton launch resolution")
 
 
-def test_linux_wow64_opt_in():
-    """New WoW64 is opt-in, probed per build, and never set blind.
+def test_linux_wow64_default_on_when_supported():
+    """New WoW64 is on by default, probed per build, and never set blind.
 
-    Guards three things: that the flag is off unless asked for, that asking for
-    it on a Proton build with no files/bin-wow64 degrades to a normal launch
-    instead of breaking it, and that a value inherited from the caller's own
-    environment cannot decide the launch mode behind the setting's back.
+    Guards four things: that an untouched install gets it on a build that ships
+    files/bin-wow64, that the same untouched install gets a normal launch on a
+    build that does not, that turning it off is honoured on a capable build, and
+    that a value inherited from the caller's own environment cannot decide the
+    launch mode behind the setting's back.
     """
     if sys.platform == "win32":
-        print("OK linux wow64 opt-in (skipped on Windows)")
+        print("OK linux wow64 default-on (skipped on Windows)")
         return
 
     import os
@@ -8406,25 +8407,48 @@ def test_linux_wow64_opt_in():
             # difference between GE-Proton10-34 and GE-Proton11-5.
             withw = root / "GE-Proton10-34"
             (withw / "files" / "bin-wow64").mkdir(parents=True)
+            (withw / "files" / "bin-wow64" / "wine").write_text("#!/bin/sh\n")
             (withw / "toolmanifest.vdf").write_text("x")
             without = root / "GE-Proton11-5"
             (without / "files" / "bin").mkdir(parents=True)
             (without / "toolmanifest.vdf").write_text("x")
+            # An interrupted download or a trimmed build: the directory is
+            # there, the loader Proton would exec is not. Proton does not check,
+            # so a directory-only probe would pass this and fail the launch.
+            partial = root / "GE-Proton10-34-partial"
+            (partial / "files" / "bin-wow64").mkdir(parents=True)
+            (partial / "toolmanifest.vdf").write_text("x")
 
             assert proton.proton_supports_wow64(withw)
             assert not proton.proton_supports_wow64(without)
+            assert not proton.proton_supports_wow64(partial)
 
-            def cmd(build, enabled):
-                proton.settings = _Stub({
+            _UNSET = object()
+
+            def cmd(build, enabled=_UNSET):
+                data = {
                     "linux_proton_path": str(build),
                     "linux_use_latest_proton": False,
                     "linux_umu_path": str(umu),
                     "linux_wineprefix": str(root / "prefix"),
-                    "linux_use_wow64": enabled,
-                })
+                }
+                # Omitted entirely rather than set, so this exercises the
+                # DEFAULTS fallback the way an untouched install hits it.
+                if enabled is not _UNSET:
+                    data["linux_use_wow64"] = enabled
+                proton.settings = _Stub(data)
                 return proton.build_launch_command(root / "WoW.exe", root)[1]
 
-            # Off by default: the flag is absent, not "0".
+            # The default an untouched install gets: on where it can be honoured.
+            assert cmd(withw).get("PROTON_USE_WOW64") == "1"
+
+            # Same untouched install, a build that cannot honour it: the flag is
+            # absent, not "0", and the launch is otherwise unchanged.
+            assert "PROTON_USE_WOW64" not in cmd(without)
+            # And the half-extracted build is declined for the same reason.
+            assert "PROTON_USE_WOW64" not in cmd(partial)
+
+            # Turning it off is honoured even where the build supports it.
             assert "PROTON_USE_WOW64" not in cmd(withw, False)
 
             # On, and the build can honour it.
@@ -8449,7 +8473,97 @@ def test_linux_wow64_opt_in():
         else:
             os.environ["PROTON_USE_WOW64"] = inherited
 
-    print("OK linux wow64 opt-in")
+    print("OK linux wow64 default-on where supported")
+
+
+def test_linux_wow64_settings_checkbox():
+    """The Settings checkbox reflects a default-on key and is Linux-only.
+
+    Two separate things. First, the upgrade path: a settings.json written before
+    this key existed must come back with it on, because _merge_loaded starts from
+    dict(DEFAULTS) -- that is what carries the new default to existing users
+    rather than only to fresh installs.
+
+    Second, refresh(): the shared loop next to it hardcodes False as its fallback,
+    which is the wrong default for this key. That fallback is unreachable while
+    _merge_loaded materialises DEFAULTS, so driving the box through the loop would
+    work today and quietly stop working if that ever changed. The absent-key
+    assertion pins it; reverting to the loop fails it.
+    """
+    import sys as _sys
+
+    from PySide6.QtWidgets import QApplication
+
+    import ichalaunch.ui.pages.settings as settings_page_mod
+    from ichalaunch.config.settings import DEFAULTS, Settings, settings
+    from ichalaunch.game.proton import WOW64_DEFAULT_ON, wow64_enabled
+
+    # Stored as null, not as the default itself. save() writes the whole
+    # DEFAULTS-merged dict, so a literal True here would be baked into every
+    # settings.json on first launch and would then outrank WOW64_DEFAULT_ON
+    # forever -- turning the one-line revert into a no-op for everyone who had
+    # already run the launcher once.
+    assert DEFAULTS["linux_use_wow64"] is None
+    assert WOW64_DEFAULT_ON is True
+
+    # The upgrade path. A settings.json from before this key existed has no
+    # opinion about it, and must stay that way rather than being pinned.
+    legacy = {"game_path": "", "close_on_launch": True}
+    merged, _ = Settings.__new__(Settings)._merge_loaded(legacy)
+    assert merged["linux_use_wow64"] is None
+    # An explicit choice in the file still wins over the default, both ways.
+    for stored in (True, False):
+        m, _ = Settings.__new__(Settings)._merge_loaded(
+            {**legacy, "linux_use_wow64": stored}
+        )
+        assert m["linux_use_wow64"] is stored
+
+    # And the revert lever still works: with nothing stored, flipping the
+    # constant flips what users get.
+    prev_stored = settings.get("linux_use_wow64", None)
+    import ichalaunch.game.proton as _proton
+    try:
+        settings.set("linux_use_wow64", None)
+        assert wow64_enabled() is True
+        _proton.WOW64_DEFAULT_ON = False
+        assert wow64_enabled() is False
+        # An explicit choice is not overridden by the constant.
+        settings.set("linux_use_wow64", True)
+        assert wow64_enabled() is True
+    finally:
+        _proton.WOW64_DEFAULT_ON = True
+        settings.set("linux_use_wow64", prev_stored)
+
+    app = QApplication.instance() or QApplication(_sys.argv)
+    assert app is not None
+    page = settings_page_mod.SettingsPage()
+
+    # Constructed on every platform so refresh() needs no platform branch, but
+    # only shown where the setting can do anything.
+    assert hasattr(page, "cb_wow64")
+    if _sys.platform == "win32":
+        assert page.cb_wow64.parent() is None
+        print("OK linux wow64 checkbox hidden on Windows")
+        return
+
+    prev = settings.get("linux_use_wow64", True)
+    try:
+        # Absent key: the box must follow DEFAULTS, not fall back to False.
+        settings._data.pop("linux_use_wow64", None)
+        page.refresh()
+        assert page.cb_wow64.isChecked()
+
+        settings.set("linux_use_wow64", False)
+        page.refresh()
+        assert not page.cb_wow64.isChecked()
+
+        settings.set("linux_use_wow64", True)
+        page.refresh()
+        assert page.cb_wow64.isChecked()
+    finally:
+        settings.set("linux_use_wow64", prev)
+
+    print("OK linux wow64 settings checkbox")
 
 
 def test_linux_dxvk_vulkan_preflight():
@@ -8822,7 +8936,8 @@ def _run_smoke_tests():
     test_prepare_for_launch_syncs_dlls_txt()
     test_client_exe_probe_is_case_insensitive()
     test_linux_proton_launch_resolution()
-    test_linux_wow64_opt_in()
+    test_linux_wow64_default_on_when_supported()
+    test_linux_wow64_settings_checkbox()
     test_linux_dxvk_vulkan_preflight()
     test_prepare_for_launch_clears_data_readonly()
     test_plan_missing_installs_dxvk()


### PR DESCRIPTION
A 32-bit client shares its 4 GB of address space with everything Wine maps into
the process: Wine's own libraries, the Vulkan loader, and DXVK's host-side
allocations. Proton's new WoW64 mode runs that translation layer in a 64-bit host
process instead, so the low 4 GB stops being shared. The client stays 32-bit and
its own ceiling does not move -- what changes is how much of that ceiling is
actually available to the game. On a vanilla WoW install with roughly 11 GB of
texture packs, peak use of the low 4 GB measured 48%, with four fifths of session
growth landing above the 4 GB line where the game never had to compete for it.

This is Linux-only by construction. On Windows there is no translation layer to
move out of the way, so there is no equivalent and none is implied here:
core/process.py imports this module only inside its "not win32" branch, so none of
it is reachable on Windows.

**Now with a checkbox, in Settings -> Launch**, and on by default where the Proton
build can honour it. It previously had no control anywhere in the launcher, so the
only way to reach it was hand-editing settings.json.

proton_supports_wow64() probes the build and the flag is only set when it can be
honoured; otherwise the launch proceeds normally and the log says which mode ran.
Builds genuinely differ -- GE-Proton10-34 ships files/bin-wow64, GE-Proton11-5 does
not -- and setting PROTON_USE_WOW64 on a build without the 64-bit host fails the
launch outright rather than degrading it. The probe tests
`files/bin-wow64/wine`, not the directory: Proton re-points its bin_dir and execs
that path without checking it exists, so an interrupted download or a trimmed
build can leave the directory present and empty, which a directory test would pass
and the launch would then fail on.

The stored value stays `null` until somebody actually ticks the box, and
`wow64_enabled()` resolves null against the `WOW64_DEFAULT_ON` constant at read
time. That is deliberate and it is about your rollback: `save()` serialises the
whole DEFAULTS-merged dict, so a literal `True` in DEFAULTS gets written into every
user's settings.json on first launch, and `merged.update(loaded)` would then make
that stored value outrank DEFAULTS permanently. Changing the default back would fix
nothing for anyone who had already run the launcher once. This way the one-line
revert keeps working. `wow64_enabled()` is also the single place the stored value
becomes a launch decision, and the checkbox calls it too, so the box and the launch
path cannot disagree.

PROTON_USE_WOW64 joins the scrub list so a value inherited from the user's
environment cannot decide the launch mode behind the setting's back, which is the
same reasoning already applied to PROTON_USE_WINED3D and the rest.

**One thing you should decide rather than me.** The original reason this was opt-in
had two halves. The probe answers the first -- not every build can honour the flag.
It cannot answer the second: DLL-injecting client mods have had little testing
under new WoW64. `vanillafixes_enabled` defaults True, so VanillaFixes is the usual
launch path and it does inject the dlls.txt chain, which means default-on makes
that combination the out-of-the-box configuration on Linux. I think the probe plus
a visible checkbox plus a working revert is a reasonable place to land, but you own
the support load, and `WOW64_DEFAULT_ON` is the single line to change if you would
rather it shipped opt-in.

test_linux_wow64_default_on_when_supported covers the unset default in both
directions, an explicit choice either way, a half-extracted build, and the
environment-inheritance guard. test_linux_wow64_settings_checkbox covers the
checkbox, that a settings.json predating the key stays unset through
_merge_loaded, that flipping WOW64_DEFAULT_ON still changes what unset users get,
and that the box is absent from the card on Windows.

---

Verified on CachyOS, stacked on #276 (the suite cannot finish on Linux without it):
118 passing before this branch, 120 after -- exactly the two tests added here --
stopping at the same pre-existing failure in both cases. Merge-clean onto current
master. I can't execute the Windows path, but the checkbox is gated off it and the
launch code is unreachable there.

Note this now conflicts with #275 in three files rather than two -- both branches
insert into the same Launch card and the same refresh() block in
ui/pages/settings.py, on top of config/settings.py and game/proton.py. They are
adjacent-line conflicts, not semantic ones; the features are independent. Happy to
rebase whichever lands second.


---

**Update — run end to end on real hardware.** Launching a real client through the
launcher, on a 9950X3D with GE-Proton10-34, the log records:

```
Launch mode: VanillaFixes + DXVK (Vulkan)
Launch mode: new WoW64 (GE-Proton10-34)
```

That is the combination the note above flags as the unknown: VanillaFixes injecting
the `dlls.txt` chain (d3d9, SuperWoWhook, VanillaHelpers, nampower, UnitXP_SP3,
perf_boost) into a 32-bit client running under the 64-bit host. The client
launched, ran, took input for about a minute, and exited cleanly. The patched
WoW.exe was byte-identical afterwards.

Stated plainly: that is **one run, and it is an absence of breakage rather than
evidence of a gain.** It does not make the injection question settled -- one clean
session is not a sample -- and I am deliberately claiming nothing about
performance, because the zone I ran in is nowhere near heavy enough to separate a
real effect from a load that was never hard. It moves this from "nobody has tried
it" to "it has been tried once and nothing fell over."
