### PR TITLE
Treat owned-path keys as comparison keys, not as filenames

### DIFF
--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -1272,8 +1272,9 @@ def _refresh_unverified_mod_flags(game: Path, actual: dict[str, bool]) -> None:
             continue
         outcome = "ok"
         for rel in rels:
-            dest = game / rel
-            if not dest.is_file():
+            # Comparison key, not a filename -- see _verify_mod_install.
+            dest = resolve_ci(game, rel)
+            if dest is None or not dest.is_file():
                 continue
             try:
                 if not validate_pe_binary(dest, min_size=_pe_min_bytes_for_rel(rel)):
@@ -2881,7 +2882,10 @@ def _install_backup_paths(game: Path, mod: dict[str, Any]) -> list[Path]:
         if key in seen:
             continue
         seen.add(key)
-        paths.append(game / rel)
+        # Snapshot the file as it is actually named on disk. Appending the
+        # lowercased key instead means the backup silently contains nothing for
+        # that entry, and a rollback then has nothing to restore.
+        paths.append(resolve_ci(game, rel) or (game / rel))
     return paths
 
 
@@ -2907,8 +2911,13 @@ def _verify_mod_install(game: Path, mod: dict[str, Any]) -> list[str]:
     failures: list[str] = []
     soft_skipped: list[str] = []
     for rel in _pe_artifacts_for_mod(mod):
-        dest = game / rel
-        if not dest.is_file():
+        # _mod_owned_paths lowercases for comparison, so `rel` is a comparison
+        # key and not a real filename. The artifacts genuinely written to disk
+        # are VanillaFixes.exe and VfPatcher.dll; game / "vanillafixes.exe"
+        # misses both on a case-sensitive filesystem and the install is then
+        # reported as having failed.
+        dest = resolve_ci(game, rel)
+        if dest is None or not dest.is_file():
             failures.append(f"{rel} was not installed")
             continue
         try:
