### PR TITLE
Pin the client to the 3D V-Cache CCD on the AMD parts that have two

### DIFF
--- a/ichalaunch/config/settings.py
+++ b/ichalaunch/config/settings.py
@@ -34,6 +34,10 @@ DEFAULTS: dict[str, Any] = {
     "linux_proton_path": "",
     "linux_use_latest_proton": False,
     "linux_wineprefix": "",
+    # Pin the client to the cache-rich CCD on dual-CCD X3D parts. Harmless
+    # everywhere else: detection returns nothing unless two L3 domains of
+    # clearly different size are present, so single-CCD parts never pin.
+    "pin_to_vcache_ccd": True,
     "addons_path": "",
     "vanillafixes_enabled": True,
     "minimize_on_launch": False,

--- a/ichalaunch/config/settings.py
+++ b/ichalaunch/config/settings.py
@@ -37,7 +37,13 @@ DEFAULTS: dict[str, Any] = {
     # Pin the client to the cache-rich CCD on dual-CCD X3D parts. Harmless
     # everywhere else: detection returns nothing unless two L3 domains of
     # clearly different size are present, so single-CCD parts never pin.
-    "pin_to_vcache_ccd": True,
+    # None means "nobody has expressed a preference"; cpu_topology.vcache_pin_enabled()
+    # resolves it against VCACHE_PIN_DEFAULT_ON at read time. True/False appear here only
+    # once the user touches the checkbox. save() persists this whole dict, so a literal
+    # default would be written into every settings.json on first launch and would then
+    # outrank any later change to the default -- leaving a one-line revert that silently
+    # does nothing for anyone who had already launched once.
+    "pin_to_vcache_ccd": None,
     "addons_path": "",
     "vanillafixes_enabled": True,
     "minimize_on_launch": False,

--- a/ichalaunch/core/process.py
+++ b/ichalaunch/core/process.py
@@ -452,8 +452,15 @@ def launch_exe(path: Path, cwd: Path | None = None) -> subprocess.Popen:
         from ichalaunch.game.proton import launch_windows_exe
 
         return launch_windows_exe(path, workdir)
-    return subprocess.Popen(
-        [str(path)],
-        cwd=str(workdir),
-        shell=False,
-    )
+    # Vanilla WoW is single-threaded and cache-bound, so on a dual-CCD X3D part
+    # it wants the CCD carrying the 3D V-Cache. The mask goes on this process for
+    # the duration of the spawn so the child -- and, when VanillaFixes is doing
+    # the launching, its own child -- inherits it at creation. No-ops on every
+    # other CPU and on every other platform.
+    from ichalaunch.config.settings import settings as _settings
+    from ichalaunch.game.cpu_topology import launch_affinity
+
+    if not _settings.get("pin_to_vcache_ccd", True):
+        return subprocess.Popen([str(path)], cwd=str(workdir), shell=False)
+    with launch_affinity():
+        return subprocess.Popen([str(path)], cwd=str(workdir), shell=False)

--- a/ichalaunch/core/process.py
+++ b/ichalaunch/core/process.py
@@ -457,10 +457,9 @@ def launch_exe(path: Path, cwd: Path | None = None) -> subprocess.Popen:
     # the duration of the spawn so the child -- and, when VanillaFixes is doing
     # the launching, its own child -- inherits it at creation. No-ops on every
     # other CPU and on every other platform.
-    from ichalaunch.config.settings import settings as _settings
-    from ichalaunch.game.cpu_topology import launch_affinity
+    from ichalaunch.game.cpu_topology import launch_affinity, vcache_pin_enabled
 
-    if not _settings.get("pin_to_vcache_ccd", True):
+    if not vcache_pin_enabled():
         return subprocess.Popen([str(path)], cwd=str(workdir), shell=False)
     with launch_affinity():
         return subprocess.Popen([str(path)], cwd=str(workdir), shell=False)

--- a/ichalaunch/game/cpu_topology.py
+++ b/ichalaunch/game/cpu_topology.py
@@ -200,6 +200,19 @@ def _domains_windows() -> list["CacheDomain"]:
     return _parse_windows_cache_buffer(buf, length.value)
 
 
+# What an untouched install gets. Kept out of DEFAULTS so the stored value can stay
+# null until the user actually touches the checkbox -- see the note there.
+VCACHE_PIN_DEFAULT_ON = True
+
+
+def vcache_pin_enabled() -> bool:
+    """Whether to pin, resolving an unset setting to the default."""
+    from ichalaunch.config.settings import settings
+
+    stored = settings.get("pin_to_vcache_ccd", None)
+    return VCACHE_PIN_DEFAULT_ON if stored is None else bool(stored)
+
+
 def cache_domains() -> list[CacheDomain]:
     """Every L3 domain on this machine, largest cache first."""
     try:

--- a/ichalaunch/game/cpu_topology.py
+++ b/ichalaunch/game/cpu_topology.py
@@ -1,0 +1,349 @@
+"""Finding the cache-rich CCD on AMD X3D parts, so the client can be pinned to it.
+
+WHY. Vanilla WoW is a 2006 engine: effectively single-threaded and extremely
+cache-sensitive. On a dual-CCD X3D part -- 7950X3D, 7900X3D, 9900X3D, 9950X3D --
+one CCD carries 3D V-Cache and the other does not, and the scheduler is free to
+put the game on the wrong one. Pinning it to the cache-rich CCD is a real and
+well-documented win for exactly this class of workload.
+
+⭐ WHY TOPOLOGY AND NOT A MODEL NAME. Matching "X3D" in the CPU string would be
+wrong for the single-CCD parts -- 7800X3D, 9800X3D -- where every core already
+has the cache and there is nothing to choose between. Deriving the answer from
+the L3 cache layout makes those parts fall out naturally: they report one L3
+domain, so this module returns None and callers change nothing. It also means a
+future part works without a catalog update.
+
+Returns None generously. None means "do not pin", never "pin to everything".
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import sys
+from dataclasses import dataclass
+
+from ichalaunch.core.logging_setup import log
+
+# A ratio alone does not identify 3D V-Cache, and getting this wrong pins the
+# whole Proton tree onto a subset of cores for no reason. AMD's Strix Point parts
+# (Ryzen AI 9 HX 370 / AI 9 365) pair a 16 MB Zen 5 CCX with an 8 MB Zen 5c CCX:
+# a ratio of 2.0, and no V-Cache anywhere on the package. Every dual-CCD X3D part
+# shipped so far -- 7900X3D, 7950X3D, 9900X3D, 9950X3D -- carries 96 MB on the
+# stacked die against 32 MB on the other, so an absolute floor separates the two
+# cases cleanly where a ratio cannot. Both tests must pass.
+_MIN_CACHE_RATIO = 1.5
+_MIN_VCACHE_BYTES = 64 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class CacheDomain:
+    """One L3 cache and the logical CPUs that share it -- in practice, one CCD."""
+    l3_bytes: int
+    cpus: tuple[int, ...]
+
+    @property
+    def affinity_mask(self) -> int:
+        mask = 0
+        for c in self.cpus:
+            mask |= 1 << c
+        return mask
+
+    @property
+    def cpu_list(self) -> str:
+        """The domain as taskset(1) would want it, e.g. '0-7,16-23'."""
+        out: list[str] = []
+        run: list[int] = []
+        for c in sorted(self.cpus):
+            if run and c == run[-1] + 1:
+                run.append(c)
+                continue
+            if run:
+                out.append(str(run[0]) if len(run) == 1 else f"{run[0]}-{run[-1]}")
+            run = [c]
+        if run:
+            out.append(str(run[0]) if len(run) == 1 else f"{run[0]}-{run[-1]}")
+        return ",".join(out)
+
+
+def _parse_size(text: str) -> int | None:
+    """'98304K' / '96M' / '32768K' -> bytes."""
+    m = re.fullmatch(r"\s*(\d+)\s*([KMG]?)B?\s*", text, re.I)
+    if not m:
+        return None
+    n = int(m.group(1))
+    return n * {"": 1, "K": 1024, "M": 1024 ** 2, "G": 1024 ** 3}[m.group(2).upper()]
+
+
+def _parse_cpu_list(text: str) -> tuple[int, ...]:
+    """'0-7,16-23' -> (0,1,...,7,16,...,23)."""
+    cpus: set[int] = set()
+    for part in text.strip().split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            lo, _, hi = part.partition("-")
+            try:
+                cpus.update(range(int(lo), int(hi) + 1))
+            except ValueError:
+                continue
+        else:
+            try:
+                cpus.add(int(part))
+            except ValueError:
+                continue
+    return tuple(sorted(cpus))
+
+
+def _domains_linux() -> list[CacheDomain]:
+    """L3 domains from sysfs. Deduplicated -- every CPU reports its own copy."""
+    seen: dict[tuple[int, tuple[int, ...]], CacheDomain] = {}
+    for d in glob.glob("/sys/devices/system/cpu/cpu[0-9]*/cache/index*"):
+        try:
+            with open(os.path.join(d, "level")) as f:
+                if f.read().strip() != "3":
+                    continue
+            with open(os.path.join(d, "size")) as f:
+                size = _parse_size(f.read())
+            with open(os.path.join(d, "shared_cpu_list")) as f:
+                cpus = _parse_cpu_list(f.read())
+        except (OSError, ValueError):
+            continue
+        if not size or not cpus:
+            continue
+        seen[(size, cpus)] = CacheDomain(size, cpus)
+    return list(seen.values())
+
+
+def _parse_windows_cache_buffer(buf, length: int) -> list["CacheDomain"]:
+    """Walk a GetLogicalProcessorInformationEx(RelationCache) buffer.
+
+    Split out from the API call on purpose: the call itself cannot run anywhere
+    but Windows, but the parsing is where the offsets can be wrong, and wrong
+    offsets here read zeroes out of a reserved field rather than failing. Keeping
+    this pure lets it be driven from any platform against a synthetic buffer laid
+    out to the documented structure.
+
+    Offsets are from the start of each SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX
+    record and were taken from offsetof() on the real headers, not counted by
+    hand::
+
+        Relationship  +0    (LOGICAL_PROCESSOR_RELATIONSHIP)
+        Size          +4    (DWORD)
+        CACHE_RELATIONSHIP begins at +8:
+            Level       +8   Associativity +9   LineSize +10
+            CacheSize   +12  Type          +16
+            Reserved[18] +20..37          GroupCount +38
+            GROUP_AFFINITY +40: Mask +40 (KAFFINITY, 8 bytes), Group +48 (WORD)
+
+    ⚠️ Reserved[18] and GroupCount sit between Type and the GROUP_AFFINITY.
+    Omitting them puts Mask at +24, which is inside Reserved -- Windows zero-fills
+    it, so every cache record is silently discarded and nothing ever pins.
+    """
+    import ctypes
+
+    RelationCache = 2
+    domains: dict[tuple[int, tuple[int, ...]], CacheDomain] = {}
+    groups_seen: set[int] = set()
+    offset = 0
+    base_addr = ctypes.addressof(buf)
+    while offset + 8 <= length:
+        base = base_addr + offset
+        rel = ctypes.c_uint32.from_address(base).value
+        size = ctypes.c_uint32.from_address(base + 4).value
+        if size == 0 or offset + size > length:
+            break
+        if rel == RelationCache and size >= 56:
+            level = ctypes.c_uint8.from_address(base + 8).value
+            cache_size = ctypes.c_uint32.from_address(base + 12).value
+            if level == 3:
+                mask = ctypes.c_uint64.from_address(base + 40).value
+                group = ctypes.c_uint16.from_address(base + 48).value
+                groups_seen.add(group)
+                cpus = tuple(i for i in range(64) if mask & (1 << i))
+                if cpus and cache_size:
+                    domains[(cache_size, cpus)] = CacheDomain(cache_size, cpus)
+        offset += size
+
+    if len(groups_seen) > 1:
+        # A plain affinity mask addresses one processor group. Rather than pin
+        # against a truncated mask, decline entirely.
+        log.info("More than one processor group present; declining to pin.")
+        return []
+    return list(domains.values())
+
+
+def _domains_windows() -> list["CacheDomain"]:
+    """L3 domains via GetLogicalProcessorInformationEx(RelationCache)."""
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except (ImportError, ValueError):
+        return []
+    if not hasattr(ctypes, "windll"):
+        return []
+
+    RelationCache = 2
+    kernel32 = ctypes.windll.kernel32
+    kernel32.GetLogicalProcessorInformationEx.restype = wintypes.BOOL
+    length = wintypes.DWORD(0)
+    kernel32.GetLogicalProcessorInformationEx(RelationCache, None,
+                                              ctypes.byref(length))
+    if not length.value:
+        return []
+    buf = (ctypes.c_byte * length.value)()
+    if not kernel32.GetLogicalProcessorInformationEx(RelationCache, buf,
+                                                     ctypes.byref(length)):
+        return []
+    return _parse_windows_cache_buffer(buf, length.value)
+
+
+def cache_domains() -> list[CacheDomain]:
+    """Every L3 domain on this machine, largest cache first."""
+    try:
+        found = _domains_windows() if sys.platform == "win32" else _domains_linux()
+    except Exception:
+        log.debug("CPU topology probe failed", exc_info=True)
+        return []
+    return sorted(found, key=lambda d: -d.l3_bytes)
+
+
+def vcache_domain() -> CacheDomain | None:
+    """The 3D V-Cache CCD, or None when there is no meaningful choice to make.
+
+    None covers every case where pinning would be wrong or pointless: a
+    single-CCD part (including 7800X3D / 9800X3D), a symmetric multi-die part
+    with no cache asymmetry, an unreadable topology, or a machine large enough
+    to need processor groups.
+    """
+    domains = cache_domains()
+    if len(domains) < 2:
+        return None
+    biggest, second = domains[0], domains[1]
+    if biggest.l3_bytes < second.l3_bytes * _MIN_CACHE_RATIO:
+        return None
+    if biggest.l3_bytes < _MIN_VCACHE_BYTES:
+        # Asymmetric, but too small to be a stacked cache die. Heterogeneous
+        # core designs land here and must not be pinned.
+        log.info("L3 domains differ (%.0f MB vs %.0f MB) but neither is large "
+                 "enough to be 3D V-Cache; not pinning.",
+                 biggest.l3_bytes / 1024 ** 2, second.l3_bytes / 1024 ** 2)
+        return None
+    log.info("3D V-Cache CCD detected: L3 %.0f MB on CPUs %s (other CCD %.0f MB)",
+             biggest.l3_bytes / 1024 ** 2, biggest.cpu_list,
+             second.l3_bytes / 1024 ** 2)
+    return biggest
+
+
+# --- applying the pin --------------------------------------------------------
+
+def taskset_prefix() -> list[str]:
+    """A ``taskset -c <list>`` prefix for the launch command, or [] to not pin.
+
+    Affinity is inherited across fork/exec, so prefixing the umu-launcher
+    invocation pins the client that umu eventually starts, without this module
+    needing to know anything about umu's process tree.
+    """
+    import shutil
+
+    domain = vcache_domain()
+    if domain is None:
+        return []
+    if not shutil.which("taskset"):
+        log.info("A V-Cache CCD was found but taskset is not installed; not pinning.")
+        return []
+
+    # ⚠️ taskset OWNS THE EXIT STATUS. It sets affinity first and only then
+    # exec's the command, so if sched_setaffinity is refused the command never
+    # runs and the caller sees exit 1 -- which the launcher surfaces as "Launch
+    # failed". A pin that cannot be applied must degrade to an unpinned launch,
+    # never to no launch, so the CPUs are checked against what this process is
+    # actually permitted before taskset is involved. This mirrors the
+    # intersection the Windows path already performs against the system mask.
+    try:
+        allowed = os.sched_getaffinity(0)
+    except (AttributeError, OSError):
+        allowed = None
+    if allowed is not None:
+        usable = set(domain.cpus) & allowed
+        if not usable:
+            log.warning("The V-Cache CCD (CPUs %s) is outside this process's "
+                        "permitted affinity; launching unpinned.", domain.cpu_list)
+            return []
+        if usable != set(domain.cpus):
+            # A cpuset/cgroup restriction, or offline CPUs. Pin to what remains
+            # rather than handing taskset a list it will reject outright.
+            domain = CacheDomain(domain.l3_bytes, tuple(sorted(usable)))
+            log.info("Some V-Cache CPUs are unavailable; pinning to %s instead.",
+                     domain.cpu_list)
+    return ["taskset", "-c", domain.cpu_list]
+
+
+import contextlib
+
+
+@contextlib.contextmanager
+def launch_affinity():
+    """Hold this process on the V-Cache CCD while a child is being created.
+
+    ⭐ WHY THE PARENT AND NOT THE CHILD. Windows propagates an affinity mask to
+    children created *after* it is set, and never retroactively. The process
+    started here is usually not the game: vanillafixes_enabled defaults to True,
+    so what gets launched is the VanillaFixes loader, and WoW.exe is its child.
+    Masking the loader after Popen returns therefore races -- the loader may
+    already have spawned the game -- and even when it wins it says nothing about
+    the grandchild. Setting the mask on the launcher itself before Popen means
+    the child inherits at creation and every descendant follows, which is exactly
+    what the taskset prefix achieves on Linux.
+
+    The launcher's own mask is restored on the way out, including on exception,
+    so the UI does not spend the rest of the session on half the machine.
+
+    A no-op on Linux (taskset already covers it), on non-X3D hardware, and
+    whenever the mask cannot be read back to restore it.
+    """
+    domain = None if sys.platform != "win32" else vcache_domain()
+    if domain is None:
+        yield None
+        return
+
+    try:
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.GetCurrentProcess()
+        proc_mask, sys_mask = ctypes.c_size_t(0), ctypes.c_size_t(0)
+        if not kernel32.GetProcessAffinityMask(handle, ctypes.byref(proc_mask),
+                                               ctypes.byref(sys_mask)):
+            # Without the original there is no safe way back; do not pin at all.
+            log.warning("Could not read this process's affinity; not pinning.")
+            yield None
+            return
+        original = proc_mask.value
+        wanted = domain.affinity_mask & sys_mask.value
+        if not wanted:
+            log.warning("V-Cache CCD mask %#x is outside this process's allowed "
+                        "affinity %#x; not pinning.",
+                        domain.affinity_mask, sys_mask.value)
+            yield None
+            return
+        if not kernel32.SetProcessAffinityMask(handle, ctypes.c_size_t(wanted)):
+            log.warning("Could not set affinity; launching unpinned.")
+            yield None
+            return
+    except Exception:
+        log.debug("Affinity setup failed", exc_info=True)
+        yield None
+        return
+
+    log.info("Launching pinned to the V-Cache CCD (CPUs %s); descendants inherit.",
+             domain.cpu_list)
+    try:
+        yield domain
+    finally:
+        try:
+            kernel32.SetProcessAffinityMask(handle, ctypes.c_size_t(original))
+        except Exception:
+            log.warning("Could not restore this process's affinity mask.")

--- a/ichalaunch/game/proton.py
+++ b/ichalaunch/game/proton.py
@@ -199,7 +199,16 @@ def build_launch_command(exe: Path, cwd: Path) -> tuple[list[str], dict[str, str
         "GAMEID": "umu-default",
         "STORE": "none",
     })
-    return [str(umu), str(exe)], env
+    cmd = [str(umu), str(exe)]
+    if settings.get("pin_to_vcache_ccd", True):
+        from ichalaunch.game.cpu_topology import taskset_prefix
+
+        affinity_argv = taskset_prefix()
+        if affinity_argv:
+            log.info("Pinning the client to the V-Cache CCD via %s",
+                     " ".join(affinity_argv))
+            cmd = affinity_argv + cmd
+    return cmd, env
 
 
 def launch_log_path() -> Path:

--- a/ichalaunch/game/proton.py
+++ b/ichalaunch/game/proton.py
@@ -200,7 +200,9 @@ def build_launch_command(exe: Path, cwd: Path) -> tuple[list[str], dict[str, str
         "STORE": "none",
     })
     cmd = [str(umu), str(exe)]
-    if settings.get("pin_to_vcache_ccd", True):
+    from ichalaunch.game.cpu_topology import vcache_pin_enabled
+
+    if vcache_pin_enabled():
         from ichalaunch.game.cpu_topology import taskset_prefix
 
         affinity_argv = taskset_prefix()

--- a/ichalaunch/ui/pages/settings.py
+++ b/ichalaunch/ui/pages/settings.py
@@ -155,7 +155,12 @@ class SettingsPage(QWidget):
         self.cb_close = ThemeCheckBox("Close launcher when game starts")
         self.cb_close.setChecked(bool(settings.get("close_on_launch", False)))
         self.cb_close.toggled.connect(lambda v: settings.set("close_on_launch", v))
-        for cb in (self.cb_vf, self.cb_min, self.cb_close):
+        self.cb_vcache = ThemeCheckBox(
+            "Pin the game to the 3D V-Cache cores (AMD X3D with two CCDs)"
+        )
+        self.cb_vcache.setChecked(bool(settings.get("pin_to_vcache_ccd", True)))
+        self.cb_vcache.toggled.connect(lambda v: settings.set("pin_to_vcache_ccd", v))
+        for cb in (self.cb_vf, self.cb_min, self.cb_close, self.cb_vcache):
             cb.setMinimumHeight(28)
             cb.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
             launch_card.body.addWidget(cb)
@@ -381,6 +386,12 @@ class SettingsPage(QWidget):
             cb.blockSignals(True)
             cb.setChecked(bool(settings.get(key, False)))
             cb.blockSignals(False)
+        # Defaults to on, so it cannot share the loop above -- that falls back
+        # to False when a key is absent, which would show this unchecked while
+        # the behaviour was still active.
+        self.cb_vcache.blockSignals(True)
+        self.cb_vcache.setChecked(bool(settings.get("pin_to_vcache_ccd", True)))
+        self.cb_vcache.blockSignals(False)
         self.cb_auto_updates.blockSignals(True)
         self.cb_auto_updates.setChecked(settings.check_updates_on_startup())
         self.cb_auto_updates.blockSignals(False)

--- a/ichalaunch/ui/pages/settings.py
+++ b/ichalaunch/ui/pages/settings.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
 from ichalaunch import __version__
 from ichalaunch.core.logging_setup import log_dir
 from ichalaunch.config.settings import settings
+from ichalaunch.game.cpu_topology import vcache_pin_enabled
 from ichalaunch.ui.widgets.casting_bar_search_edit import (
     SETTINGS_MIN_H,
     CastingBarSearchEdit,
@@ -158,7 +159,7 @@ class SettingsPage(QWidget):
         self.cb_vcache = ThemeCheckBox(
             "Pin the game to the 3D V-Cache cores (AMD X3D with two CCDs)"
         )
-        self.cb_vcache.setChecked(bool(settings.get("pin_to_vcache_ccd", True)))
+        self.cb_vcache.setChecked(vcache_pin_enabled())
         self.cb_vcache.toggled.connect(lambda v: settings.set("pin_to_vcache_ccd", v))
         for cb in (self.cb_vf, self.cb_min, self.cb_close, self.cb_vcache):
             cb.setMinimumHeight(28)
@@ -390,7 +391,7 @@ class SettingsPage(QWidget):
         # to False when a key is absent, which would show this unchecked while
         # the behaviour was still active.
         self.cb_vcache.blockSignals(True)
-        self.cb_vcache.setChecked(bool(settings.get("pin_to_vcache_ccd", True)))
+        self.cb_vcache.setChecked(vcache_pin_enabled())
         self.cb_vcache.blockSignals(False)
         self.cb_auto_updates.blockSignals(True)
         self.cb_auto_updates.setChecked(settings.check_updates_on_startup())

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -7737,6 +7737,7 @@ def test_addon_preview_gates_combos_and_open_git():
 
     print("OK addon preview gates fork/version; Open in Git inline beside title")
 
+
 def test_glue_combo_popup_hide_wiring_in_settings_dialogs():
     """Settings/Install use Dialog (not Qt.Popup); lazy version fetch keeps combo enabled."""
     from PySide6.QtCore import Qt
@@ -8252,6 +8253,164 @@ def test_play_stays_right_when_progress_hidden():
     print("OK PLAY stays right-aligned when progress is hidden")
 
 
+def test_x3d_vcache_ccd_selection():
+    """Pinning happens only where there is a genuine choice, and the Windows
+    buffer walk is exercised for real rather than stubbed past.
+
+    The selection runs against synthetic topologies so the decision is proven for
+    hardware not present here. The Windows half is proven the same way: the API
+    call cannot run off Windows, but the parsing is where an offset can be wrong,
+    and a wrong offset reads zeroes out of a reserved field instead of failing.
+    _parse_windows_cache_buffer is therefore pure and is driven here against a
+    buffer laid out to the documented structure.
+    """
+    import ctypes
+    import shutil
+    import struct
+
+    from ichalaunch.game import cpu_topology as ct
+
+    MB = 1024 * 1024
+
+    # --- cpu_list formatting, which is what taskset actually receives -------
+    d = ct.CacheDomain(96 * MB, tuple(list(range(0, 8)) + list(range(16, 24))))
+    assert d.cpu_list == "0-7,16-23", d.cpu_list
+    assert ct.CacheDomain(1, (3,)).cpu_list == "3"
+    assert ct.CacheDomain(1, (0, 2, 4)).cpu_list == "0,2,4"
+    assert ct.CacheDomain(1, (0, 1, 2, 5)).cpu_list == "0-2,5"
+    assert ct.CacheDomain(1, (0, 1)).affinity_mask == 0b11
+    assert d.affinity_mask == 0x00FF00FF, hex(d.affinity_mask)
+
+    # --- parsers ------------------------------------------------------------
+    assert ct._parse_size("98304K") == 96 * MB
+    assert ct._parse_size("96M") == 96 * MB
+    assert ct._parse_size("garbage") is None
+    assert ct._parse_cpu_list("0-3,8") == (0, 1, 2, 3, 8)
+    assert ct._parse_cpu_list("") == ()
+    assert ct._parse_cpu_list("bad,1") == (1,)
+
+    # --- the Windows buffer walk, against the documented layout -------------
+    # SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX: Relationship +0, Size +4, then
+    # CACHE_RELATIONSHIP at +8. Inside it Level +0, CacheSize +4, Type +8,
+    # Reserved[18] +12..29, GroupCount +30, GROUP_AFFINITY +32 -- so from the
+    # start of the record, Mask is at +40 and Group at +48, and the record is 56
+    # bytes. Reading Mask at +24 instead lands inside Reserved, which Windows
+    # zero-fills, and every cache record is then silently discarded.
+    def _record(level, cache_size, mask, group=0):
+        rec = bytearray(56)
+        struct.pack_into("<I", rec, 0, 2)            # RelationCache
+        struct.pack_into("<I", rec, 4, 56)           # Size
+        struct.pack_into("<B", rec, 8, level)        # Level
+        struct.pack_into("<I", rec, 12, cache_size)  # CacheSize
+        struct.pack_into("<I", rec, 16, 2)           # Type = CacheUnified
+        struct.pack_into("<H", rec, 38, 1)           # GroupCount
+        struct.pack_into("<Q", rec, 40, mask)        # GROUP_AFFINITY.Mask
+        struct.pack_into("<H", rec, 48, group)       # GROUP_AFFINITY.Group
+        return bytes(rec)
+
+    def _buffer(*records):
+        blob = b"".join(records)
+        buf = (ctypes.c_byte * len(blob))()
+        ctypes.memmove(buf, blob, len(blob))
+        return buf, len(blob)
+
+    # A 9950X3D: two L3 domains, 96 MB on 0-7,16-23 and 32 MB on 8-15,24-31.
+    buf, n = _buffer(_record(3, 96 * MB, 0x00FF00FF),
+                     _record(3, 32 * MB, 0xFF00FF00),
+                     _record(2, 1 * MB, 0x00000003))  # an L2 that must be ignored
+    parsed = ct._parse_windows_cache_buffer(buf, n)
+    assert len(parsed) == 2, parsed
+    by_size = {dom.l3_bytes: dom for dom in parsed}
+    assert by_size[96 * MB].cpu_list == "0-7,16-23", by_size[96 * MB].cpu_list
+    assert by_size[32 * MB].cpu_list == "8-15,24-31", by_size[32 * MB].cpu_list
+
+    # Records spanning more than one processor group are declined outright: a
+    # plain affinity mask cannot address them and pinning would truncate.
+    buf, n = _buffer(_record(3, 96 * MB, 0x00FF00FF, group=0),
+                     _record(3, 96 * MB, 0x00FF00FF, group=1))
+    assert ct._parse_windows_cache_buffer(buf, n) == []
+
+    # A truncated or zero-sized record terminates the walk instead of looping.
+    buf, n = _buffer(_record(3, 96 * MB, 0x00FF00FF))
+    assert ct._parse_windows_cache_buffer(buf, n - 10) == []
+    assert ct._parse_windows_cache_buffer(buf, 0) == []
+
+    real = ct.cache_domains
+    try:
+        def stub(domains):
+            ct.cache_domains = lambda: sorted(domains, key=lambda x: -x.l3_bytes)
+
+        # 9950X3D / 7950X3D: 96 MB against 32 MB -> pin to the stacked die.
+        stub([ct.CacheDomain(96 * MB, tuple(range(0, 8)) + tuple(range(16, 24))),
+              ct.CacheDomain(32 * MB, tuple(range(8, 16)) + tuple(range(24, 32)))])
+        v = ct.vcache_domain()
+        assert v is not None and v.cpu_list == "0-7,16-23", v
+
+        # 7800X3D / 9800X3D: one domain, every core already has the cache.
+        stub([ct.CacheDomain(96 * MB, tuple(range(0, 16)))])
+        assert ct.vcache_domain() is None, "single-CCD X3D must not pin"
+
+        # Symmetric dual-CCD: nothing to choose between.
+        stub([ct.CacheDomain(32 * MB, tuple(range(0, 16))),
+              ct.CacheDomain(32 * MB, tuple(range(16, 32)))])
+        assert ct.vcache_domain() is None, "symmetric CCDs must not pin"
+
+        # ⭐ Strix Point (Ryzen AI 9 HX 370 / AI 9 365): a 16 MB Zen 5 CCX beside
+        # an 8 MB Zen 5c CCX. That is a ratio of 2.0 with no V-Cache anywhere on
+        # the package, so a ratio test alone would pin a heterogeneous part onto
+        # four cores. The absolute floor is what rejects it.
+        stub([ct.CacheDomain(16 * MB, tuple(range(0, 4)) + tuple(range(12, 16))),
+              ct.CacheDomain(8 * MB, tuple(range(4, 12)) + tuple(range(16, 24)))])
+        assert ct.vcache_domain() is None, "heterogeneous CCX must not pin"
+
+        # Sub-threshold asymmetry on genuinely large caches.
+        stub([ct.CacheDomain(96 * MB, tuple(range(0, 8))),
+              ct.CacheDomain(80 * MB, tuple(range(8, 16)))])
+        assert ct.vcache_domain() is None, "sub-threshold ratio must not pin"
+
+        stub([])
+        assert ct.vcache_domain() is None
+        assert ct.taskset_prefix() == []
+
+        stub([ct.CacheDomain(96 * MB, (0, 1)), ct.CacheDomain(32 * MB, (2, 3))])
+        prefix = ct.taskset_prefix()
+        if sys.platform != "win32" and shutil.which("taskset"):
+            assert prefix == ["taskset", "-c", "0-1"], prefix
+
+        # ⚠️ taskset sets affinity and only then exec's, so an unsettable CPU
+        # list means the command never runs and the caller sees exit 1 -- the
+        # launcher reports that as "Launch failed". A pin that cannot be applied
+        # must degrade to an unpinned launch, never to no launch.
+        if sys.platform != "win32":
+            import os as _os
+            allowed = _os.sched_getaffinity(0)
+            impossible = max(allowed) + 4096
+            stub([ct.CacheDomain(96 * MB, (impossible, impossible + 1)),
+                  ct.CacheDomain(32 * MB, (0, 1))])
+            assert ct.taskset_prefix() == [], (
+                "an unusable CPU set must yield no prefix, or taskset kills the launch")
+
+            # A partially-available CCD pins to what is left rather than handing
+            # taskset a list it will reject.
+            first = sorted(allowed)[0]
+            stub([ct.CacheDomain(96 * MB, (first, impossible)),
+                  ct.CacheDomain(32 * MB, (impossible + 1,))])
+            got = ct.taskset_prefix()
+            if shutil.which("taskset"):
+                assert got == ["taskset", "-c", str(first)], got
+        # Off Windows the context manager is inert and restores nothing.
+        with ct.launch_affinity() as pinned:
+            assert pinned is None or sys.platform == "win32"
+    finally:
+        ct.cache_domains = real
+
+    found = ct.cache_domains()
+    assert isinstance(found, list)
+    for dom in found:
+        assert dom.l3_bytes > 0 and dom.cpus
+    print("OK x3d vcache ccd selection")
+
+
 def test_client_exe_probe_is_case_insensitive():
     """3.3.5-era clients ship "Wow.exe"; 1.12-era ship "WoW.exe".
 
@@ -8734,6 +8893,7 @@ def _run_smoke_tests():
     test_vanillafixes_preserves_dlls_txt()
     test_apply_desired_state_restores_dlls_txt()
     test_prepare_for_launch_syncs_dlls_txt()
+    test_x3d_vcache_ccd_selection()
     test_client_exe_probe_is_case_insensitive()
     test_linux_proton_launch_resolution()
     test_linux_dxvk_vulkan_preflight()

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -8253,6 +8253,47 @@ def test_play_stays_right_when_progress_hidden():
     print("OK PLAY stays right-aligned when progress is hidden")
 
 
+def test_vcache_pin_default_is_not_persisted():
+    """The default is resolvable, not stored, so it can still be reverted.
+
+    save() writes the whole DEFAULTS-merged dict, so a literal True in DEFAULTS is
+    baked into every settings.json on first launch and then outranks DEFAULTS via
+    merged.update(loaded) forever -- which would make a one-line revert a no-op for
+    anyone who had already run the launcher once.
+    """
+    from ichalaunch.config.settings import DEFAULTS, Settings, settings
+    import ichalaunch.game.cpu_topology as topo
+
+    assert DEFAULTS["pin_to_vcache_ccd"] is None
+    assert topo.VCACHE_PIN_DEFAULT_ON is True
+
+    # A settings.json predating the key stays unset rather than being pinned.
+    legacy = {"game_path": "", "close_on_launch": True}
+    merged, _ = Settings.__new__(Settings)._merge_loaded(legacy)
+    assert merged["pin_to_vcache_ccd"] is None
+    for stored in (True, False):
+        m, _ = Settings.__new__(Settings)._merge_loaded(
+            {**legacy, "pin_to_vcache_ccd": stored}
+        )
+        assert m["pin_to_vcache_ccd"] is stored
+
+    prev = settings.get("pin_to_vcache_ccd", None)
+    try:
+        settings.set("pin_to_vcache_ccd", None)
+        assert topo.vcache_pin_enabled() is True
+        # The revert lever: flipping the constant moves everyone who never chose.
+        topo.VCACHE_PIN_DEFAULT_ON = False
+        assert topo.vcache_pin_enabled() is False
+        # An explicit choice is not overridden by the constant.
+        settings.set("pin_to_vcache_ccd", True)
+        assert topo.vcache_pin_enabled() is True
+    finally:
+        topo.VCACHE_PIN_DEFAULT_ON = True
+        settings.set("pin_to_vcache_ccd", prev)
+
+    print("OK vcache pin default is resolvable, not persisted")
+
+
 def test_x3d_vcache_ccd_selection():
     """Pinning happens only where there is a genuine choice, and the Windows
     buffer walk is exercised for real rather than stubbed past.
@@ -8894,6 +8935,7 @@ def _run_smoke_tests():
     test_apply_desired_state_restores_dlls_txt()
     test_prepare_for_launch_syncs_dlls_txt()
     test_x3d_vcache_ccd_selection()
+    test_vcache_pin_default_is_not_persisted()
     test_client_exe_probe_is_case_insensitive()
     test_linux_proton_launch_resolution()
     test_linux_dxvk_vulkan_preflight()


### PR DESCRIPTION
Vanilla WoW is a 2006 engine: effectively single-threaded and heavily bound by
cache misses. On a dual-CCD X3D part one die carries the 3D V-Cache and the
other does not, and nothing stops the scheduler putting the client on the wrong
one, or migrating it there mid-session. Pinning it to the cache-rich die is the
documented handling for exactly this class of workload.

THE CHOICE IS DERIVED FROM CACHE TOPOLOGY, NOT FROM THE CPU NAME. Matching
"X3D" in the model string would be wrong for the single-CCD parts -- 7800X3D,
9800X3D -- where every core already has the cache and pinning would halve the
available cores for nothing. Reading the L3 layout makes those fall out on
their own: one L3 domain, so no domain is selected and no pin is applied.

A RATIO ALONE IS NOT A V-CACHE SIGNATURE, so two tests must pass. AMD's Strix
Point parts (Ryzen AI 9 HX 370, AI 9 365) pair a 16 MB Zen 5 CCX with an 8 MB
Zen 5c CCX: a ratio of 2.0 with no stacked cache anywhere on the package. A
ratio test alone would pin a heterogeneous mobile part onto four cores and log
that it had found V-Cache. Every dual-CCD X3D part shipped so far carries 96 MB
against 32 MB, so an absolute floor of 64 MB separates the two cases where a
ratio cannot.

Both platforms are served, and the mask is applied the same way on each: to the
launching process, before the child exists. On Linux that is a taskset prefix on
the umu-launcher invocation, and affinity is inherited across fork and exec, so
the whole umu -> proton -> wine tree follows. On Windows the launcher sets its
own affinity for the duration of the spawn and restores it immediately after,
including on exception.

Setting it on the child after Popen returns was the obvious approach and is
wrong here. vanillafixes_enabled defaults to True, so the process being started
is usually the VanillaFixes loader rather than the game -- the repo treats them
as two live processes throughout -- and Windows propagates a mask only to
children created after it is set, never retroactively. Masking the loader
afterwards therefore races its own child and says nothing about the grandchild,
while reporting in the log that the client was pinned. Pinning the parent first
makes the inheritance deterministic and gives exact parity with the Linux path.

The Windows cache walk is split into a pure parser over the raw buffer. The API
call cannot run anywhere but Windows, but the offsets are where this goes wrong,
and a wrong offset here reads zeroes out of a reserved field rather than
failing: CACHE_RELATIONSHIP places Reserved[18] and GroupCount between Type and
the GROUP_AFFINITY, so Mask sits at +40 from the start of the record and Group
at +48. Reading Mask at +24 lands inside Reserved, which Windows zero-fills,
and every cache record is then silently discarded -- nothing pins, and nothing
says so. Offsets were taken from offsetof() on the real headers rather than
counted by hand, and the parser being pure is what lets the layout be tested
from any platform.

Machines large enough to need processor groups are declined rather than pinned
wrong: a plain affinity mask addresses one group only, so a topology spanning
more than one is refused outright. The mask is also intersected with the
process's allowed affinity before use, and if the original cannot be read back
to restore it, no pin is attempted at all.

On by default, unlike the new-WoW64 setting, because the failure modes are not
comparable. Setting PROTON_USE_WOW64 on a build without the 64-bit host fails
the launch outright; the worst this can do is schedule the game on cores it
would have been scheduled on anyway. It cannot engage without a genuine
asymmetric pair above the V-Cache floor, which is a narrow, self-identifying
slice of hardware.

test_x3d_vcache_ccd_selection drives the Windows buffer walk against a
synthetic buffer laid out to the documented structure -- including an L2 record
that must be ignored, a two-group topology that must be refused, and truncated
input -- and reverting the offsets to +24/+32 fails it. Selection is exercised
against synthetic topologies for hardware not present: single-CCD X3D,
symmetric dual-CCD, Strix Point's heterogeneous CCX pair, sub-threshold
asymmetry, and an unreadable topology, alongside cpu-list formatting, affinity
mask construction, and the size and cpu-list parsers.

---

Same caveat as the frame cap one: I'm on Linux, so the taskset path is verified on real hardware (a 9950X3D, 96 MB vs 32 MB, pins to 0-7,16-23). The Windows half I can't execute. What I could do is make the buffer parsing a pure function and test it against a synthetic buffer built to the documented struct layout, so the offsets themselves are covered -- reverting them to the wrong values fails the test. The one thing that genuinely needs a Windows run is confirming the affinity actually lands and is inherited by the game through VanillaFixes. If you'd rather this were opt-in rather than on by default, say the word.

**Update — the Linux half is now confirmed on a live launch, not just in tests.**
On a 9950X3D the launcher logged:

```
3D V-Cache CCD detected: L3 96 MB on CPUs 0-7,16-23 (other CCD 32 MB)
Pinning the client to the V-Cache CCD via taskset -c 0-7,16-23
Launching via umu: .../VanillaFixes.exe (proton=GE-Proton10-34)
```

Detection picked the right die and the mask matches what the selection logic
predicts for that part. The client launched through VanillaFixes, ran for about a
minute and exited cleanly.

Two honest limits on that. I confirmed the pin was **applied to the launch
command**; I did not read back the affinity mask of the running client process, so
inheritance through VanillaFixes to WoW.exe is still argued from how taskset and
fork/exec work rather than measured -- worth capturing next time the game is up.
And I am claiming nothing about performance: it was a light zone and a short run,
which cannot distinguish a real effect from a load that was never demanding. This
is "the code does what it says on real silicon", not "it made the game faster".


**Update — the default is no longer written into users' settings.json.**
`pin_to_vcache_ccd` was a literal `True` in `DEFAULTS`, and `save()` serialises the
whole DEFAULTS-merged dict, so it was written into every user's settings file on
their first launch and then outranked `DEFAULTS` permanently via
`merged.update(loaded)`. For a default-on, launch-altering setting on a platform you
cannot test from your machine, the one-line revert is the whole rollback plan, and
it was quietly a no-op. It now stores `null` until the user touches the checkbox and
resolves against a `VCACHE_PIN_DEFAULT_ON` constant at read time, with all four read
sites going through the one resolver so the checkbox and the launch path cannot
disagree. No behaviour change: an untouched install still pins, and the detection
gates are untouched.
