### PR TITLE
Stop a power cut during a settings save from wiping the Nampower encryption key

### DIFF
--- a/ichalaunch/config/settings.py
+++ b/ichalaunch/config/settings.py
@@ -268,6 +268,56 @@ def _settings_tmp_path(path: Path) -> Path:
     return path.with_name(f"{path.name}.{token}.tmp")
 
 
+def _write_settings_payload(tmp: Path, payload: str) -> None:
+    """Write the temp file and force its bytes to disk before any rename.
+
+    Path.write_text only hands the bytes to the page cache. On ext4 with the
+    default data=ordered mount the os.replace metadata can reach the journal
+    before that data reaches the platter, so a power cut in the gap leaves a
+    zero length or truncated settings.json. Since v1.3.1 that file carries
+    wow_encryption_key, and losing the key makes every saved Nampower
+    password permanently unreadable with nothing on screen to explain it.
+
+    The open() call deliberately mirrors Path.write_text: text mode, utf-8,
+    and the default newline handling, so the bytes on disk are unchanged on
+    every platform. Only the fsync is new, and fsync is valid on Windows too.
+    """
+    with open(tmp, "w", encoding="utf-8") as fh:
+        fh.write(payload)
+        fh.flush()
+        os.fsync(fh.fileno())
+
+
+def _fsync_settings_dir(directory: Path) -> None:
+    """Make the rename itself durable, on the platforms that allow it.
+
+    fsync on the containing directory is the second half of the POSIX
+    write-temp-then-rename recipe: without it the new directory entry can
+    still be lost even though the file data survived. Windows has no way to
+    open a directory as a file descriptor, so os.open would fail there and
+    the call is skipped. NTFS orders the metadata for os.replace itself, and
+    the file fsync above already covers the data, so nothing is lost by that.
+
+    Any OSError is swallowed. The settings are already written and renamed at
+    this point, and a failure to flush the directory must not turn a
+    successful save into a raised exception or trigger the retry loop.
+    """
+    if sys.platform == "win32":
+        return
+    fd: int | None = None
+    try:
+        fd = os.open(str(directory), getattr(os, "O_DIRECTORY", os.O_RDONLY))
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
 def migrate_legacy_mod_ids(data: dict[str, Any]) -> bool:
     """Rename removed catalog mod ids in persisted settings (one-time on load)."""
     changed = False
@@ -487,7 +537,7 @@ class Settings:
         try:
             for attempt in range(_SETTINGS_SAVE_RETRIES):
                 try:
-                    tmp.write_text(payload, encoding="utf-8")
+                    _write_settings_payload(tmp, payload)
                     if path.is_file():
                         bak = _settings_backup_path(path)
                         try:
@@ -495,6 +545,7 @@ class Settings:
                         except OSError:
                             pass
                     os.replace(tmp, path)
+                    _fsync_settings_dir(path.parent)
                     return
                 except OSError as exc:
                     last = exc

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -7677,6 +7677,110 @@ def test_settings_save_survives_double_process_replace_race():
     print("OK settings save survives double-process replace race")
 
 
