### PR TITLE
Keep the launcher's own CA bundle out of the environment the game inherits

### DIFF
--- a/ichalaunch/core/process.py
+++ b/ichalaunch/core/process.py
@@ -479,9 +479,20 @@ def file_in_use_hint(*paths: Path | str) -> str:
 
 def child_launch_env(base: dict[str, str] | None = None) -> dict[str, str]:
     """Environment for the game child: inherit, then apply launcher-owned vars."""
+    from ichalaunch.core.logging_setup import log
+    from ichalaunch.core.tls import strip_launcher_ca_env
     from ichalaunch.game.nampower_encrypt import apply_wow_encryption_env
 
     env = dict(os.environ if base is None else base)
+    # This process's own CA bundle sits inside the PyInstaller extraction
+    # directory, which is removed when the launcher exits. The child outlives
+    # it, so the path must not be inherited.
+    dropped_ca = strip_launcher_ca_env(env)
+    if dropped_ca:
+        log.info(
+            "Dropped launcher-owned CA variables from the launch environment: %s",
+            ", ".join(dropped_ca),
+        )
     apply_wow_encryption_env(env)
     return env
 

--- a/ichalaunch/core/tls.py
+++ b/ichalaunch/core/tls.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 import ssl
 import sys
-from typing import Iterable
+from typing import Iterable, MutableMapping
 
 # File-valued CA env vars read by OpenSSL, requests, curl, git, pip, or Node.
 CA_FILE_ENV_VARS: tuple[str, ...] = (
@@ -150,6 +150,43 @@ def _apply_requests_defaults(cafile: str) -> None:
                 setattr(urllib3_ssl, attr, cafile)
             except Exception:  # noqa: BLE001
                 pass
+
+
+def strip_launcher_ca_env(env: MutableMapping[str, str]) -> list[str]:
+    """Drop CA variables that point at this launcher's own bundled certifi.
+
+    sanitize_tls_ca_env() pins this process to a readable CA bundle, and where
+    nothing valid was inherited that bundle is the copy of certifi inside the
+    frozen build. It lives under the PyInstaller extraction directory, which is
+    removed when the launcher exits.
+
+    A launched child outlives the launcher. That is the whole point of the game,
+    and closing the launcher when the game starts is a shipped setting. Handing
+    that child a CA path which is about to disappear recreates, one process
+    along, the exact failure this module exists to repair. umu fetches its own
+    runtime over HTTPS, so this breaks a real thing rather than a hypothetical
+    one, and it does so only on the machines where the runtime was not already
+    cached, which is what makes it hard to reproduce.
+
+    A CA file the user set themselves is deliberately left in place: it is
+    readable, it is theirs, and a corporate prefix may well need it. Only the
+    launcher's own bundled copy is removed.
+
+    Returns the variable names removed, so the launch log can say so.
+    """
+    bundled = bundled_ca_file()
+    if not bundled:
+        return []
+    owned = os.path.normcase(os.path.normpath(bundled))
+    removed: list[str] = []
+    for name in CA_FILE_ENV_VARS:
+        raw = env.get(name)
+        if not raw:
+            continue
+        if os.path.normcase(os.path.normpath(raw.strip())) == owned:
+            env.pop(name, None)
+            removed.append(name)
+    return removed
 
 
 def sanitize_tls_ca_env() -> str | None:

--- a/ichalaunch/game/proton.py
+++ b/ichalaunch/game/proton.py
@@ -230,6 +230,18 @@ def build_launch_command(exe: Path, cwd: Path) -> tuple[list[str], dict[str, str
     ):
         env.pop(name, None)
 
+    # A CA bundle that belongs to this process must not cross into a child that
+    # outlives it: the path is inside the PyInstaller extraction directory and
+    # goes away when the launcher exits. umu fetches its runtime over HTTPS.
+    from ichalaunch.core.tls import strip_launcher_ca_env
+
+    dropped_ca = strip_launcher_ca_env(env)
+    if dropped_ca:
+        log.info(
+            "Dropped launcher-owned CA variables from the launch environment: %s",
+            ", ".join(dropped_ca),
+        )
+
     env.update({
         "WINEPREFIX": str(prefix),
         "PROTONPATH": str(proton),

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -113,6 +113,97 @@ def test_tls_ca_env_sanitizer():
     print("OK tls ca env sanitizer")
 
 
+def test_launcher_ca_env_does_not_reach_the_game():
+    """The launcher's own bundled CA path is stripped from the child environment."""
+    from ichalaunch.core.process import child_launch_env
+    from ichalaunch.core.tls import (
+        CA_FILE_ENV_VARS,
+        bundled_ca_file,
+        strip_launcher_ca_env,
+    )
+
+    bundled = bundled_ca_file()
+    assert bundled, "the test needs a readable bundled CA to have something to strip"
+
+    # A CA the user set themselves is theirs and stays. Only the launcher's own
+    # copy is removed, because only that one is about to be deleted.
+    user_ca = "/etc/ssl/certs/ca-certificates.crt"
+    env = {"SSL_CERT_FILE": bundled, "REQUESTS_CA_BUNDLE": user_ca}
+    removed = strip_launcher_ca_env(env)
+    assert removed == ["SSL_CERT_FILE"]
+    assert "SSL_CERT_FILE" not in env
+    assert env["REQUESTS_CA_BUNDLE"] == user_ca
+
+    # Nothing to strip is not an error.
+    assert strip_launcher_ca_env({}) == []
+    assert strip_launcher_ca_env({"SSL_CERT_FILE": user_ca}) == []
+
+    saved = {n: os.environ.get(n) for n in CA_FILE_ENV_VARS}
+    try:
+        for name in CA_FILE_ENV_VARS:
+            os.environ[name] = bundled
+
+        # The Windows launch path builds its own environment.
+        win_env = child_launch_env()
+        for name in CA_FILE_ENV_VARS:
+            assert name not in win_env, f"{name} must not reach the game child"
+
+        if sys.platform != "win32":
+            import tempfile as _tf
+
+            from ichalaunch.game import proton
+
+            class _Stub:
+                def __init__(self, d):
+                    self.d = d
+
+                def get(self, k, default=None):
+                    return self.d.get(k, default)
+
+                def set(self, k, v):
+                    self.d[k] = v
+
+            real = proton.settings
+            try:
+                with _tf.TemporaryDirectory() as td:
+                    root = Path(td)
+                    umu = root / "umu-run"
+                    umu.write_text("#!/bin/sh\nexit 0\n")
+                    umu.chmod(0o755)
+                    build = root / "GE-Proton10-34"
+                    (build / "files" / "bin-wow64").mkdir(parents=True)
+                    (build / "files" / "bin-wow64" / "wine").write_text("#!/bin/sh\n")
+                    (build / "toolmanifest.vdf").write_text("x")
+                    proton.settings = _Stub({
+                        "linux_proton_path": str(build),
+                        "linux_use_latest_proton": False,
+                        "linux_umu_path": str(umu),
+                        "linux_wineprefix": str(root / "prefix"),
+                    })
+                    launch_env = proton.build_launch_command(root / "WoW.exe", root)[1]
+                    for name in CA_FILE_ENV_VARS:
+                        assert name not in launch_env, (
+                            f"{name} points inside the PyInstaller extraction "
+                            "directory, which is deleted when the launcher exits. "
+                            "umu fetches its runtime over HTTPS after that."
+                        )
+
+                    # The user's own CA is still handed through, so a corporate
+                    # prefix keeps working.
+                    os.environ["SSL_CERT_FILE"] = user_ca
+                    kept = proton.build_launch_command(root / "WoW.exe", root)[1]
+                    assert kept.get("SSL_CERT_FILE") == user_ca
+            finally:
+                proton.settings = real
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+    print("OK launcher CA env does not reach the game")
+
+
 def test_github_parse():
     assert parse_github_url("https://github.com/shagu/ShaguTweaks") == (
         "shagu",
@@ -12386,6 +12477,7 @@ def main():
 def _run_smoke_tests():
     test_catalogs()
     test_tls_ca_env_sanitizer()
+    test_launcher_ca_env_does_not_reach_the_game()
     test_github_parse()
     test_gitlab_parse_and_install_url()
     test_gitlab_preview_does_not_use_github_api()


### PR DESCRIPTION
sanitize_tls_ca_env() pins this process to a readable CA bundle, and where
nothing valid was inherited that bundle is the copy of certifi inside the
frozen build. Its path is under the PyInstaller extraction directory, which is
removed when the launcher exits.

Both launch paths build the child environment from os.environ, so that path was
handed to the game, and on Linux to umu, Proton and Wine underneath it. The
child outlives the launcher: that is the point of the game, and closing the
launcher when the game starts is a shipped setting. So the child was left
holding a CA path that had just been deleted, which is the same failure this
module exists to repair, one process further along.

It is not hypothetical. umu fetches its own runtime over HTTPS, and it does so
on exactly the machines where that runtime is not already cached, which is what
makes the resulting report hard to reproduce.

strip_launcher_ca_env() removes only variables whose value is this launcher's
own bundled copy. A CA file the user set themselves is readable, is theirs, and
may well be what a corporate prefix needs, so it is passed through untouched.
Removed names are logged, so a launch log says what happened.

Applied to both launch paths rather than only to the Linux one. The Windows
path builds its environment separately and has the same extraction directory
underneath it, so the same value would have crossed the same boundary there.

The new smoke test covers the unit behaviour, both launch paths, and the case
that must not regress: a user-set CA still reaches the child.

---

Merges clean onto 7837c1c, and cleanly against the other branch open from me.

Verification: the full smoke suite was run on this branch merged with that other
fix. 190 tests pass in sequence, including the new one, and the suite then stops
at `test_mainwindow_addons_next_all_filter_fully_loaded`. That stop reproduces
identically on unmodified 7837c1c, so it is not from this change. The remaining
tests were run individually: 18 pass, and the two that do not also reproduce on
unmodified 7837c1c. Both are filed separately.