### PR TITLE
Pin the bundle to charset_normalizer and drop chardet, saving about 50ms a launch

### DIFF
--- a/IchaLaunch.spec
+++ b/IchaLaunch.spec
@@ -27,6 +27,23 @@ hiddenimports = [
 datas += collect_data_files("certifi")
 hiddenimports.append("certifi")
 
+# requests chooses its character-detection library at runtime, taking the first
+# of chardet / charset_normalizer that imports. That choice goes through
+# importlib, so it is invisible to PyInstaller's analysis and would otherwise be
+# decided by whatever the build machine happens to have installed.
+#
+# charset_normalizer is a hard dependency of requests and is always present.
+# chardet is only an optional extra (requests[use-chardet-on-py3]), is not in
+# requirements.txt, and arrives incidentally through unrelated packages. When it
+# does it wins, and it costs about 50 ms of every launch plus 12 MB of language
+# frequency models for Welsh, Thai, Slovak and friends, to do a job
+# charset_normalizer already does. Pinning the choice here makes the build
+# reproducible rather than dependent on the machine it was made on.
+cn_datas, cn_binaries, cn_hidden = collect_all("charset_normalizer")
+datas += cn_datas
+binaries += cn_binaries
+hiddenimports += cn_hidden
+
 # PySide6 + shiboken6 (plugins, translations, Qt DLLs, .pyd modules).
 for package in ("PySide6", "shiboken6"):
     pkg_datas, pkg_binaries, pkg_hidden = collect_all(package)
@@ -110,7 +127,7 @@ a = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=[],
+    excludes=["chardet"],
     noarchive=False,
     optimize=0,
 )

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -113,6 +113,54 @@ def test_tls_ca_env_sanitizer():
     print("OK tls ca env sanitizer")
 
 
+def test_bundle_pins_charset_normalizer_and_excludes_chardet():
+    """The build pins one character-detection library, and requests works with it."""
+    import subprocess
+
+    spec = (ROOT / "IchaLaunch.spec").read_text(encoding="utf-8")
+    assert '"chardet"' in spec and "excludes=" in spec, "chardet must be excluded"
+    assert 'collect_all("charset_normalizer")' in spec, (
+        "requests resolves its detector through importlib, which PyInstaller "
+        "cannot see, so charset_normalizer has to be collected explicitly"
+    )
+
+    # requests hard-requires charset_normalizer; chardet is only the optional
+    # use-chardet-on-py3 extra. Excluding chardet is therefore safe, but only if
+    # the fallback really works, so check it rather than assume it. Run in a
+    # subprocess: blocking an import in-process would leak into later tests.
+    probe = (
+        "import sys, io\n"
+        "class B:\n"
+        "    def find_spec(self, name, path=None, target=None):\n"
+        "        if name == 'chardet' or name.startswith('chardet.'):\n"
+        "            raise ImportError('excluded from the bundle')\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, B())\n"
+        "import requests, requests.compat\n"
+        "det = requests.compat.chardet\n"
+        "assert det is not None, 'no detector: Response.text would raise'\n"
+        "assert det.__name__ == 'charset_normalizer', det.__name__\n"
+        "from requests.models import Response\n"
+        "from urllib3 import HTTPResponse\n"
+        "r = Response()\n"
+        "r.raw = HTTPResponse(body=io.BytesIO('h\\u00e9llo w\\u00f6rld'.encode('utf-8')),\n"
+        "                     preload_content=False, status=200)\n"
+        "r.status_code = 200; r.headers = {}; r.encoding = None\n"
+        "assert r.apparent_encoding\n"
+        "assert r.text == 'h\\u00e9llo w\\u00f6rld', r.text\n"
+        "print('ok')\n"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, timeout=120
+    )
+    assert out.returncode == 0, (
+        "requests must still decode an undeclared charset with chardet absent:\n"
+        + (out.stderr or "")[-800:]
+    )
+    assert out.stdout.strip().endswith("ok")
+    print("OK bundle pins charset_normalizer and excludes chardet")
+
+
 def test_github_parse():
     assert parse_github_url("https://github.com/shagu/ShaguTweaks") == (
         "shagu",
@@ -12386,6 +12434,7 @@ def main():
 def _run_smoke_tests():
     test_catalogs()
     test_tls_ca_env_sanitizer()
+    test_bundle_pins_charset_normalizer_and_excludes_chardet()
     test_github_parse()
     test_gitlab_parse_and_install_url()
     test_gitlab_preview_does_not_use_github_api()


### PR DESCRIPTION
requests picks its character-detection library at runtime, taking the first of
chardet / charset_normalizer that imports. It does that through importlib, so
PyInstaller's analysis cannot see the choice, and excludes was empty. Whichever
library happened to be installed on the build machine went into the bundle.

charset_normalizer is a hard dependency of requests and is always there. chardet
is only the optional use-chardet-on-py3 extra, is not in requirements.txt, and
turns up incidentally through unrelated packages. When it does it wins the race,
and it is not cheap: about 12 MB of language frequency models for Welsh, Thai,
Slovak, Dutch and the rest, loaded on every start, to do a job charset_normalizer
already does in 194 KB.

Measured on the same machine, importing ichalaunch.ui.main_window, three runs
each, the only difference being whether chardet can be imported:

  with chardet     187 ms   (186, 188, 187)
  chardet excluded 135 ms   (136, 134, 135)

So roughly 50 ms off every launch, a bit over a quarter of the import, plus the
bundle size.

Excluding it also has to guarantee the replacement is present, since the same
importlib indirection hides charset_normalizer from analysis too, and requests
falls back to no detector at all rather than raising. That is a latent crash the
first time a response arrives without a declared charset, so charset_normalizer
is now collected explicitly. Nothing in the project imports chardet directly.

The test checks both halves: that the spec still pins the choice, and that
requests really does decode an undeclared charset with chardet unavailable.
The second runs in a subprocess so blocking an import cannot leak into other
tests. Verified against a reverted exclude: the guard fails and says why.

---

Merges clean onto 7837c1c, and independently of the other branches open from me.

One thing I could not check myself: PyInstaller is not installed on the machine I
tested this on, so I have not built the bundle and confirmed the packaged exe. The
evidence here is the dependency metadata, the A/B import measurement, and the
behavioural test that requests still decodes without chardet. Worth a build on
your side before merging, and if `collect_all("charset_normalizer")` turns out
to be redundant because a hook already covers it, it is harmless to drop that
half and keep the exclude.