### PR TITLE
Identify the patched exe by what the run wrote, and fail when it wrote nothing

### DIFF
--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -212,6 +212,23 @@ def migrate_legacy_pretty_night_sky_y(game_path: Path) -> bool:
     return True
 
 
+def swap_patched_client_exe(tweaked: Path, wow: Path) -> None:
+    """Put the patcher's output in place of the client binary, in one step.
+
+    Unlinking the client first meant that a rename which then failed left the
+    game with no client binary at all. That window is not theoretical: the
+    patched exe has just been written by an unsigned third-party patcher, which
+    is the single most likely moment for antivirus to hold it open, and the
+    unlink had already happened by then.
+
+    Path.replace is atomic within a directory on both Windows and Linux, so
+    WoW.exe is either the old build or the new one and never absent. A failure
+    now raises with the original still in place, which install_mod already
+    knows how to roll back.
+    """
+    tweaked.replace(wow)
+
+
 def _install_copy(src: Path, dest: Path, game_path: Path | None = None) -> None:
     """Copy into the game tree. DLLs/EXEs are never LoadLibrary'd; lock/AV → OSError skip."""
     if is_stock_data_mpq(dest):
@@ -2959,8 +2976,7 @@ def install_mod(mod_id: str, progress: ProgressCb | None = None, *, prefer_lates
                 if not tweaked.exists() and wow.stem != "WoW":
                     tweaked = game / "WoW_tweaked.exe"
                 if tweaked.exists():
-                    wow.unlink(missing_ok=True)
-                    tweaked.rename(wow)
+                    swap_patched_client_exe(tweaked, wow)
                 soft: list[str] = []
                 try:
                     if not validate_pe_binary(wow, min_size=_DLL_PE_MIN_BYTES):

--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -212,6 +212,64 @@ def migrate_legacy_pretty_night_sky_y(game_path: Path) -> bool:
     return True
 
 
+def tweaked_exe_snapshot(game: Path) -> dict[Path, tuple[int, float]]:
+    """Every ``*_tweaked.exe`` beside the client, with size and mtime.
+
+    Taken before the patcher runs so its output can be identified by what
+    actually changed rather than by guessing the filename it chose.
+    """
+    out: dict[Path, tuple[int, float]] = {}
+    try:
+        children = list(game.iterdir())
+    except OSError:
+        return out
+    for child in children:
+        if not child.name.lower().endswith("_tweaked.exe"):
+            continue
+        try:
+            if not child.is_file():
+                continue
+            st = child.stat()
+        except OSError:
+            continue
+        out[child] = (st.st_size, st.st_mtime)
+    return out
+
+
+def patched_exe_from_run(
+    game: Path,
+    infile: Path,
+    wow: Path,
+    before: dict[Path, tuple[int, float]],
+) -> Path | None:
+    """The executable the patcher just wrote, or None if it wrote nothing.
+
+    The patcher takes an input path and no output flag, so the name of its
+    output is whatever it derives from that input. Feeding it the stock backup,
+    which is what stops option changes from stacking, means the name follows the
+    backup and not the client. Named candidates are tried in that order first.
+
+    Only files that appeared or changed during this run are eligible. A
+    ``WoW_tweaked.exe`` left behind by an earlier run carries that run's
+    options, so installing it would quietly apply the wrong settings.
+
+    Anything else fresh is accepted as a last resort, so a filename change
+    upstream degrades into a working install rather than a silent no-op.
+    """
+    after = tweaked_exe_snapshot(game)
+    fresh = {path for path, meta in after.items() if before.get(path) != meta}
+    if not fresh:
+        return None
+    for candidate in (
+        game / f"{Path(infile).stem}_tweaked.exe",
+        game / f"{Path(wow).stem}_tweaked.exe",
+        game / "WoW_tweaked.exe",
+    ):
+        if candidate in fresh:
+            return candidate
+    return max(fresh, key=lambda path: after[path][1])
+
+
 def swap_patched_client_exe(tweaked: Path, wow: Path) -> None:
     """Put the patcher's output in place of the client binary, in one step.
 
@@ -2971,12 +3029,16 @@ def install_mod(mod_id: str, progress: ProgressCb | None = None, *, prefer_lates
                 )
                 cmd = tweaks_patch_command(mod_id, vt, infile, opts)
                 status_only(progress, "Patching WoW.exe with Vanilla Tweaks...")
+                before_tweaked = tweaked_exe_snapshot(game)
                 subprocess.run(cmd, cwd=str(game), check=True)
-                tweaked = game / f"{wow.stem}_tweaked.exe"
-                if not tweaked.exists() and wow.stem != "WoW":
-                    tweaked = game / "WoW_tweaked.exe"
-                if tweaked.exists():
-                    swap_patched_client_exe(tweaked, wow)
+                tweaked = patched_exe_from_run(game, infile, wow, before_tweaked)
+                if tweaked is None:
+                    raise FileNotFoundError(
+                        "Vanilla Tweaks exited successfully but wrote no patched "
+                        f"executable beside {infile.name}, so the client is "
+                        "unchanged."
+                    )
+                swap_patched_client_exe(tweaked, wow)
                 soft: list[str] = []
                 try:
                     if not validate_pe_binary(wow, min_size=_DLL_PE_MIN_BYTES):

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -560,6 +560,52 @@ def test_vanilla_tweaks_disable_clears_pending():
     print("OK vanilla tweaks disable clears pending")
 
 
+def test_vanilla_tweaks_exe_swap_is_atomic():
+    """A failed patched-exe swap leaves the client binary in place, not missing."""
+    from ichalaunch.mods.installer import swap_patched_client_exe
+
+    with tempfile.TemporaryDirectory() as td:
+        game = Path(td)
+        wow = game / "WoW.exe"
+        tweaked = game / "WoW_tweaked.exe"
+
+        wow.write_bytes(b"MZ" + b"old" * 64)
+        tweaked.write_bytes(b"MZ" + b"new" * 64)
+        original = wow.read_bytes()
+
+        # Happy path: the patched build lands and the scratch file is consumed.
+        swap_patched_client_exe(tweaked, wow)
+        assert wow.is_file()
+        assert wow.read_bytes().startswith(b"MZ" + b"new")
+        assert not tweaked.exists()
+
+        # Failure path, which is the regression this guards. Unlinking first
+        # left the game with no WoW.exe whenever the rename afterwards failed.
+        # A one-step replace cannot produce that state.
+        wow.write_bytes(original)
+        tweaked.write_bytes(b"MZ" + b"new" * 64)
+        real_replace = Path.replace
+
+        def refuse(self, target):
+            raise OSError(32, "The process cannot access the file")
+
+        Path.replace = refuse
+        try:
+            failed = False
+            try:
+                swap_patched_client_exe(tweaked, wow)
+            except OSError:
+                failed = True
+            assert failed, "a swap that cannot complete must raise, not pass silently"
+        finally:
+            Path.replace = real_replace
+
+        assert wow.is_file(), "WoW.exe must survive a swap that could not complete"
+        assert wow.read_bytes() == original, "the surviving WoW.exe must be the old build"
+        assert tweaked.is_file(), "the patched build must survive for a retry"
+    print("OK vanilla tweaks exe swap is atomic")
+
+
 def test_hand_patched_wow_exe_is_not_vanilla_tweaks():
     """Play must not restore stock WoW.exe over a hand-patched client (#280)."""
     from ichalaunch.config.settings import settings as s
@@ -12393,6 +12439,7 @@ def _run_smoke_tests():
     test_dlls_txt()
     test_detect_state()
     test_vanilla_tweaks_disable_clears_pending()
+    test_vanilla_tweaks_exe_swap_is_atomic()
     test_hand_patched_wow_exe_is_not_vanilla_tweaks()
     test_apply_desired_state_guard()
     test_mod_remove_desired_state()

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -606,6 +606,60 @@ def test_vanilla_tweaks_exe_swap_is_atomic():
     print("OK vanilla tweaks exe swap is atomic")
 
 
+def test_vanilla_tweaks_patcher_output_is_identified_or_fails():
+    """The patched exe is found by what the run wrote, and a no-op run is not success."""
+    import time as _time
+
+    from ichalaunch.mods.installer import patched_exe_from_run, tweaked_exe_snapshot
+
+    with tempfile.TemporaryDirectory() as td:
+        game = Path(td)
+        wow = game / "WoW.exe"
+        backup = game / "WoW-OriginalBackup.exe"
+        wow.write_bytes(b"MZ" + b"client" * 32)
+        backup.write_bytes(b"MZ" + b"stock" * 32)
+
+        # The real case. The patcher is fed the stock backup so option changes do
+        # not stack, so it names its output after the backup, not after WoW.exe.
+        before = tweaked_exe_snapshot(game)
+        out = game / "WoW-OriginalBackup_tweaked.exe"
+        out.write_bytes(b"MZ" + b"patched" * 32)
+        assert patched_exe_from_run(game, backup, wow, before) == out
+        out.unlink()
+
+        # A patcher that names its output after the client is also handled.
+        before = tweaked_exe_snapshot(game)
+        alt = game / "WoW_tweaked.exe"
+        alt.write_bytes(b"MZ" + b"patched" * 32)
+        assert patched_exe_from_run(game, backup, wow, before) == alt
+
+        # A stale file from an earlier run carries that run's options. A run that
+        # writes nothing must report nothing rather than reinstalling it.
+        before = tweaked_exe_snapshot(game)
+        assert patched_exe_from_run(game, backup, wow, before) is None
+
+        # Stale present and a fresh one written: the fresh one wins.
+        before = tweaked_exe_snapshot(game)
+        _time.sleep(0.01)
+        fresh = game / "WoW-OriginalBackup_tweaked.exe"
+        fresh.write_bytes(b"MZ" + b"newer" * 32)
+        assert patched_exe_from_run(game, backup, wow, before) == fresh
+        fresh.unlink()
+
+        # A name nobody predicted is still accepted, so an upstream rename
+        # degrades to a working install instead of a silent no-op.
+        before = tweaked_exe_snapshot(game)
+        odd = game / "vanillatweaks-output_tweaked.exe"
+        odd.write_bytes(b"MZ" + b"odd" * 32)
+        assert patched_exe_from_run(game, backup, wow, before) == odd
+        odd.unlink()
+
+        # An empty game folder is not a crash.
+        assert patched_exe_from_run(game, backup, wow, tweaked_exe_snapshot(game)) is None
+        assert tweaked_exe_snapshot(game / "does-not-exist") == {}
+    print("OK vanilla tweaks patcher output is identified or fails")
+
+
 def test_hand_patched_wow_exe_is_not_vanilla_tweaks():
     """Play must not restore stock WoW.exe over a hand-patched client (#280)."""
     from ichalaunch.config.settings import settings as s
@@ -12440,6 +12494,7 @@ def _run_smoke_tests():
     test_detect_state()
     test_vanilla_tweaks_disable_clears_pending()
     test_vanilla_tweaks_exe_swap_is_atomic()
+    test_vanilla_tweaks_patcher_output_is_identified_or_fails()
     test_hand_patched_wow_exe_is_not_vanilla_tweaks()
     test_apply_desired_state_guard()
     test_mod_remove_desired_state()


### PR DESCRIPTION
The exe_patch path guessed the patcher's output filename and treated a miss as
success. Two ways that goes wrong, both silent.

First, the guess can miss. The candidates were WoW_tweaked.exe and, only when
the client was not called WoW.exe, WoW_tweaked.exe again. The second branch is
guarded by `wow.stem != "WoW"`, so on any ordinary install it never runs and
there is really only one candidate. Meanwhile the patcher is deliberately fed
the stock backup, because that is what stops option changes from stacking, and
it takes an input path and no output flag. Its output name therefore follows
WoW-OriginalBackup.exe rather than the client. If that is what it writes, no
candidate matches, nothing is swapped, and _finish_mod_install still records
the mod as installed. The user is told Vanilla Tweaks is on and the client is
untouched.

Second, the guess can hit the wrong file. A WoW_tweaked.exe left behind by an
earlier run satisfies the existence check, so a run that produced nothing could
install the previous run's build, carrying the previous run's options.

Both disappear if the output is identified by what actually changed. The folder
is snapshotted before the patcher runs and the output is whatever appeared or
changed during it, preferring the names derived from the input and the client,
falling back to anything else fresh so an upstream rename degrades to a working
install instead of a no-op. Nothing fresh now raises, which install_mod already
knows how to roll back.

There was no coverage for any of this: `grep _tweaked smoke_test.py` returned
nothing. The new test covers the backup-derived name, the client-derived name,
a run that writes nothing, a stale file that must not be reused, a stale file
alongside a fresh one, and a name nobody predicted.

Stacked on the atomic swap change, which touches the same lines.

---

**Stacked on #342**, which touches the same lines. The first of the two commits
here is that PR. Merging #342 first leaves this one showing only its own commit.

Merges clean onto 7837c1c. All 64 installer, mod and Vanilla Tweaks tests in the
suite pass on this branch, including the two new ones. The full suite cannot run
to completion on a fresh config for reasons unrelated to this change, filed as
#344.