### PR TITLE
Stop the addon list's finally blocks from swallowing exceptions

### DIFF
--- a/ichalaunch/ui/pages/addons.py
+++ b/ichalaunch/ui/pages/addons.py
@@ -1209,14 +1209,15 @@ class AddonsPage(QWidget):
         finally:
             self._sync_check_btn()
             if self._pending_list_work and not self._lists_frozen() and not self._scan_busy():
-                # Reveal-only while the page is off-stack must not spin the flush
-                # loop — showEvent will drain it when Addons becomes current.
                 if self._pending_list_work <= {"reveal"} and not self._page_is_live():
-                    return
-                if self._rendering_avail:
+                    # Reveal-only while the page is off-stack must not spin the
+                    # flush loop. showEvent drains it when Addons becomes
+                    # current, so nothing is scheduled here.
+                    pass
+                elif self._rendering_avail:
                     self._arm_flush_timer()
-                    return
-                QTimer.singleShot(0, self._flush_list_work)
+                else:
+                    QTimer.singleShot(0, self._flush_list_work)
             else:
                 QTimer.singleShot(0, self._flush_pending_page)
 
@@ -1412,9 +1413,13 @@ class AddonsPage(QWidget):
                 self._pending_list_work.add("reveal")
             self._sync_check_btn()
             if self._pending_list_work and not self._lists_frozen() and not self._scan_busy():
-                if self._pending_list_work <= {"reveal"} and not self._page_is_live():
-                    return
-                QTimer.singleShot(0, self._flush_list_work)
+                # Reveal-only while the page is off-stack is left for showEvent
+                # to drain, so it does not spin the flush loop.
+                off_stack_reveal_only = (
+                    self._pending_list_work <= {"reveal"} and not self._page_is_live()
+                )
+                if not off_stack_reveal_only:
+                    QTimer.singleShot(0, self._flush_list_work)
 
     def set_never_update(self, entry: dict, enabled: bool) -> None:
         folder = entry.get("folder") or entry.get("name")

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -113,6 +113,52 @@ def test_tls_ca_env_sanitizer():
     print("OK tls ca env sanitizer")
 
 
+def test_no_control_flow_escapes_a_finally_block():
+    """No return/break/continue inside a finally: it discards the in-flight exception."""
+    import ast
+
+    root = ROOT / "ichalaunch"
+    offenders: list[str] = []
+
+    def scan(body, *, in_loop):
+        """Walk a finally body without entering nested scopes that reset the rule."""
+        for node in body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue  # its own scope; a return there is that function's
+            if isinstance(node, ast.Return):
+                yield node
+                continue
+            if isinstance(node, (ast.Break, ast.Continue)) and not in_loop:
+                yield node
+                continue
+            if isinstance(node, (ast.For, ast.AsyncFor, ast.While)):
+                for f in ("body", "orelse"):
+                    yield from scan(getattr(node, f), in_loop=True)
+                continue
+            for field in ("body", "orelse", "finalbody"):
+                yield from scan(getattr(node, field, []) or [], in_loop=in_loop)
+            for handler in getattr(node, "handlers", []) or []:
+                yield from scan(handler.body, in_loop=in_loop)
+
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Try, getattr(ast, "TryStar", ast.Try))):
+                continue
+            for bad in scan(node.finalbody, in_loop=False):
+                offenders.append(
+                    f"{path.relative_to(ROOT)}:{bad.lineno} "
+                    f"{type(bad).__name__.lower()} in finally"
+                )
+
+    assert not offenders, (
+        "control flow leaving a finally block silently discards whatever "
+        "exception was propagating, so the crash reporter never sees it:\n  "
+        + "\n  ".join(offenders)
+    )
+    print("OK no control flow escapes a finally block")
+
+
 def test_github_parse():
     assert parse_github_url("https://github.com/shagu/ShaguTweaks") == (
         "shagu",
@@ -12386,6 +12432,7 @@ def main():
 def _run_smoke_tests():
     test_catalogs()
     test_tls_ca_env_sanitizer()
+    test_no_control_flow_escapes_a_finally_block()
     test_github_parse()
     test_gitlab_parse_and_install_url()
     test_gitlab_preview_does_not_use_github_api()


### PR DESCRIPTION
Three returns sat inside finally blocks in the Addons page. A return there
discards whatever exception was propagating, so the exception never reaches
anything.

In _flush_list_work the try catches RuntimeError only. Anything else raised by
_do_refresh, _apply_filter_mode, _patch_installed_statuses or _flush_avail_search
lands in the finally, and the return throws it away. A KeyError or AttributeError
walking a catalog dict is entirely plausible there, and the result is an addon
list that silently stops updating with no traceback, no log line, and nothing
for the crash reporter, which is the one thing that would have told anyone this
was happening. The same pattern is in the reveal path.

Python already flags this: compiling the module emits three SyntaxWarnings, and
it is a hard error under PEP 765.

The scheduling logic is unchanged. Each return became the branch it was there to
skip, so the finally now only cleans up and an exception passes through it. All
31 addon tests pass, including the pagination and reveal cases that drive these
exact paths.

The new test is an AST scan of the whole package rather than a check on these
three lines, so the class cannot come back somewhere else. It skips nested
function and class bodies, and loops for break and continue, since control flow
that stays inside its own scope is fine. Verified against a reintroduced
violation: it reports the file and line.

---

Merges clean onto 7837c1c, and independently of the other branches open from me.

Verification: all 31 addon tests in the suite pass, including
`test_addons_available_pagination_after_reveal`,
`test_addons_all_filter_pagination_fully_loaded` and
`test_addons_defers_list_build_while_scanning`, which drive these exact paths.
`ruff --select B012` and `python -W error::SyntaxWarning -m compileall` are
both clean on the package. The full suite cannot run to completion on a fresh
config for reasons unrelated to this change, filed as #344.