### PR TITLE
Drop four unused module-level imports, and record why the patch-9 host allowlist is safe today

### DIFF
--- a/ichalaunch/core/detect.py
+++ b/ichalaunch/core/detect.py
@@ -30,7 +30,6 @@ from ichalaunch.mods.installer import (
     enforce_vanilla_helpers_for_hd_desired,
     load_mod_catalog,
     reconcile_exclusive_desired_mods,
-    reconcile_vanillafixes_dxvk,
 )
 
 

--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -27,7 +27,6 @@ from ichalaunch.addons.github import (
     GitHubRateLimitError,
     fetch_repo_readme,
     github_get,
-    github_latest_commit,
     github_latest_version_tag,
     github_remote_tip,
     parse_github_url,
@@ -38,7 +37,6 @@ from ichalaunch.core.filesystem import (
     LOCK_AV_VERIFY_MESSAGE,
     LOCK_AV_VERIFY_TITLE,
     copy_file_tolerant,
-    copy_tree,
     ensure_data_writable,
     extract_tar,
     extract_zip,
@@ -78,7 +76,6 @@ from ichalaunch.core.process import (
 from ichalaunch.game.launcher import (
     detect_game,
     detect_vf_disk_mode,
-    ensure_addons_dir,
     resolve_addons_dir,
     sync_vanillafixes_enabled_from_desired,
     vf_mode_display,

--- a/ichalaunch/mods/stock_patch.py
+++ b/ichalaunch/mods/stock_patch.py
@@ -50,6 +50,17 @@ STOCK_PATCH9_EXPECTED_SIZE = 506_642_995
 STOCK_PATCH9_MIN_BYTES = 400 * 1024 * 1024
 STOCK_PATCH9_BANNER_TEXT = "Patch-9 is missing or incomplete."
 
+# Only github.com is pinned to this repo's path prefix. The two
+# githubusercontent CDN hosts are accepted on ANY path, because a release
+# asset redirect lands on an opaque, signed, per-download path that we cannot
+# predict or match. That is safe today for one reason only: the catalog
+# (ichalaunch/data/stock_patch9.json) is bundled with the app, so the URL this
+# check guards is always one we shipped. If the catalog ever moves to a network
+# fetch, a hostile response could name any file on GitHub and these two entries
+# would wave it through. Two details would make that worse: the href match in
+# patch9_url_from_index_html is a substring test, so a name like
+# patch-9.mpq.exe passes it, and the ~483 MiB result is checked against a size
+# floor only, never a hash. Tighten this before that happens, do not loosen it.
 _GITHUB_ASSET_HOSTS = (
     "github.com",
     "objects.githubusercontent.com",

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -12383,6 +12383,50 @@ def main():
             settings_mod.settings.load()
 
 
+def test_detect_and_installer_drop_unused_imports():
+    """Removed F401 names stay gone and both modules still work without them."""
+    import tempfile
+    from pathlib import Path
+
+    import ichalaunch.core.detect as detect
+    import ichalaunch.mods.installer as installer
+
+    # Each name below was bound at module scope and never referenced, and
+    # nothing in the tree imports it FROM these modules, so the binding was
+    # pure dead weight. Guard against it drifting back in.
+    assert not hasattr(detect, "reconcile_vanillafixes_dxvk")
+    for name in ("github_latest_commit", "copy_tree", "ensure_addons_dir"):
+        assert not hasattr(installer, name), name
+
+    # The modules that actually define them still export them, so callers that
+    # want these functions have an unchanged place to get them from.
+    from ichalaunch.addons.github import github_latest_commit
+    from ichalaunch.core.filesystem import copy_tree
+    from ichalaunch.game.launcher import ensure_addons_dir
+    from ichalaunch.mods.installer import reconcile_vanillafixes_dxvk
+
+    for fn in (github_latest_commit, copy_tree, ensure_addons_dir, reconcile_vanillafixes_dxvk):
+        assert callable(fn)
+
+    # The public surface that sat next to the removed imports still behaves.
+    both = {"vanillafixes": True, "dxvk": True}
+    fixed = reconcile_vanillafixes_dxvk(dict(both), prefer="dxvk")
+    assert fixed.get("dxvk") is True
+    assert fixed.get("vanillafixes") is False
+    assert isinstance(installer.load_mod_catalog(), list)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        addons = Path(tmp) / "AddOns"
+        good = addons / "Atlas-CFM"
+        good.mkdir(parents=True)
+        (good / "Atlas-CFM.toc").write_text("## Title: Atlas\n", encoding="utf-8")
+        valid, mismatched = detect._classify_toc_dir(addons, skip_blizzard=True)
+        assert valid == ["Atlas-CFM"]
+        assert mismatched == []
+
+    print("OK detect/installer carry no unused module-level imports")
+
+
 def _run_smoke_tests():
     test_catalogs()
     test_tls_ca_env_sanitizer()
@@ -12593,6 +12637,7 @@ def _run_smoke_tests():
     test_chrome_buttons_clear_metal_tr()
     test_play_stays_right_when_progress_hidden()
     test_wayland_window_move_and_resize_handoff()
+    test_detect_and_installer_drop_unused_imports()
     print("\nAll smoke tests passed.")
 
 


### PR DESCRIPTION
detect.py bound reconcile_vanillafixes_dxvk and installer.py bound
github_latest_commit, copy_tree and ensure_addons_dir, none of which is
referenced anywhere in the file that imports it, and nothing in the tree
imports those names from these modules either. They are the modules that
define them (installer, addons.github, core.filesystem, game.launcher) that
callers already reach for, so removing the re-bindings moves nothing.

Worth being clear about what this does not buy. detect.py still costs about
88 ms to import, unchanged (median of nine runs of python3 -X importtime,
86.5 ms before, 87.9 ms after, inside the run-to-run spread). requests is
still pulled in and always will be while detect.py imports installer at
module scope, because installer.py does a plain "import requests" of its own
and needs it in six places. Deferring only the addons.github import in
detect.py would buy nothing for the same reason. A real fix has to move
requests out of installer.py's module scope, which is a much larger change
than this.

Separately, _is_allowed_patch9_host in stock_patch.py pins github.com to this
repo's release path prefix but accepts any path on the two githubusercontent
CDN hosts, which serve every release asset on GitHub. That is fine only
because ichalaunch/data/stock_patch9.json ships with the app, so the URL the
check guards is always one we shipped. A comment now says so, because moving
that catalog to a network fetch would turn those two entries into an open
door. The logic is untouched.

---

Merges clean onto 7837c1c, independently of the other branches open from me.

Verification: the four names were each confirmed unused and not re-exported by grepping the whole tree for
anyone importing them from these modules, not just by trusting the linter. Existing tests covering detect.py
and installer.py were run individually and pass. The full suite is not runnable on a fresh config for
reasons unrelated to this change, filed as #344.

One honest note on the import cost. Removing these four names does not by itself drop requests out of
core/detect.py, because other names still in use come from ichalaunch.addons.github. Making that import
lazy would be the real saving and is deliberately not attempted here, since it is a behaviour change rather
than dead-code removal and wants its own change.

The stock_patch.py hunk is a comment only, no logic touched.