@@ -2972,8 +2981,11 @@ def _revert_failed_mod_install(
         norm = _norm_rel_path(rel)
         if norm in manifest_files:
             continue
+        target = resolve_ci(game, rel)
+        if target is None:
+            continue
         try:
-            remove_path_strict(game / rel)
+            remove_path_strict(target)
         except OSError as exc:
             log.warning("Rollback cleanup skipped %s: %s", rel, exc)
 

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -8252,6 +8252,76 @@ def test_play_stays_right_when_progress_hidden():
     print("OK PLAY stays right-aligned when progress is hidden")
 
 
+def test_owned_paths_are_comparison_keys_not_filenames():
+    """Owned-path keys are lowercased for comparison and must not be used as
+    filenames.
+
+    _mod_owned_paths() normalises to lowercase on purpose -- its docstring says
+    so -- because it exists to answer "does this mod own that path". Four call
+    sites then joined those keys onto the game directory and touched the result.
+    On Windows and macOS that works by accident; on Linux the lookup misses and
+    the miss is read as "the file is not there".
+
+    The visible symptom was that every vanillafixes and dxvk install rolled
+    itself back: the installer writes VanillaFixes.exe and VfPatcher.dll, then
+    verified vanillafixes.exe and vfpatcher.dll and declared the install failed.
+    """
+    from ichalaunch.mods.installer import (
+        _install_backup_paths,
+        _mod_owned_paths,
+        _pe_artifacts_for_mod,
+        _verify_mod_install,
+        get_mod,
+    )
+
+    mod = get_mod("vanillafixes")
+    assert mod, "vanillafixes missing from the catalog"
+
+    # The keys really are lowercased -- this is the property the call sites
+    # were relying on being a filename.
+    owned = _mod_owned_paths(mod)
+    assert "vanillafixes.exe" in owned, owned
+    assert "VanillaFixes.exe" not in owned, owned
+    artifacts = _pe_artifacts_for_mod(mod)
+    assert "vanillafixes.exe" in artifacts, artifacts
+
+    with tempfile.TemporaryDirectory() as td:
+        game = Path(td)
+        # Written exactly as install_mod writes them: mixed case.
+        (game / "WoW.exe").write_bytes(b"MZ" + b"\0" * 4096)
+        (game / "VanillaFixes.exe").write_bytes(b"MZ" + b"\0" * 65536)
+        (game / "VfPatcher.dll").write_bytes(b"MZ" + b"\0" * 65536)
+
+        # Verification must find them. Before the fix this raised OSError(22)
+        # "vanillafixes.exe was not installed; vfpatcher.dll was not installed"
+        # and the caller rolled back an install that had in fact succeeded.
+        try:
+            _verify_mod_install(game, mod)
+        except OSError as exc:
+            raise AssertionError(
+                f"verify rejected a correctly installed mod: {exc}") from exc
+
+        # The pre-install snapshot must point at the real files. A backup that
+        # silently holds nothing is worse than no backup, because the rollback
+        # path believes it has something to restore.
+        backups = {p.name for p in _install_backup_paths(game, mod)}
+        assert "VanillaFixes.exe" in backups, backups
+        assert "VfPatcher.dll" in backups, backups
+        assert "vfpatcher.dll" not in backups, backups
+
+        # And a genuinely absent artifact must still be reported as absent --
+        # the fix must not turn the check into a no-op.
+        (game / "VfPatcher.dll").unlink()
+        raised = False
+        try:
+            _verify_mod_install(game, mod)
+        except OSError:
+            raised = True
+        assert raised, "verify must still fail when an artifact is really missing"
+
+    print("OK owned paths are comparison keys not filenames")
+
+
 def test_client_exe_probe_is_case_insensitive():
     """3.3.5-era clients ship "Wow.exe"; 1.12-era ship "WoW.exe".
 
@@ -8734,6 +8804,7 @@ def _run_smoke_tests():
     test_vanillafixes_preserves_dlls_txt()
     test_apply_desired_state_restores_dlls_txt()
     test_prepare_for_launch_syncs_dlls_txt()
+    test_owned_paths_are_comparison_keys_not_filenames()
     test_client_exe_probe_is_case_insensitive()
     test_linux_proton_launch_resolution()
     test_linux_dxvk_vulkan_preflight()


### PR DESCRIPTION
_mod_owned_paths() normalises to lowercase deliberately -- its own docstring
says "normalized, lowercase" -- because it exists to answer "does this mod own
that path". Four call sites then joined those keys onto the game directory and
touched the result. On Windows and macOS that works by accident, because the
filesystem resolves case for them. On Linux the lookup misses, and every one of
the four reads the miss as "the file is not there".

The visible symptom is that installing VanillaFixes or DXVK always fails.
install_mod writes VanillaFixes.exe and VfPatcher.dll, _verify_mod_install then
looks for vanillafixes.exe and vfpatcher.dll, finds neither, and raises
OSError(22) "vanillafixes.exe was not installed; vfpatcher.dll was not
installed". The caller treats that as a failed install and rolls back files that
were written correctly. The user sees "Install vanillafixes failed" and a
Task Manager hint, with the two files sitting on disk the whole time.

The other three are quieter and one of them is worse:

- _install_backup_paths appends game / rel to the pre-install snapshot list, so
  the snapshot silently contains nothing for those entries. A rollback then
  believes it has something to restore and does not, which is a worse position
  than having taken no backup at all.
- _refresh_unverified_mod_flags cannot see the artifacts, so an unverified flag
  never clears once set.
- The rollback cleanup loop calls remove_path_strict(game / rel) and removes
  nothing, leaving behind the files it was trying to clean up.

resolve_ci() already exists for exactly this and is already imported by this
module. It tries the exact path first, so it costs nothing on the platforms
that do not need it, and returns None when nothing matches in any case -- which
keeps every one of these checks honest: a genuinely missing artifact is still
reported missing rather than the check becoming a no-op. One call site,
_ensure_data_writable_for_desired, was already doing this and carries a comment
explaining the trap; this applies the same treatment to the remaining four.

Sites that use rel purely as a string -- the suffix test in
_mod_touches_pe_artifacts and the dedup key in _install_backup_paths -- are
unchanged, since a lowercase comparison key is exactly right there.

⚠️ This also unblocks the smoke suite. test_vf_dxvk_roundtrip_plan_clean is
test 31 of 152 and fails on the rollback described above; the suite aborts on
the first failure, so 121 tests never execute. With this change the suite goes
from 30 passing to 117. It then stops at
test_auto_update_sequence_is_launcher_addons_client, which fails identically on
unmodified master when run on its own, so that one is separate and is not
addressed here.

test_owned_paths_are_comparison_keys_not_filenames asserts the keys really are
lowercased, that verification accepts a correctly installed mod, that the
backup list names the real files, and that a genuinely absent artifact is still
reported absent. Restoring any one of the four joins fails it.

---

Found this while checking my other PRs didn't regress the suite -- I couldn't get a clean baseline because the suite aborts at test 31. It's Linux-only in effect, so it won't show up on your machine at all, which is presumably why it's gone unnoticed. Verified on CachyOS: before, every VanillaFixes/DXVK install rolls back; after, the suite goes 30 -> 117 passing. Happy to split the four fixes apart if you'd rather review them separately. Cheers.