### PR TITLE
Make the Vanilla Tweaks exe swap atomic so a failed patch cannot delete WoW.exe

### DIFF
--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -212,6 +212,23 @@ def migrate_legacy_pretty_night_sky_y(game_path: Path) -> bool:
     return True
 
 
+def swap_patched_client_exe(tweaked: Path, wow: Path) -> None:
+    """Put the patcher's output in place of the client binary, in one step.
+
+    Unlinking the client first meant that a rename which then failed left the
+    game with no client binary at all. That window is not theoretical: the
+    patched exe has just been written by an unsigned third-party patcher, which
+    is the single most likely moment for antivirus to hold it open, and the
+    unlink had already happened by then.
+
+    Path.replace is atomic within a directory on both Windows and Linux, so
+    WoW.exe is either the old build or the new one and never absent. A failure
+    now raises with the original still in place, which install_mod already
+    knows how to roll back.
+    """
+    tweaked.replace(wow)
+
+
 def _install_copy(src: Path, dest: Path, game_path: Path | None = None) -> None:
     """Copy into the game tree. DLLs/EXEs are never LoadLibrary'd; lock/AV → OSError skip."""
     if is_stock_data_mpq(dest):
@@ -2959,8 +2976,7 @@ def install_mod(mod_id: str, progress: ProgressCb | None = None, *, prefer_lates
                 if not tweaked.exists() and wow.stem != "WoW":
                     tweaked = game / "WoW_tweaked.exe"
                 if tweaked.exists():
-                    wow.unlink(missing_ok=True)
-                    tweaked.rename(wow)
+                    swap_patched_client_exe(tweaked, wow)
                 soft: list[str] = []
                 try:
                     if not validate_pe_binary(wow, min_size=_DLL_PE_MIN_BYTES):

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -560,6 +560,52 @@ def test_vanilla_tweaks_disable_clears_pending():
     print("OK vanilla tweaks disable clears pending")
 
 
+def test_vanilla_tweaks_exe_swap_is_atomic():
+    """A failed patched-exe swap leaves the client binary in place, not missing."""
+    from ichalaunch.mods.installer import swap_patched_client_exe
+
+    with tempfile.TemporaryDirectory() as td:
+        game = Path(td)
+        wow = game / "WoW.exe"
+        tweaked = game / "WoW_tweaked.exe"
+
+        wow.write_bytes(b"MZ" + b"old" * 64)
+        tweaked.write_bytes(b"MZ" + b"new" * 64)
+        original = wow.read_bytes()
+
+        # Happy path: the patched build lands and the scratch file is consumed.
+        swap_patched_client_exe(tweaked, wow)
+        assert wow.is_file()
+        assert wow.read_bytes().startswith(b"MZ" + b"new")
+        assert not tweaked.exists()
+
+        # Failure path, which is the regression this guards. Unlinking first
+        # left the game with no WoW.exe whenever the rename afterwards failed.
+        # A one-step replace cannot produce that state.
+        wow.write_bytes(original)
+        tweaked.write_bytes(b"MZ" + b"new" * 64)
+        real_replace = Path.replace
+
+        def refuse(self, target):
+            raise OSError(32, "The process cannot access the file")
+
+        Path.replace = refuse
+        try:
+            failed = False
+            try:
+                swap_patched_client_exe(tweaked, wow)
+            except OSError:
+                failed = True
+            assert failed, "a swap that cannot complete must raise, not pass silently"
+        finally:
+            Path.replace = real_replace
+
+        assert wow.is_file(), "WoW.exe must survive a swap that could not complete"
+        assert wow.read_bytes() == original, "the surviving WoW.exe must be the old build"
+        assert tweaked.is_file(), "the patched build must survive for a retry"
+    print("OK vanilla tweaks exe swap is atomic")
+
+
 def test_hand_patched_wow_exe_is_not_vanilla_tweaks():
     """Play must not restore stock WoW.exe over a hand-patched client (#280)."""
     from ichalaunch.config.settings import settings as s
@@ -12393,6 +12439,7 @@ def _run_smoke_tests():
     test_dlls_txt()
     test_detect_state()
     test_vanilla_tweaks_disable_clears_pending()
+    test_vanilla_tweaks_exe_swap_is_atomic()
     test_hand_patched_wow_exe_is_not_vanilla_tweaks()
     test_apply_desired_state_guard()
     test_mod_remove_desired_state()


### PR DESCRIPTION
The exe_patch path replaced the client binary in two steps: unlink WoW.exe,
then rename the patcher's output over it. Anything that stopped the rename
after the unlink had already run left the game with no client binary at all.

That window is not theoretical. The file being renamed has just been written
by an unsigned third-party patcher, which is the single most likely moment for
antivirus to hold it open, and by then WoW.exe is already gone. A process kill
or a power loss between the two calls does the same thing.

WoW-OriginalBackup.exe survives, so the state is recoverable, but nothing in
the launcher offers that recovery and the user has no way to know it exists.

Path.replace is atomic within a directory on both Windows and Linux, so the
client binary is either the old build or the new one and never absent. A
failure now raises with the original still in place, which install_mod already
knows how to roll back.

The swap moves into swap_patched_client_exe() so the invariant can be asserted
rather than described. The new smoke test drives a swap that cannot complete
and checks that WoW.exe is still there and still the old build; against the
previous code that assertion fails, because WoW.exe is gone.

---

Merges clean onto 7837c1c, and cleanly against the other branch open from me.

Verification: the full smoke suite was run on this branch merged with that other
fix. 190 tests pass in sequence, including the new one, and the suite then stops
at `test_mainwindow_addons_next_all_filter_fully_loaded`. That stop reproduces
identically on unmodified 7837c1c, so it is not from this change. The remaining
tests were run individually: 18 pass, and the two that do not also reproduce on
unmodified 7837c1c. Both are filed separately.