+def test_settings_save_fsyncs_payload_before_replace():
+    """Settings.save must flush the temp file to disk before os.replace publishes it."""
+    import json
+    import os
+    import tempfile
+    from pathlib import Path
+    from unittest import mock
+
+    import ichalaunch.config.settings as settings_mod
+    from ichalaunch.config.settings import Settings, _settings_backup_path
+
+    key = "0123456789abcdef0123456789abcdef"
+
+    with tempfile.TemporaryDirectory() as td:
+        fake = Path(td) / "settings.json"
+        orig_path = settings_mod.settings_path
+        settings_mod.settings_path = lambda: fake
+        real_fsync = os.fsync
+        real_replace = os.replace
+        try:
+            s = Settings()
+            s._data["game_path"] = r"D:\Games\RavenCraft"
+            s._data["wow_encryption_key"] = key
+
+            synced: list[tuple[int, int]] = []
+            seen: dict[str, object] = {}
+
+            def _record_fsync(fd):
+                st = os.fstat(fd)
+                synced.append((st.st_dev, st.st_ino))
+                return real_fsync(fd)
+
+            def _record_replace(src, dest):
+                st = os.stat(src)
+                seen["tmp_id"] = (st.st_dev, st.st_ino)
+                seen["tmp_text"] = Path(src).read_text(encoding="utf-8")
+                seen["synced_before"] = list(synced)
+                return real_replace(src, dest)
+
+            with mock.patch.object(settings_mod.os, "fsync", _record_fsync):
+                with mock.patch.object(settings_mod.os, "replace", _record_replace):
+                    s.save()
+
+            # The whole point: the temp file's data was on disk before the rename.
+            assert seen["tmp_id"] in seen["synced_before"], "temp file was renamed without fsync"
+            assert json.loads(seen["tmp_text"])["wow_encryption_key"] == key
+            assert json.loads(seen["tmp_text"])["game_path"] == r"D:\Games\RavenCraft"
+
+            # On POSIX the directory entry is flushed too, after the rename.
+            if os.name == "posix":
+                dir_st = os.stat(td)
+                assert (dir_st.st_dev, dir_st.st_ino) in synced, "settings dir was not fsynced"
+                assert (dir_st.st_dev, dir_st.st_ino) not in seen["synced_before"]
+
+            # Normal saves still round-trip and leave no temp behind.
+            assert json.loads(fake.read_text(encoding="utf-8"))["wow_encryption_key"] == key
+            assert Settings().get("wow_encryption_key") == key
+            assert list(Path(td).glob("settings.json.*.tmp")) == []
+
+            # A save that dies at the rename still leaves complete bytes on disk,
+            # never a truncated temp file, and still cleans the temp up.
+            fatal: dict[str, object] = {}
+
+            def _dying_replace(src, dest):
+                fatal["text"] = Path(src).read_text(encoding="utf-8")
+                raise OSError(28, "No space left on device")
+
+            s._data["game_path"] = r"D:\Games\Other"
+            with mock.patch.object(settings_mod.os, "replace", _dying_replace):
+                try:
+                    s.save()
+                    raise AssertionError("save should have propagated the replace failure")
+                except OSError as exc:
+                    assert getattr(exc, "errno", None) == 28
+            assert json.loads(str(fatal["text"]))["game_path"] == r"D:\Games\Other"
+            assert list(Path(td).glob("settings.json.*.tmp")) == []
+            # The failed save left the previously published file untouched.
+            assert json.loads(fake.read_text(encoding="utf-8"))["game_path"] == r"D:\Games\RavenCraft"
+
+            # The replace-race retry loop and the .bak copy are unchanged.
+            denied = OSError(13, "Access is denied")
+            denied.winerror = 5
+            calls = {"n": 0}
+
+            def _flaky_replace(src, dest):
+                calls["n"] += 1
+                if calls["n"] < 3:
+                    raise denied
+                return real_replace(src, dest)
+
+            s._data["game_path"] = r"D:\Games\Retried"
+            with mock.patch.object(settings_mod.os, "replace", _flaky_replace):
+                s.save()
+            assert calls["n"] == 3
+            assert json.loads(fake.read_text(encoding="utf-8"))["game_path"] == r"D:\Games\Retried"
+            bak = _settings_backup_path(fake)
+            assert bak.is_file()
+            assert json.loads(bak.read_text(encoding="utf-8"))["game_path"] == r"D:\Games\RavenCraft"
+            assert list(Path(td).glob("settings.json.*.tmp")) == []
+        finally:
+            settings_mod.settings_path = orig_path
+    print("OK settings save fsyncs the payload before the atomic replace")
+
+
 def test_addons_filter_persists():
     """Addons list filter survives save/load; unknown values fall back to All."""
     import ichalaunch.config.settings as settings_mod
@@ -12492,6 +12596,7 @@ def _run_smoke_tests():
     test_settings_paths_recover_from_backup()
     test_settings_merge_keeps_game_path_and_tweaks_v2()
     test_settings_save_survives_double_process_replace_race()
+    test_settings_save_fsyncs_payload_before_replace()
     test_addons_filter_persists()
     test_addons_page_restores_and_saves_filter()
     test_bagshui_catalog_pin()


### PR DESCRIPTION
Settings.save wrote the temp file with Path.write_text and then called os.replace. The rename is atomic against itself, but on ext4 with the default data=ordered mount nothing orders the new file's data ahead of the rename's metadata, so a power loss in that window could publish a zero length or truncated settings.json. Since v1.3.1 that file holds wow_encryption_key, and losing the key silently makes every saved Nampower password unreadable forever.

The temp file is now opened explicitly, written, flushed and fsynced before the replace, and on POSIX the containing directory is fsynced afterwards so the new directory entry is durable too. The directory half is skipped on Windows, which has no way to open a directory as a file descriptor; the file fsync is valid there and still applies. The open() call mirrors Path.write_text exactly (text mode, utf-8, default newline handling) so the bytes on disk are unchanged on every platform. The replace-race retry loop, the .bak copy and the temp cleanup in the finally block are untouched.

---

Merges clean onto 7837c1c, independently of the other branches open from me.

Verification: the new test drives the failure path (os.replace made to raise) and asserts the temp file on
disk already holds the complete payload, so the write is proven flushed rather than sitting in a buffer. It
fails against the unfixed code. Existing settings tests were run individually and pass. The full suite is
not runnable on a fresh config for reasons unrelated to this change, filed as #344.

Two things a reviewer should weigh rather than take on trust:

An OSError from os.fsync now propagates out of Settings.save(), where the directory fsync deliberately
swallows its own errors. That asymmetry is a real new failure mode on an exotic filesystem, and it is a
deliberate choice rather than an oversight: a failed data fsync means the payload may not be durable, which
is exactly what this change exists to prevent, whereas a failed directory fsync only weakens the durability
of the rename. Happy to make it swallow both if you would rather save never raise.

The added fsync cost was not measured in a way worth quoting. The obvious measurement is misleading because
the natural test location is tmpfs, where fsync is a no-op.