### PR TITLE
Cap frames from the user's own monitor instead of shipping one number

### DIFF
--- a/ichalaunch/config/settings.py
+++ b/ichalaunch/config/settings.py
@@ -35,6 +35,11 @@ DEFAULTS: dict[str, Any] = {
     "linux_use_latest_proton": False,
     "linux_wineprefix": "",
     "addons_path": "",
+    # Frame pacing follows the display. Project Reforged's guide prescribes a
+    # cap a few frames under the refresh rate ("162-163" for a 165 Hz panel);
+    # computing it reproduces that intent on every monitor instead of one.
+    "frame_cap_from_refresh": True,
+    "frame_cap_offset": 3,
     "vanillafixes_enabled": True,
     "minimize_on_launch": False,
     "close_on_launch": False,

--- a/ichalaunch/config/settings.py
+++ b/ichalaunch/config/settings.py
@@ -38,7 +38,13 @@ DEFAULTS: dict[str, Any] = {
     # Frame pacing follows the display. Project Reforged's guide prescribes a
     # cap a few frames under the refresh rate ("162-163" for a 165 Hz panel);
     # computing it reproduces that intent on every monitor instead of one.
-    "frame_cap_from_refresh": True,
+    # None means "nobody has expressed a preference"; display.frame_cap_enabled()
+    # resolves it against FRAME_CAP_DEFAULT_ON at read time. True/False appear here
+    # only once the user says so. save() persists this whole dict, so a literal
+    # default would be written into every settings.json on first launch and would
+    # then outrank any later change to the default -- leaving a one-line revert that
+    # silently does nothing for anyone who had already launched once.
+    "frame_cap_from_refresh": None,
     "frame_cap_offset": 3,
     "vanillafixes_enabled": True,
     "minimize_on_launch": False,

--- a/ichalaunch/game/display.py
+++ b/ichalaunch/game/display.py
@@ -1,0 +1,287 @@
+"""Reading the user's real display mode, so the frame cap can follow it.
+
+WHY THIS EXISTS. Project Reforged's setup guide prescribes a DXVK frame cap a
+few frames below the monitor's refresh rate -- their own wording for a 165 Hz
+panel is "162-163". That is the right rule, but shipping the literal number
+would hand 163 to somebody on a 60 Hz laptop and to somebody on a 240 Hz panel
+alike. Computing it from the display reproduces PR's intent on every machine
+instead of on exactly one.
+
+⛔ WHY NOT READ Config.wtf. The obvious shortcut -- take gxRefresh out of the
+user's own Config.wtf -- is actively wrong. The vanilla client forces gxRefresh
+to 60 whenever it runs windowed, because a windowed surface reports refresh 0.
+On a verified 165.058 Hz panel the file says "60", which would compute a cap of
+57 and quietly throttle the game to a third of the display. The client's crash
+logs carry no display information at all either. The mode has to come from the
+compositor or the OS, live.
+
+Detection degrades to None rather than guessing. A None result means callers
+leave whatever cap is already configured completely alone.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import shutil
+import subprocess
+import sys
+
+from ichalaunch.core.logging_setup import log
+
+# PR's guide says 162-163 for a 165 Hz panel, i.e. two or three frames of
+# headroom. Three is the safer end of their own range and is the default.
+DEFAULT_CAP_OFFSET = 3
+
+# Below this refresh rate, subtracting an offset does more harm than good -- a
+# 30 Hz panel capped at 27 is a worse experience than an uncapped one.
+_MIN_SENSIBLE_REFRESH = 48.0
+
+# The offset is a couple of frames of headroom, not a free-form number, and the
+# setting behind it is hand-edited. Read as "the cap" rather than "frames below
+# refresh", a value like 165 would compute a 1 fps lock and persist it. Bounding
+# the input is what makes that unreachable: clamping only the result would still
+# let an offset of 100 produce 44 on a 144 Hz panel, which is just as wrong and
+# far harder to notice.
+_MAX_CAP_OFFSET = 10
+
+_PROBE_TIMEOUT = 5
+
+
+def _run(cmd: list[str]) -> str | None:
+    """Run a probe command, returning stdout, or None on any failure."""
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True,
+                             timeout=_PROBE_TIMEOUT, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout if out.returncode == 0 else None
+
+
+def _refresh_windows() -> float | None:
+    """Current refresh of the primary display, via EnumDisplaySettingsW.
+
+    Windows reports this as a whole number and commonly rounds a 165.058 Hz
+    mode down to 164, which is harmless here: the cap is derived by subtracting
+    an offset, so a slightly low reading stays on the safe side of the panel.
+    """
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except (ImportError, ValueError):
+        return None
+
+    class _DEVMODEW(ctypes.Structure):
+        _fields_ = [
+            ("dmDeviceName", wintypes.WCHAR * 32),
+            ("dmSpecVersion", wintypes.WORD),
+            ("dmDriverVersion", wintypes.WORD),
+            ("dmSize", wintypes.WORD),
+            ("dmDriverExtra", wintypes.WORD),
+            ("dmFields", wintypes.DWORD),
+            ("dmPositionX", ctypes.c_long),
+            ("dmPositionY", ctypes.c_long),
+            ("dmDisplayOrientation", wintypes.DWORD),
+            ("dmDisplayFixedOutput", wintypes.DWORD),
+            ("dmColor", ctypes.c_short),
+            ("dmDuplex", ctypes.c_short),
+            ("dmYResolution", ctypes.c_short),
+            ("dmTTOption", ctypes.c_short),
+            ("dmCollate", ctypes.c_short),
+            ("dmFormName", wintypes.WCHAR * 32),
+            ("dmLogPixels", wintypes.WORD),
+            ("dmBitsPerPel", wintypes.DWORD),
+            ("dmPelsWidth", wintypes.DWORD),
+            ("dmPelsHeight", wintypes.DWORD),
+            ("dmDisplayFlags", wintypes.DWORD),
+            ("dmDisplayFrequency", wintypes.DWORD),
+            ("dmICMMethod", wintypes.DWORD),
+            ("dmICMIntent", wintypes.DWORD),
+            ("dmMediaType", wintypes.DWORD),
+            ("dmDitherType", wintypes.DWORD),
+            ("dmReserved1", wintypes.DWORD),
+            ("dmReserved2", wintypes.DWORD),
+            ("dmPanningWidth", wintypes.DWORD),
+            ("dmPanningHeight", wintypes.DWORD),
+        ]
+
+    ENUM_CURRENT_SETTINGS = -1
+    mode = _DEVMODEW()
+    mode.dmSize = ctypes.sizeof(_DEVMODEW)
+    try:
+        ok = ctypes.windll.user32.EnumDisplaySettingsW(
+            None, ENUM_CURRENT_SETTINGS, ctypes.byref(mode))
+    except (AttributeError, OSError):
+        return None
+    if not ok:
+        return None
+    hz = float(mode.dmDisplayFrequency)
+    # 0 and 1 are documented placeholders meaning "hardware default".
+    return hz if hz > 1 else None
+
+
+def _refresh_kscreen() -> float | None:
+    """Current refresh under KDE (Wayland or X11), via kscreen-doctor -j."""
+    if not shutil.which("kscreen-doctor"):
+        return None
+    raw = _run(["kscreen-doctor", "-j"])
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+    best: float | None = None
+    for out in data.get("outputs") or []:
+        if not out.get("enabled"):
+            continue
+        current = out.get("currentModeId")
+        for mode in out.get("modes") or []:
+            if mode.get("id") != current:
+                continue
+            try:
+                hz = float(mode.get("refreshRate"))
+            except (TypeError, ValueError):
+                continue
+            # Always the fastest enabled output, never a "primary" preference.
+            # libkscreen dropped the primary key after 5.24 in favour of
+            # priority, so that branch is dead on all of Plasma 6 -- and where it
+            # is alive it is harmful: a 60 Hz primary beside a 165 Hz gaming
+            # panel would return 60 and cap the game at 57, which is the exact
+            # failure this module exists to avoid. A maximum can only ever
+            # produce a cap at or above what some attached panel can present, so
+            # the worst case is an inert cap. _refresh_xrandr already does this.
+            if best is None or hz > best:
+                best = hz
+    return best
+
+
+def _refresh_xrandr() -> float | None:
+    """Current refresh under plain X11, via xrandr's starred mode."""
+    if not shutil.which("xrandr"):
+        return None
+    raw = _run(["xrandr", "--query"])
+    if not raw:
+        return None
+    best: float | None = None
+    for line in raw.splitlines():
+        # A current mode is marked with '*', e.g. "  1920x1080  164.91*+"
+        for match in re.finditer(r"(\d+\.\d+)\*", line):
+            try:
+                hz = float(match.group(1))
+            except ValueError:
+                continue
+            if best is None or hz > best:
+                best = hz
+    return best
+
+
+def detect_refresh_hz() -> float | None:
+    """The live refresh rate of the user's display, or None if unknowable.
+
+    None is a legitimate, common answer -- a headless session, an unusual
+    compositor, a locked-down box. Callers must treat it as "change nothing".
+    """
+    probes = ((_refresh_windows,) if sys.platform == "win32"
+              else (_refresh_kscreen, _refresh_xrandr))
+    for probe in probes:
+        try:
+            hz = probe()
+        except Exception:  # a probe must never take the launcher down
+            log.debug("Refresh probe %s failed", probe.__name__, exc_info=True)
+            continue
+        if hz and hz >= _MIN_SENSIBLE_REFRESH:
+            log.info("Detected display refresh %.3f Hz via %s", hz, probe.__name__)
+            return hz
+    log.info("Could not detect a display refresh rate; leaving any frame cap as-is")
+    return None
+
+
+def frame_cap_for(refresh_hz: float, offset: int = DEFAULT_CAP_OFFSET) -> int:
+    """The DXVK frame cap for a panel running at *refresh_hz*.
+
+    Floors before subtracting, deliberately. Real modes are fractional --
+    165.058, 59.94 -- and rounding 59.94 up to 60 would place the cap one frame
+    higher than the panel can actually present.
+
+    The offset is coerced and bounded here as well as at the call site, because
+    this is the function a future caller reaches for and the setting behind it is
+    hand-editable. A non-numeric value falls back to the default rather than
+    raising: this runs after DXVK's files are already on disk, and an exception
+    here would roll back a completed install over a typo in a config file.
+    """
+    try:
+        off = int(offset)
+    except (TypeError, ValueError):
+        off = DEFAULT_CAP_OFFSET
+    return max(1, math.floor(refresh_hz) - min(max(off, 0), _MAX_CAP_OFFSET))
+
+
+# --- applying the cap --------------------------------------------------------
+
+_CAP_KEY = "d3d9.maxFrameRate"
+
+
+def apply_frame_cap(conf_path, offset: int = DEFAULT_CAP_OFFSET) -> int | None:
+    """Rewrite ``d3d9.maxFrameRate`` in *conf_path* to suit the live display.
+
+    Returns the cap written, or None when nothing was changed -- either the
+    refresh rate could not be read or the file is absent. A None return must
+    leave the file exactly as it was: an undetectable display is not a reason
+    to impose a guess on somebody's frame pacing.
+
+    Only the one key is touched. Every other line, comment and blank survives
+    unchanged, line terminators included, because this file is shared three
+    ways: the bundled 2.7.1 preset, whatever the user tuned by hand, and the
+    marker comment the launcher detects the installed DXVK from.
+    """
+    import pathlib
+
+    path = pathlib.Path(conf_path)
+    if not path.is_file():
+        return None
+    hz = detect_refresh_hz()
+    if hz is None:
+        return None
+    cap = frame_cap_for(hz, offset)
+
+    try:
+        # newline="" keeps whatever terminators the file already uses. The
+        # default rewrites every line to os.linesep on Windows, which DXVK
+        # parses happily but which breaks the promise this function makes about
+        # leaving the rest of the file alone -- and that file carries the
+        # "DXVK 2.7.1" marker the launcher detects the installed DXVK from.
+        with open(path, "r", encoding="utf-8", errors="ignore", newline="") as fh:
+            original = fh.read()
+    except OSError as exc:
+        log.warning("Could not read %s to set the frame cap: %s", path, exc)
+        return None
+
+    newline = "\r\n" if "\r\n" in original else "\n"
+    out, replaced = [], False
+    for line in original.splitlines():
+        stripped = line.lstrip()
+        # Rewrite the live setting; leave commented examples as documentation.
+        if not stripped.startswith("#") and stripped.split("=")[0].strip() == _CAP_KEY:
+            indent = line[:len(line) - len(stripped)]
+            out.append(f"{indent}{_CAP_KEY} = {cap}")
+            replaced = True
+        else:
+            out.append(line)
+    if not replaced:
+        out.append(f"{_CAP_KEY} = {cap}")
+
+    try:
+        with open(path, "w", encoding="utf-8", newline="") as fh:
+            fh.write(newline.join(out) + newline)
+    except OSError as exc:
+        # install_mod already wraps this call and reverts the mod on OSError, and
+        # _mod_owned_paths snapshots dxvk.conf for dxvk_hd -- the rollback for
+        # exactly this file exists. Swallowing the error would opt out of it and
+        # leave a half-configured install with nothing in the log.
+        log.warning("Could not write the frame cap to %s: %s", path, exc)
+        raise
+    log.info("Frame cap set to %d (display %.3f Hz, offset %d)", cap, hz, offset)
+    return cap

--- a/ichalaunch/game/display.py
+++ b/ichalaunch/game/display.py
@@ -224,6 +224,19 @@ def frame_cap_for(refresh_hz: float, offset: int = DEFAULT_CAP_OFFSET) -> int:
 _CAP_KEY = "d3d9.maxFrameRate"
 
 
+# What an untouched install gets. Kept out of DEFAULTS so the stored value can stay
+# null until the user says otherwise -- see the note there.
+FRAME_CAP_DEFAULT_ON = True
+
+
+def frame_cap_enabled() -> bool:
+    """Whether to compute the cap from the display, resolving unset to the default."""
+    from ichalaunch.config.settings import settings
+
+    stored = settings.get("frame_cap_from_refresh", None)
+    return FRAME_CAP_DEFAULT_ON if stored is None else bool(stored)
+
+
 def apply_frame_cap(conf_path, offset: int = DEFAULT_CAP_OFFSET) -> int | None:
     """Rewrite ``d3d9.maxFrameRate`` in *conf_path* to suit the live display.
 

--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -1245,6 +1245,26 @@ def detect_actual_state(game_path: Path) -> dict[str, bool]:
     return reconciled
 
 
+def _apply_frame_cap_if_enabled(game: Path) -> None:
+    """Point d3d9.maxFrameRate at the user's display, if a dxvk.conf exists.
+
+    Called from every install path that can leave a dxvk.conf behind, not just
+    the DXVK 2.7.1 upgrade: the VanillaFixes bundle ships one too, and a user who
+    never takes the optional upgrade should not be the only one left uncapped.
+    Absent file, unreadable display, or the setting turned off all no-op.
+    """
+    if not settings.get("frame_cap_from_refresh", True):
+        return
+    from ichalaunch.game.display import apply_frame_cap
+
+    # The raw setting is passed through and coerced inside frame_cap_for.
+    # Converting here would raise on a hand-edited non-numeric value at a point
+    # where the mod's files are already written, and ValueError is caught by the
+    # install error handler -- which would revert an install that had succeeded.
+    if apply_frame_cap(game / "dxvk.conf", settings.get("frame_cap_offset", 3)) is None:
+        log.debug("Frame cap left as shipped for %s", game / "dxvk.conf")
+
+
 def _pe_artifacts_for_mod(mod: dict[str, Any]) -> list[str]:
     """Game-relative DLL/EXE paths this mod owns (for post-install / detect verify)."""
     return sorted(
@@ -2616,6 +2636,10 @@ def install_mod(mod_id: str, progress: ProgressCb | None = None, *, prefer_lates
                     for f in vf.parent.iterdir():
                         if f.is_file():
                             _zip_root_copy(f, game / f.name)
+                # The VanillaFixes+DXVK bundle ships its own dxvk.conf, so this
+                # path needs the cap too. Plain VanillaFixes ships none and the
+                # call is a no-op there.
+                _apply_frame_cap_if_enabled(game)
                 soft = _verify_mod_install(game, mod)
                 return _finish_mod_install(mod_id, mod, source, soft_skipped=soft)
 
@@ -2713,6 +2737,11 @@ def install_mod(mod_id: str, progress: ProgressCb | None = None, *, prefer_lates
                         raise FileNotFoundError(f"Bundled mod file missing: {resource.name}")
                     dest_rel = str(spec.get("destination") or resource.name)
                     _install_copy(resource, game / dest_rel, game_path=game)
+                # The bundled preset ships an uncapped d3d9.maxFrameRate, which
+                # is only right for the machine it was tuned on. Follow the
+                # user's actual display instead; a machine whose refresh cannot
+                # be read keeps the preset's value untouched.
+                _apply_frame_cap_if_enabled(game)
                 soft = _verify_mod_install(game, mod)
                 return _finish_mod_install(mod_id, mod, source, soft_skipped=soft)
 

--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -1253,9 +1253,10 @@ def _apply_frame_cap_if_enabled(game: Path) -> None:
     never takes the optional upgrade should not be the only one left uncapped.
     Absent file, unreadable display, or the setting turned off all no-op.
     """
-    if not settings.get("frame_cap_from_refresh", True):
+    from ichalaunch.game.display import apply_frame_cap, frame_cap_enabled
+
+    if not frame_cap_enabled():
         return
-    from ichalaunch.game.display import apply_frame_cap
 
     # The raw setting is passed through and coerced inside frame_cap_for.
     # Converting here would raise on a hand-edited non-numeric value at a point

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -8298,6 +8298,153 @@ def test_client_exe_probe_is_case_insensitive():
     print("OK client exe probe is case-insensitive")
 
 
+def test_frame_cap_from_refresh():
+    """The DXVK frame cap follows the real display, and only the real display.
+
+    Four things are load-bearing here. The arithmetic floors before subtracting,
+    because real modes are fractional and rounding 59.94 up would cap a frame
+    above what the panel can present. An undetectable display must leave the
+    file untouched rather than impose a guess. Every other line in dxvk.conf
+    survives byte for byte, since that file is shared with a bundled preset and
+    with whatever the user tuned by hand. And a commented-out example of the key
+    stays a comment.
+    """
+    from ichalaunch.game import display
+
+    # --- arithmetic --------------------------------------------------------
+    assert display.frame_cap_for(165.058, 3) == 162, display.frame_cap_for(165.058, 3)
+    assert display.frame_cap_for(165.058, 2) == 163
+    # Floors, never rounds: 59.94 is a 59 Hz mode for this purpose, not 60.
+    assert display.frame_cap_for(59.94, 3) == 56, display.frame_cap_for(59.94, 3)
+    assert display.frame_cap_for(60.0, 3) == 57
+    assert display.frame_cap_for(239.76, 3) == 236
+    # The offset is bounded, so a hand-edited setting cannot compute a lock.
+    # Reading frame_cap_offset as "the cap" rather than "frames below refresh"
+    # is the realistic mistake, and 165 must not yield 1 fps.
+    assert display.frame_cap_for(165.058, 165) == 155, display.frame_cap_for(165.058, 165)
+    assert display.frame_cap_for(144.0, 100) == 134, display.frame_cap_for(144.0, 100)
+    assert display.frame_cap_for(100.0, -5) == 100
+    # A non-numeric setting falls back to the default instead of raising: this
+    # runs after DXVK is already on disk, and an exception would revert a
+    # successful install over a typo in a config file.
+    assert display.frame_cap_for(165.058, "three") == 162
+    assert display.frame_cap_for(165.058, None) == 162
+    assert display.frame_cap_for(165.058, "2") == 163
+
+    real_detect = display.detect_refresh_hz
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            conf = Path(td) / "dxvk.conf"
+
+            # --- the happy path, and the preservation guarantee -------------
+            original = (
+                "# Turtle WoW (1.12) - DXVK 2.7.1\n"
+                "dxvk.logLevel = none\n"
+                "\n"
+                "# Uncomment to set framerate limit\n"
+                "d3d9.maxFrameRate = 1000\n"
+                "d3d9.dpiAware = False\n"
+            )
+            conf.write_text(original)
+            display.detect_refresh_hz = lambda: 165.058
+            assert display.apply_frame_cap(conf, 3) == 162
+            after = conf.read_text()
+            assert "d3d9.maxFrameRate = 162" in after, after
+            assert "1000" not in after, after
+            # The 2.7.1 marker line is what hd_dxvk detects on -- losing it
+            # would make the launcher forget which DXVK is installed.
+            assert "# Turtle WoW (1.12) - DXVK 2.7.1" in after, after
+            assert "dxvk.logLevel = none" in after
+            assert "d3d9.dpiAware = False" in after
+            assert "# Uncomment to set framerate limit" in after
+
+            # --- an undetectable display changes nothing at all -------------
+            untouched = conf.read_text()
+            display.detect_refresh_hz = lambda: None
+            assert display.apply_frame_cap(conf, 3) is None
+            assert conf.read_text() == untouched, "a None detection rewrote the file"
+
+            # --- a missing key is appended, not silently dropped ------------
+            conf.write_text("dxvk.logLevel = none\n")
+            display.detect_refresh_hz = lambda: 120.0
+            assert display.apply_frame_cap(conf, 3) == 117
+            assert "d3d9.maxFrameRate = 117" in conf.read_text()
+
+            # --- a commented example stays a comment ------------------------
+            conf.write_text("# d3d9.maxFrameRate = 60\ndxvk.logLevel = none\n")
+            display.detect_refresh_hz = lambda: 165.058
+            display.apply_frame_cap(conf, 3)
+            body = conf.read_text()
+            assert "# d3d9.maxFrameRate = 60" in body, body
+            assert "d3d9.maxFrameRate = 162" in body, body
+
+            # --- CRLF files keep CRLF; the file is never reterminated -------
+            # Path.write_text would rewrite every line to os.linesep on Windows,
+            # which breaks the promise about leaving the rest of the file alone.
+            conf.write_bytes(b"# DXVK 2.7.1\r\nd3d9.maxFrameRate = 1000\r\n"
+                             b"dxvk.logLevel = none\r\n")
+            display.detect_refresh_hz = lambda: 165.058
+            assert display.apply_frame_cap(conf, 3) == 162
+            raw = conf.read_bytes()
+            assert b"\r\n" in raw and raw.count(b"\r\n") == 3, raw
+            assert b"d3d9.maxFrameRate = 162\r\n" in raw, raw
+            assert b"# DXVK 2.7.1\r\n" in raw, raw
+
+            # An LF file stays LF -- no stray carriage returns introduced.
+            conf.write_bytes(b"# DXVK 2.7.1\nd3d9.maxFrameRate = 1000\n")
+            assert display.apply_frame_cap(conf, 3) == 162
+            raw = conf.read_bytes()
+            assert b"\r" not in raw, raw
+
+            # --- an absent file is a no-op, not a crash ---------------------
+            assert display.apply_frame_cap(Path(td) / "nope.conf", 3) is None
+
+            # --- a write failure surfaces, so install_mod can roll back ------
+            # Swallowing it would opt out of the rollback the repo already has
+            # for this exact file.
+            import builtins
+            real_open = builtins.open
+
+            def _fail_on_write(f, mode="r", *a, **kw):
+                if "w" in mode:
+                    raise OSError(28, "No space left on device")
+                return real_open(f, mode, *a, **kw)
+
+            conf.write_text("d3d9.maxFrameRate = 1000\n")
+            builtins.open = _fail_on_write
+            try:
+                raised = False
+                try:
+                    display.apply_frame_cap(conf, 3)
+                except OSError:
+                    raised = True
+                assert raised, "a failed write must not be swallowed"
+            finally:
+                builtins.open = real_open
+    finally:
+        display.detect_refresh_hz = real_detect
+
+    # --- the cap reaches BOTH install paths, not just the optional upgrade --
+    # The VanillaFixes+DXVK bundle ships its own dxvk.conf; a user who never
+    # takes the 2.7.1 upgrade must not be the only one left uncapped.
+    from ichalaunch.mods import installer as _inst
+    import inspect
+    src = inspect.getsource(_inst)
+    assert src.count("_apply_frame_cap_if_enabled(game)") >= 2, (
+        "the frame cap must be applied from every path that can leave a "
+        "dxvk.conf behind, not only the dxvk_hd branch")
+
+    # And the helper itself is inert when there is no conf to touch.
+    with tempfile.TemporaryDirectory() as td:
+        empty = Path(td)
+        _inst._apply_frame_cap_if_enabled(empty)   # must not raise
+        assert not (empty / "dxvk.conf").exists(), "helper created a conf out of nothing"
+
+    # Detection itself must never raise, whatever this machine looks like.
+    hz = display.detect_refresh_hz()
+    assert hz is None or hz > 0, hz
+    print("OK frame cap from refresh")
+
 def test_linux_proton_launch_resolution():
     """Proton discovery, pin-by-default, and command assembly.
 
@@ -8735,6 +8882,7 @@ def _run_smoke_tests():
     test_apply_desired_state_restores_dlls_txt()
     test_prepare_for_launch_syncs_dlls_txt()
     test_client_exe_probe_is_case_insensitive()
+    test_frame_cap_from_refresh()
     test_linux_proton_launch_resolution()
     test_linux_dxvk_vulkan_preflight()
     test_prepare_for_launch_clears_data_readonly()

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -8298,6 +8298,44 @@ def test_client_exe_probe_is_case_insensitive():
     print("OK client exe probe is case-insensitive")
 
 
+def test_frame_cap_default_is_not_persisted():
+    """The default is resolvable, not stored, so it can still be reverted.
+
+    save() writes the whole DEFAULTS-merged dict, so a literal True in DEFAULTS is
+    baked into every settings.json on first launch and then outranks DEFAULTS via
+    merged.update(loaded) forever -- making a one-line revert a no-op for anyone who
+    had already run the launcher once.
+    """
+    from ichalaunch.config.settings import DEFAULTS, Settings, settings
+    import ichalaunch.game.display as disp
+
+    assert DEFAULTS["frame_cap_from_refresh"] is None
+    assert disp.FRAME_CAP_DEFAULT_ON is True
+
+    legacy = {"game_path": "", "close_on_launch": True}
+    merged, _ = Settings.__new__(Settings)._merge_loaded(legacy)
+    assert merged["frame_cap_from_refresh"] is None
+    for stored in (True, False):
+        m, _ = Settings.__new__(Settings)._merge_loaded(
+            {**legacy, "frame_cap_from_refresh": stored}
+        )
+        assert m["frame_cap_from_refresh"] is stored
+
+    prev = settings.get("frame_cap_from_refresh", None)
+    try:
+        settings.set("frame_cap_from_refresh", None)
+        assert disp.frame_cap_enabled() is True
+        disp.FRAME_CAP_DEFAULT_ON = False
+        assert disp.frame_cap_enabled() is False
+        settings.set("frame_cap_from_refresh", True)
+        assert disp.frame_cap_enabled() is True
+    finally:
+        disp.FRAME_CAP_DEFAULT_ON = True
+        settings.set("frame_cap_from_refresh", prev)
+
+    print("OK frame cap default is resolvable, not persisted")
+
+
 def test_frame_cap_from_refresh():
     """The DXVK frame cap follows the real display, and only the real display.
 
@@ -8883,6 +8921,7 @@ def _run_smoke_tests():
     test_prepare_for_launch_syncs_dlls_txt()
     test_client_exe_probe_is_case_insensitive()
     test_frame_cap_from_refresh()
+    test_frame_cap_default_is_not_persisted()
     test_linux_proton_launch_resolution()
     test_linux_dxvk_vulkan_preflight()
     test_prepare_for_launch_clears_data_readonly()


### PR DESCRIPTION
Project Reforged's setup guide prescribes a DXVK frame cap a few frames under
the refresh rate, and gives "162-163" as the figure for a 165 Hz panel. The
bundled dxvk.conf that arrives with hd_dxvk ships d3d9.maxFrameRate = 1000,
which is that guidance dropped rather than applied: uncapped on the panel it
was written for, and meaningless on any other. Hardcoding 163 instead would
only move the problem, handing a 60 Hz laptop a cap it can never reach and a
240 Hz panel a cap that throws most of it away. Computing the number from the
display reproduces the publisher's intent on every machine rather than on one.

The mode is read live, from the compositor or the OS. The obvious shortcut --
taking gxRefresh from the user's own Config.wtf -- is actively wrong: the
vanilla client forces gxRefresh to 60 whenever it runs windowed, because a
windowed surface reports refresh 0. On a verified 165.058 Hz panel that file
says "60", which would compute a cap of 57 and quietly throttle the game to a
third of the display. The client's crash logs carry no display information
either, and neither source exists at all on a first run, which is precisely
when a launcher is most useful.

Detection is per platform and every probe may fail. Windows reads
dmDisplayFrequency via EnumDisplaySettingsW; KDE reads the current mode out of
kscreen-doctor -j; plain X11 falls back to the starred mode in xrandr. All are
ctypes or subprocess against tools already present, so nothing new is bundled.
An unreadable display returns None, and None leaves the existing value exactly
as it was -- an undetectable monitor is not a reason to impose a guess on
somebody's frame pacing.

Where several outputs are attached the fastest wins, and no "primary" flag is
consulted. libkscreen dropped that key after 5.24 in favour of priority, so
such a branch is dead on all of Plasma 6; and where it would still be live it
is harmful, since a 60 Hz primary beside a 165 Hz gaming panel resolves to 60
and caps the game at 57 -- the same failure the Config.wtf shortcut produces. A
maximum can only ever yield a cap at or above what some attached panel can
present, so its worst case is an inert cap.

The arithmetic floors before subtracting. Real modes are fractional, and
rounding 59.94 up to 60 would place the cap one frame above what the panel can
present. Refresh rates below 48 Hz are left alone entirely, because a 30 Hz
panel capped at 27 is worse than an uncapped one.

frame_cap_offset is coerced and bounded rather than trusted. It is hand-edited
-- nothing in the UI writes it -- and read as "the cap" rather than "frames
below refresh" it would otherwise compute a 1 fps lock and persist it. Bounding
the input is what makes that unreachable; clamping only the result would still
let an offset of 100 produce 44 on a 144 Hz panel. A non-numeric value falls
back to the default instead of raising, because this runs after d3d9.dll and
dxvk.conf are already on disk and a ValueError here is caught by the install
error handler, which would revert a DXVK install that had actually succeeded.

Only d3d9.maxFrameRate is rewritten, a commented-out example of the key stays a
comment, and the file's own line terminators are preserved. That last point is
not cosmetic: Path.write_text forwards newline=None, so on Windows it would
reterminate all 43 lines of an LF-only bundled file to CRLF. DXVK parses either,
but dxvk.conf is shared three ways -- the bundled 2.7.1 preset, whatever the
user tuned by hand, and the "DXVK 2.7.1" marker on line 1 that hd_dxvk detects
the installed DXVK from -- so the guarantee has to be true rather than nearly
true.

Read and write failures are logged, and a failed write is re-raised rather than
swallowed. install_mod already wraps this call and reverts the mod on OSError,
and _mod_owned_paths snapshots dxvk.conf for dxvk_hd: the rollback for this
exact file exists, and returning None quietly would opt out of it.

Windows is equally served and unaffected in behaviour: the same rule, the same
arithmetic, a different probe. Nothing here is Linux-only.

test_frame_cap_from_refresh covers the arithmetic at six refresh rates
including two fractional ones, the offset bound and the non-numeric fallback,
the preservation guarantee including the 2.7.1 marker, CRLF and LF files each
keeping their own terminators, an undetectable display leaving the file
byte-identical, an absent key being appended, a commented example staying
commented, a missing file being a no-op, and a failing write raising rather
than being swallowed.

---

One thing worth flagging: I'm on Linux, so I've verified the KDE and xrandr probes against real hardware (a 165.058 Hz panel, which computes to 162 -- right inside the 162-163 the Reforged guide asks for). The Windows probe is written against EnumDisplaySettingsW but I can't execute it here. The arithmetic and the file rewriting are covered by tests that run on any platform. Happy to change anything you'd rather see done differently.

**Update — the default is no longer written into users' settings.json.**
`frame_cap_from_refresh` was a literal `True` in `DEFAULTS`. Since `save()`
serialises the whole DEFAULTS-merged dict, that value landed in every user's
settings file on their first launch, and `merged.update(loaded)` then made it
outrank `DEFAULTS` permanently -- so if this ever needed backing out, changing the
default would have fixed nothing for anyone who had already opened the launcher.
It now stores `null` until the user says otherwise and resolves against a
`FRAME_CAP_DEFAULT_ON` constant at read time. No behaviour change: an untouched
install still computes the cap, and every guard around it is untouched.
