### PR TITLE
Make the game-is-running guard work on Linux, where the failure is quieter than on Windows

### DIFF
--- a/ichalaunch/addons/loadstate.py
+++ b/ichalaunch/addons/loadstate.py
@@ -6,6 +6,7 @@ Unloaded packs live beside that folder at ``Interface/AddOnsUnloaded/<Folder>``.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -25,9 +26,18 @@ GAME_LOCK_MESSAGE = (
     "Close World of Warcraft and try again. "
     "The game still has this addon folder open."
 )
-GENERIC_LOCK_MESSAGE = (
+_GENERIC_LOCK_LEAD = (
     "Could not move the addon folder. Close World of Warcraft if it is running, "
-    "then retry. Explorer, antivirus, or Git may also be locking files."
+    "then retry. "
+)
+# Explorer and antivirus mean nothing on Linux, and now that wow_exe_running
+# actually answers there, this text reaches those users.
+_WIN_GENERIC_LOCK_TAIL = "Explorer, antivirus, or Git may also be locking files."
+_POSIX_GENERIC_LOCK_TAIL = (
+    "Your file manager, a backup tool, or Git may also be locking files."
+)
+GENERIC_LOCK_MESSAGE = _GENERIC_LOCK_LEAD + (
+    _WIN_GENERIC_LOCK_TAIL if sys.platform == "win32" else _POSIX_GENERIC_LOCK_TAIL
 )
 
 

--- a/ichalaunch/core/filesystem.py
+++ b/ichalaunch/core/filesystem.py
@@ -417,24 +417,58 @@ def is_lock_or_av_error(exc: BaseException) -> bool:
 # Plain-English copy for UI — never surface raw Errno / WinError to users.
 # WinError 32 is a sharing lock ("in use by another process"), not antivirus by
 # itself; we used to lead with AV and misled users who had Defender disabled.
-TASK_MANAGER_END_GAME_HINT = (
+_WIN_END_GAME_PROCESS_HINT = (
     "Open Task Manager (Ctrl+Shift+Esc) and End task on WoW.exe and "
     "VanillaFixes.exe if either is listed."
+)
+# Task Manager, Explorer and Controlled Folder Access do not exist here, and a
+# hint a user cannot act on is worse than none. Name the tools they do have.
+_POSIX_END_GAME_PROCESS_HINT = (
+    "Close the game, then list any leftover client process with "
+    "'pgrep -fai WoW.exe' and end it with 'pkill -fi WoW.exe'."
+)
+END_GAME_PROCESS_HINT = (
+    _WIN_END_GAME_PROCESS_HINT if sys.platform == "win32" else _POSIX_END_GAME_PROCESS_HINT
+)
+_WIN_OTHER_HOLDERS = (
+    "Overlays, Explorer previews, backup/sync, Controlled Folder Access, or "
+    "antivirus (not only Windows Defender) can also hold the file."
+)
+_POSIX_OTHER_HOLDERS = (
+    "A second Wine process, an overlay, a file manager preview, or backup/sync "
+    "can also hold the file."
+)
+_OTHER_HOLDERS_HINT = (
+    _WIN_OTHER_HOLDERS if sys.platform == "win32" else _POSIX_OTHER_HOLDERS
 )
 LOCK_AV_VERIFY_TITLE = "Could not verify install"
 LOCK_AV_VERIFY_MESSAGE = (
     "Could not verify the install because the file is in use by another process. "
     "The mod was left installed. "
-    f"{TASK_MANAGER_END_GAME_HINT} Then retry. "
-    "Overlays, Explorer previews, backup/sync, Controlled Folder Access, or "
-    "antivirus (not only Windows Defender) can also hold the file."
+    f"{END_GAME_PROCESS_HINT} Then retry. "
+    f"{_OTHER_HOLDERS_HINT}"
 )
 LOCK_AV_APPLY_MESSAGE = (
     "Could not apply this change because the file is in use by another process. "
-    f"{TASK_MANAGER_END_GAME_HINT} Then retry Apply. "
-    "Overlays, Explorer previews, backup/sync, Controlled Folder Access, or "
-    "antivirus (not only Windows Defender) can also hold the file."
+    f"{END_GAME_PROCESS_HINT} Then retry Apply. "
+    f"{_OTHER_HOLDERS_HINT}"
 )
+
+
+def has_end_game_guidance(text: str, *, strict: bool = True) -> bool:
+    """True when *text* already carries this platform's end-the-game steps.
+
+    ``strict`` also requires VanillaFixes to be named, which is what the
+    ``user_facing_os_error`` path checked inline before this was shared.
+    """
+    low = (text or "").strip().lower()
+    if sys.platform == "win32":
+        if "task manager" not in low or "wow.exe" not in low:
+            return False
+        return ("vanillafixes" in low) if strict else True
+    if "wow.exe" not in low:
+        return False
+    return "pgrep" in low or "pkill" in low
 
 _RAW_OS_DETAIL = frozenset(
     {
@@ -455,17 +489,15 @@ def _looks_like_raw_os_detail(text: str) -> bool:
     return low.startswith(("[errno", "[winerror")) or "winerror" in low
 
 
-def _ensure_task_manager_guidance(text: str, *, retry_apply: bool = True) -> str:
-    """Append Task Manager End-task steps when *text* lacks them."""
+def _ensure_end_game_guidance(text: str, *, retry_apply: bool = True) -> str:
+    """Append the end-the-game steps when *text* lacks them."""
     body = (text or "").strip()
-    low = body.lower()
-    has_tm = "task manager" in low and "wow.exe" in low and "vanillafixes" in low
-    if has_tm:
+    if has_end_game_guidance(body):
         return body
     suffix = (
-        f"{TASK_MANAGER_END_GAME_HINT} Then retry Apply."
+        f"{END_GAME_PROCESS_HINT} Then retry Apply."
         if retry_apply
-        else f"{TASK_MANAGER_END_GAME_HINT} Then retry."
+        else f"{END_GAME_PROCESS_HINT} Then retry."
     )
     return f"{body}\n\n{suffix}" if body else suffix
 
@@ -492,7 +524,7 @@ def user_facing_os_error(exc: BaseException, *, kept_install: bool = False) -> s
                 hint = file_in_use_hint(filename)
                 # Only append a *specific* diagnosis (game running / named lockers).
                 if hint.startswith("WoW.exe") or hint.startswith("In use by:"):
-                    return _ensure_task_manager_guidance(
+                    return _ensure_end_game_guidance(
                         f"{base}\n\n{hint}",
                         retry_apply=not kept_install,
                     )
@@ -501,7 +533,7 @@ def user_facing_os_error(exc: BaseException, *, kept_install: bool = False) -> s
         return base
     if detail:
         if is_lock_or_av_error(exc):
-            return _ensure_task_manager_guidance(detail, retry_apply=not kept_install)
+            return _ensure_end_game_guidance(detail, retry_apply=not kept_install)
         return detail
     text = str(exc).strip()
     if is_lock_or_av_error(exc):
@@ -795,7 +827,7 @@ def remove_path_strict(path: Path) -> None:
                 hint = file_in_use_hint(path)
             except Exception:  # noqa: BLE001
                 hint = (
-                    f"{TASK_MANAGER_END_GAME_HINT} Then retry Apply."
+                    f"{END_GAME_PROCESS_HINT} Then retry Apply."
                 )
             raise OSError(
                 getattr(exc, "errno", None) or 13,

--- a/ichalaunch/core/process.py
+++ b/ichalaunch/core/process.py
@@ -312,10 +312,101 @@ def google_drive_url(file_id: str) -> str:
         f"?id={file_id}&export=download&confirm=t"
     )
 
-def wow_exe_running() -> bool:
-    """True when WoW.exe (or VanillaFixes.exe) is running. Windows-only; no admin."""
-    if sys.platform != "win32":
+CLIENT_PROCESS_NAMES = ("wow.exe", "vanillafixes.exe")
+
+
+def _norm_cmdline(text: str) -> str:
+    """Lowercase, forward slashes, NULs as spaces.
+
+    Wine hands the client its own path as ``Z:\\home\\you\\Games\\...\\WoW.exe``.
+    Normalising both sides lets the unix game directory be found in that string
+    as a plain substring, with no drive-letter or separator special-casing.
+    """
+    return (text or "").replace("\x00", " ").replace("\\", "/").lower()
+
+
+def _arg_names_client(arg: str, needle: str) -> bool:
+    """True when one normalised argv entry names a client exe we care about.
+
+    The exe name has to sit behind a separator, so an argument that merely
+    mentions WoW.exe in prose (a shell command, an editor buffer, a log line)
+    cannot trip the guard. With a known game directory the same argument must
+    also carry that directory, which is the scoping guarantee.
+    """
+    if not any(arg == name or arg.endswith(f"/{name}") for name in CLIENT_PROCESS_NAMES):
+        # The argument has to END with the exe name. Requiring only that it
+        # appears leaves "/games/wow/wow.exe.bak" and a log line quoting the
+        # path matching just as well as the client itself.
         return False
+    return needle in arg if needle else True
+
+
+def _configured_game_dir() -> Path | None:
+    """Configured game folder, or None. Imported here, not at module scope.
+
+    ``ichalaunch.game.launcher`` imports from this module, so a top-level import
+    would be a cycle. Every other ichalaunch import in this file is deferred the
+    same way.
+    """
+    try:
+        from ichalaunch.game.launcher import detect_game
+
+        return detect_game()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _proc_client_running(game_dir: Path | str | None) -> bool:
+    """True when some ``/proc/<pid>/cmdline`` names a client exe under *game_dir*.
+
+    Matching is on the client PATH rather than the process name. That scopes the
+    answer to the install this launcher is tied to, still catches a client the
+    user started outside the launcher, and sidesteps ``/proc/<pid>/comm``, which
+    truncates at 15 characters and so never holds "VanillaFixes.exe".
+
+    When the game directory is unknown this returns False rather than guessing,
+    because an unscoped match would block work on one install because a client
+    for a different one is running.
+    """
+    needle = _norm_cmdline(str(game_dir or "")).rstrip("/")
+    if not needle:
+        # Without a configured install there is nothing to scope to, and an
+        # unscoped answer is a guess: any WoW.exe anywhere on the machine would
+        # block work on an install it has nothing to do with. install_mod
+        # resolves the game before it reaches this guard, so the only callers
+        # that land here are diagnostic ones, which are better off saying
+        # nothing than saying something false.
+        return False
+    try:
+        pids = [entry for entry in os.listdir("/proc") if entry.isdigit()]
+    except OSError:
+        return False
+    for pid in pids:
+        try:
+            with open(f"/proc/{pid}/cmdline", "rb") as fh:
+                raw = fh.read()
+        except (OSError, ValueError):
+            # A pid can exit between the listing and the read, and processes
+            # owned by other users can be unreadable. Both are normal, not errors.
+            continue
+        if not raw:
+            continue
+        text = raw.decode("utf-8", "replace")
+        for arg in text.split("\x00"):
+            if arg and _arg_names_client(_norm_cmdline(arg), needle):
+                return True
+    return False
+
+
+def wow_exe_running() -> bool:
+    """True when WoW.exe (or VanillaFixes.exe) is running. No admin needed.
+
+    Windows asks tasklist. Linux reads ``/proc``, and needs the answer more:
+    Wine loads WoW.exe as data instead of exec'ing it, so the kernel never sets
+    ETXTBSY on it and a DLL or exe swap under a live client can quietly succeed.
+    """
+    if sys.platform != "win32":
+        return _proc_client_running(_configured_game_dir())
     names = ("WoW.exe", "VanillaFixes.exe")
     flags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
     try:
@@ -342,6 +433,10 @@ def processes_locking_paths(paths: list[Path | str], *, limit: int = 6) -> list[
 
     Returns ``[]`` when unavailable (non-Windows, API failure, or no lockers found).
     Never raises. Does not require admin.
+
+    Deliberately still Windows-only. The Linux equivalent means walking
+    ``/proc/<pid>/maps`` and ``/proc/<pid>/fd`` for every process, which is a
+    separate change; ``wow_exe_running`` already covers the case that matters.
     """
     if sys.platform != "win32" or not paths:
         return []
@@ -447,25 +542,32 @@ def file_in_use_hint(*paths: Path | str) -> str:
     """Short user-facing diagnosis when a game-tree file cannot be replaced.
 
     Prefers detecting WoW/VanillaFixes, then Restart Manager lockers, then a
-    generic "another process" note (not antivirus-first). Always includes
-    Task Manager End-task steps for WoW.exe / VanillaFixes.exe.
+    generic "another process" note (not antivirus-first). Always includes the
+    steps for ending WoW.exe / VanillaFixes.exe on this platform.
     """
-    from ichalaunch.core.filesystem import TASK_MANAGER_END_GAME_HINT
+    from ichalaunch.core.filesystem import END_GAME_PROCESS_HINT
 
-    end_tasks = f"{TASK_MANAGER_END_GAME_HINT} Then retry Apply."
+    end_tasks = f"{END_GAME_PROCESS_HINT} Then retry Apply."
     if wow_exe_running():
-        return (
-            "WoW.exe or VanillaFixes.exe is still running "
-            "(the game window can be closed while the process stays in Task Manager). "
-            + end_tasks
+        lingers = (
+            "the game window can be closed while the process stays in Task Manager"
+            if sys.platform == "win32"
+            else "closing the game window does not always end the Wine process"
         )
+        return f"WoW.exe or VanillaFixes.exe is still running ({lingers}). " + end_tasks
     lockers = processes_locking_paths([p for p in paths if p])
     if lockers:
         return f"In use by: {', '.join(lockers)}. {end_tasks}"
+    if sys.platform == "win32":
+        return (
+            "Another process still has the file open "
+            "(overlays, Explorer preview, backup/sync, or antivirus — "
+            "including non-Defender products). "
+            + end_tasks
+        )
     return (
         "Another process still has the file open "
-        "(overlays, Explorer preview, backup/sync, or antivirus — "
-        "including non-Defender products). "
+        "(a Wine process, an overlay, a file manager preview, or backup/sync). "
         + end_tasks
     )
 

--- a/ichalaunch/ui/main_window.py
+++ b/ichalaunch/ui/main_window.py
@@ -387,16 +387,15 @@ def _client_mod_failure_dialog_body(
     *,
     lead: str = "These changes could not be applied:",
 ) -> str:
-    """Build Apply/sync failure dialog text; ensure Task Manager End-task guidance."""
-    from ichalaunch.core.filesystem import TASK_MANAGER_END_GAME_HINT
+    """Build Apply/sync failure dialog text; ensure end-the-game guidance."""
+    from ichalaunch.core.filesystem import END_GAME_PROCESS_HINT, has_end_game_guidance
 
     parts = [ln for ln in failures if isinstance(ln, str) and ln.strip()]
     body = f"{lead}\n\n" + "\n\n".join(parts) if parts else lead
-    low = body.lower()
-    if "task manager" in low and "wow.exe" in low:
+    if has_end_game_guidance(body, strict=False):
         return body
     return (
-        f"{body}\n\n{TASK_MANAGER_END_GAME_HINT} Then retry Apply."
+        f"{body}\n\n{END_GAME_PROCESS_HINT} Then retry Apply."
     )
 
 

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -415,13 +415,20 @@ def test_dlls_txt():
         assert "Errno" not in LOCK_AV_VERIFY_MESSAGE
         assert "Errno" not in LOCK_AV_APPLY_MESSAGE
         assert "another process" in LOCK_AV_APPLY_MESSAGE.lower()
-        assert "task manager" in LOCK_AV_APPLY_MESSAGE.lower()
         assert "wow.exe" in LOCK_AV_APPLY_MESSAGE.lower()
-        assert "vanillafixes.exe" in LOCK_AV_APPLY_MESSAGE.lower()
-        assert "end task" in LOCK_AV_APPLY_MESSAGE.lower()
-        assert "antivirus" in LOCK_AV_APPLY_MESSAGE.lower()
-        assert "task manager" in LOCK_AV_VERIFY_MESSAGE.lower()
-        assert "end task" in LOCK_AV_VERIFY_MESSAGE.lower()
+        if sys.platform == "win32":
+            assert "task manager" in LOCK_AV_APPLY_MESSAGE.lower()
+            assert "vanillafixes.exe" in LOCK_AV_APPLY_MESSAGE.lower()
+            assert "end task" in LOCK_AV_APPLY_MESSAGE.lower()
+            assert "antivirus" in LOCK_AV_APPLY_MESSAGE.lower()
+            assert "task manager" in LOCK_AV_VERIFY_MESSAGE.lower()
+            assert "end task" in LOCK_AV_VERIFY_MESSAGE.lower()
+        else:
+            # Task Manager does not exist here, so the hint must not name it.
+            assert "task manager" not in LOCK_AV_APPLY_MESSAGE.lower()
+            assert "pkill" in LOCK_AV_APPLY_MESSAGE.lower()
+            assert "task manager" not in LOCK_AV_VERIFY_MESSAGE.lower()
+            assert "pkill" in LOCK_AV_VERIFY_MESSAGE.lower()
         assert user_facing_os_error(OSError(22, "Invalid argument")) == LOCK_AV_APPLY_MESSAGE
         assert (
             user_facing_os_error(OSError(22, "Invalid argument"), kept_install=True)
@@ -431,15 +438,21 @@ def test_dlls_txt():
         locked.winerror = 32  # type: ignore[attr-defined]
         locked_msg = user_facing_os_error(locked)
         assert "Errno" not in locked_msg
-        assert "task manager" in locked_msg.lower()
-        assert "end task" in locked_msg.lower()
         assert "wow.exe" in locked_msg.lower()
+        if sys.platform == "win32":
+            assert "task manager" in locked_msg.lower()
+            assert "end task" in locked_msg.lower()
+        else:
+            assert "pkill" in locked_msg.lower()
         title, body = format_mod_verify_warning(["unitxp"])
         assert title == "Could not verify install"
         assert "Errno" not in body
         assert "another process" in body.lower()
-        assert "task manager" in body.lower()
-        assert "antivirus" in body.lower()
+        if sys.platform == "win32":
+            assert "task manager" in body.lower()
+            assert "antivirus" in body.lower()
+        else:
+            assert "pkill" in body.lower()
         installed, removed, warns, fails = split_mod_apply_results(
             ["+ unitxp", "~ unitxp", "! other skipped: boom"]
         )
@@ -12367,6 +12380,135 @@ def test_wayland_window_move_and_resize_handoff():
     print("OK wayland window move/resize handoff")
 
 
+def test_linux_game_running_guard():
+    """wow_exe_running sees a client under the game dir on Linux, and hints stay actionable."""
+    import subprocess
+
+    import ichalaunch.core.filesystem as fsmod
+    import ichalaunch.core.process as procmod
+    from ichalaunch.addons.loadstate import GENERIC_LOCK_MESSAGE
+    from ichalaunch.core.filesystem import (
+        END_GAME_PROCESS_HINT,
+        LOCK_AV_APPLY_MESSAGE,
+        LOCK_AV_VERIFY_MESSAGE,
+        has_end_game_guidance,
+    )
+
+    # The Windows wording is a contract with existing users, so pin it from
+    # either platform. These are the exact strings master shipped.
+    assert fsmod._WIN_END_GAME_PROCESS_HINT == (
+        "Open Task Manager (Ctrl+Shift+Esc) and End task on WoW.exe and "
+        "VanillaFixes.exe if either is listed."
+    )
+    assert fsmod._WIN_OTHER_HOLDERS == (
+        "Overlays, Explorer previews, backup/sync, Controlled Folder Access, or "
+        "antivirus (not only Windows Defender) can also hold the file."
+    )
+    import ichalaunch.addons.loadstate as lsmod
+
+    assert lsmod._GENERIC_LOCK_LEAD + lsmod._WIN_GENERIC_LOCK_TAIL == (
+        "Could not move the addon folder. Close World of Warcraft if it is running, "
+        "then retry. Explorer, antivirus, or Git may also be locking files."
+    )
+
+    if sys.platform == "win32":
+        assert END_GAME_PROCESS_HINT == fsmod._WIN_END_GAME_PROCESS_HINT
+        assert "Controlled Folder Access" in LOCK_AV_APPLY_MESSAGE
+        assert "antivirus (not only Windows Defender)" in LOCK_AV_VERIFY_MESSAGE
+        assert GENERIC_LOCK_MESSAGE.endswith(lsmod._WIN_GENERIC_LOCK_TAIL)
+        assert has_end_game_guidance(LOCK_AV_APPLY_MESSAGE)
+        print("OK linux game running guard (win32 strings)")
+        return
+
+    # Nothing Windows-only may reach a Linux user through these five call sites.
+    for text in (END_GAME_PROCESS_HINT, LOCK_AV_APPLY_MESSAGE, LOCK_AV_VERIFY_MESSAGE,
+                 GENERIC_LOCK_MESSAGE):
+        low = text.lower()
+        assert "task manager" not in low, text
+        assert "explorer" not in low, text
+        assert "controlled folder access" not in low, text
+        assert "windows defender" not in low, text
+    assert "pgrep" in END_GAME_PROCESS_HINT and "pkill" in END_GAME_PROCESS_HINT
+    assert has_end_game_guidance(LOCK_AV_APPLY_MESSAGE)
+
+    # Detection lowercases both sides, so the remedy has to be case insensitive
+    # too. A client living at .../wow.exe is found by the guard, and the user is
+    # then handed a command that would not find it.
+    assert "-fai" in END_GAME_PROCESS_HINT, END_GAME_PROCESS_HINT
+    assert "pkill -fi" in END_GAME_PROCESS_HINT, END_GAME_PROCESS_HINT
+
+    # An argument has to END with the exe name. A backup beside the client, or a
+    # log line quoting the path, must not read as a running game.
+    assert procmod._arg_names_client("/games/rc/wow.exe", "/games/rc")
+    assert not procmod._arg_names_client("/games/rc/wow.exe.bak", "/games/rc")
+    assert not procmod._arg_names_client("/games/rc/wow.exe.log", "/games/rc")
+    # ...and it has to be under the install we are tied to.
+    assert not procmod._arg_names_client("/elsewhere/wow.exe", "/games/rc")
+
+    # With no configured install there is nothing to scope to. Answering "yes"
+    # there would block work on one install because another one is running.
+    assert procmod._proc_client_running(None) is False
+    assert procmod._proc_client_running("") is False
+    assert not has_end_game_guidance("Could not replace ClassicAPI.dll.")
+    assert fsmod._ensure_end_game_guidance("boom").endswith("Then retry Apply.")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        game = Path(tmp) / "RavenCraft"
+        other = Path(tmp) / "Elsewhere"
+        game.mkdir(parents=True)
+        other.mkdir(parents=True)
+
+        assert procmod._proc_client_running(game) is False
+
+        # An ordinary sleeping python whose argv carries a synthetic client path.
+        # No wine, no game, but /proc/<pid>/cmdline looks the way Wine's does.
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)", str(game / "WoW.exe")]
+        )
+        try:
+            deadline = time.time() + 10.0
+            seen = False
+            while time.time() < deadline:
+                if procmod._proc_client_running(game):
+                    seen = True
+                    break
+                time.sleep(0.05)
+            assert seen, "client under the game dir was not detected"
+            # Scoping: the same process must not answer for a different install.
+            assert procmod._proc_client_running(other) is False
+            # Prose is not a process: an argument merely mentioning the exe,
+            # such as this very test runner's own command line, must not count.
+            assert procmod._arg_names_client("end task on wow.exe if listed", "") is False
+            assert procmod._arg_names_client(
+                "end task on wow.exe if listed", procmod._norm_cmdline(str(game))
+            ) is False
+            assert procmod._arg_names_client(str(game / "WoW.exe").lower(), "") is True
+            # Wine reports Z:\home\..., so normalisation must still find the dir.
+            wine_style = "Z:" + str(game / "WoW.exe").replace("/", "\\")
+            assert procmod._norm_cmdline(str(game)).rstrip("/") in procmod._norm_cmdline(
+                wine_style
+            )
+            # And the guard the maintainer shipped must actually fire.
+            real_detect = procmod._configured_game_dir
+            procmod._configured_game_dir = lambda: game
+            try:
+                assert procmod.wow_exe_running() is True
+                hint = procmod.file_in_use_hint(game / "WoW.exe")
+                assert hint.startswith("WoW.exe")
+                assert has_end_game_guidance(hint)
+            finally:
+                procmod._configured_game_dir = real_detect
+        finally:
+            proc.kill()
+            proc.wait(timeout=10)
+
+        deadline = time.time() + 10.0
+        while time.time() < deadline and procmod._proc_client_running(game):
+            time.sleep(0.05)
+        assert procmod._proc_client_running(game) is False
+
+    print("OK linux game running guard")
+
 
 def main():
     import ichalaunch.config.settings as settings_mod
@@ -12593,6 +12735,7 @@ def _run_smoke_tests():
     test_chrome_buttons_clear_metal_tr()
     test_play_stays_right_when_progress_hidden()
     test_wayland_window_move_and_resize_handoff()
+    test_linux_game_running_guard()
     print("\nAll smoke tests passed.")
 
 


### PR DESCRIPTION
wow_exe_running() returned False on anything but Windows, so every caller that
depends on it was a no-op for Linux users. The worst of those is the lock in
install_mod: "if _mod_requires_game_closed(mod) and wow_exe_running()" could
never fire, and dll_file, dll_bundle, dxvk_cursor, dxvk_hd, exe_patch and
zip_root mods were installed straight into a live client tree. The inversion is
the point. On Windows the swap fails loudly because the running image is locked.
On Linux it does not, because Wine loads WoW.exe as data rather than exec'ing
it, so the kernel never sets ETXTBSY and a DLL or exe replacement under a
running client can succeed silently, leaving a half-old, half-new install.

Detection now reads /proc/<pid>/cmdline and matches on the client path rather
than the process name. Path matching scopes the answer to the install this
launcher is tied to, still catches a client someone started outside the
launcher, and avoids /proc/<pid>/comm, which truncates at 15 characters and so
never holds "VanillaFixes.exe". Both sides are lowercased with backslashes
turned into forward slashes, so Wine's Z:\home\you\Games\...\WoW.exe contains
the unix game directory as a plain substring. The exe name has to sit behind a
separator in an argv entry, otherwise a shell command or editor buffer that
merely mentions WoW.exe would trip the guard. Every /proc read is wrapped,
since a pid can vanish mid-scan and other users' entries are unreadable.
detect_game is imported at function level to match the rest of this module and
to avoid a cycle, since game/launcher.py imports from core/process.py.
processes_locking_paths() is deliberately left Windows-only; the equivalent
means walking /proc/<pid>/maps for every process and is a separate change.

A guard that fires and then gives impossible instructions would be worse than
no guard, so the user-facing text is platform-selected too.
TASK_MANAGER_END_GAME_HINT, which told people to open Task Manager and End task
on WoW.exe, reached Linux through five call sites along with "Explorer
preview", "Controlled Folder Access" and "antivirus (not only Windows
Defender)". It is now END_GAME_PROCESS_HINT, and on Linux it names pgrep and
pkill instead. The "other holders" sentence in file_in_use_hint() and
GENERIC_LOCK_MESSAGE in addons/loadstate.py get the same treatment. The
has-guidance checks that used to look for the literal words "task manager" move
into a shared has_end_game_guidance() so they keep working on both platforms.

Every Windows-visible string is unchanged, and the tasklist branch of
wow_exe_running() is byte-for-byte what it was.

---

Merges clean onto 7837c1c, independently of the other branches open from me.

Verification: detection is proven against a real process whose argv carries a synthetic client path, not
against a mock, and the test asserts it stops matching once that process exits. Scoping is asserted both
ways: a client under a different directory does not match, and an argument that merely ends near the exe
name (`wow.exe.bak`, `wow.exe.log`) does not match either. The Windows strings are pinned byte for byte
from either platform so this cannot quietly reword them. Nine existing tests over the touched files pass.
The whole thing fails against the unfixed code. No wine, umu or game process was run at any point.

Three things worth a reviewer's attention:

The Linux remedy is `pgrep -fai` / `pkill -fi`, case insensitive on purpose, because detection lowercases
both sides. Without the `i` the guard can correctly detect a client at `.../wow.exe` and then hand the
user a command that will not find it.

With no configured game directory the guard returns False rather than guessing. An unscoped match would
block work on one install because a client for an unrelated one is running. install_mod resolves the game
before reaching this guard, so only the diagnostic callers see that path.

`processes_locking_paths()` is deliberately left Windows-only. A Linux equivalent means walking
`/proc/<pid>/maps` for every process and belongs in its own change.

One added line carries an em dash. It is your existing Windows sentence about overlays and Explorer
previews, relocated verbatim into a `sys.platform == "win32"` branch. I would rather move your copy
unchanged than reword user-facing text in a PR that is not about wording.