### PR TITLE
Run the Vanilla Tweaks patcher through Proton, so Tweaks works on Linux at all

### DIFF
--- a/ichalaunch/core/process.py
+++ b/ichalaunch/core/process.py
@@ -486,6 +486,29 @@ def child_launch_env(base: dict[str, str] | None = None) -> dict[str, str]:
     return env
 
 
+def run_windows_exe(argv: list[str], cwd: Path) -> None:
+    """Run a Windows command line to completion, raising unless it exits 0.
+
+    The blocking sibling of launch_exe, and it dispatches the same way. On
+    Windows the executable runs directly. Everywhere else argv[0] is a PE that
+    the kernel refuses to exec (ENOEXEC unless the user happens to have a
+    binfmt_misc wine registration), so it goes through Proton, which is the
+    same route the game itself takes.
+
+    Used for the tools the launcher drives rather than hands to the player, the
+    Vanilla Tweaks patcher among them. Those have to be waited for: the caller
+    reads their output the moment they return.
+    """
+    if not argv:
+        raise ValueError("run_windows_exe needs a command")
+    if sys.platform == "win32":
+        subprocess.run(argv, cwd=str(cwd), check=True)
+        return
+    from ichalaunch.game.proton import run_windows_exe as _run_under_proton
+
+    _run_under_proton(Path(argv[0]), cwd, argv[1:])
+
+
 def launch_exe(path: Path, cwd: Path | None = None) -> subprocess.Popen:
     if not path.exists():
         raise FileNotFoundError(str(path))

--- a/ichalaunch/game/proton.py
+++ b/ichalaunch/game/proton.py
@@ -18,6 +18,7 @@ import re
 import shutil
 import subprocess
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 from ichalaunch.config.settings import appdata_root, settings
@@ -190,8 +191,51 @@ def wineprefix_for(game_dir: Path) -> Path:
     return appdata_root() / "prefixes" / game_dir.name
 
 
-def build_launch_command(exe: Path, cwd: Path) -> tuple[list[str], dict[str, str]]:
-    """argv and environment for running *exe* under umu. Raises if unusable."""
+def wine_arg(arg: str) -> str:
+    """One argument as the Windows program should see it.
+
+    Wine hands argv through untouched, so a POSIX path like
+    /home/me/WoW/WoW.exe arrives as a rooted path with no drive letter and gets
+    resolved against whatever drive the working directory happened to land on.
+    That is Z: today only because Z: is the default mapping for /, which makes a
+    working patch depend on a detail no code here controls. Naming Z: outright
+    removes the dependency.
+
+    Only an absolute path to something that already exists is rewritten, so
+    flags ("--farclip") and values ("777") are passed through untouched. A path
+    the tool is being asked to create would not survive that test, which is why
+    this is a helper for inputs and not a general argv filter.
+    """
+    if sys.platform == "win32" or not arg.startswith("/"):
+        return arg
+    try:
+        if not Path(arg).exists():
+            return arg
+    except OSError:
+        return arg
+    return "Z:" + arg.replace("/", "\\")
+
+
+def build_launch_command(
+    exe: Path,
+    cwd: Path,
+    args: Sequence[str] = (),
+    *,
+    for_game: bool = True,
+) -> tuple[list[str], dict[str, str]]:
+    """argv and environment for running *exe* under umu. Raises if unusable.
+
+    *args* are extra arguments for the Windows program itself, which is how a
+    command-line tool such as the Vanilla Tweaks patcher gets its flags.
+
+    *for_game* separates a real game session from a short-lived tool run, and
+    governs the two things that belong to the session rather than to Proton.
+    A tool is not pinned to the V-Cache CCD, because that pin is a frame rate
+    measure and narrowing a patcher's affinity only makes it slower. A tool
+    also never receives WOW_ENCRYPTION_KEY: only the client reads it, and a
+    third-party binary that prints its environment on failure would put it
+    somewhere a user can paste.
+    """
     umu = find_umu_run()
     if umu is None:
         raise FileNotFoundError(UMU_MISSING_MSG)
@@ -267,14 +311,19 @@ def build_launch_command(exe: Path, cwd: Path) -> tuple[list[str], dict[str, str
         # loader ran costs a round trip to find out.
         log.info("Launch mode: default (new WoW64 turned off in Settings)")
 
-    from ichalaunch.game.nampower_encrypt import apply_wow_encryption_env
+    from ichalaunch.game.nampower_encrypt import WOW_ENCRYPTION_ENV, apply_wow_encryption_env
 
-    apply_wow_encryption_env(env)
+    if for_game:
+        apply_wow_encryption_env(env)
+    else:
+        # Popped rather than simply not added, so an inherited value cannot ride
+        # along into a tool either.
+        env.pop(WOW_ENCRYPTION_ENV, None)
 
-    cmd = [str(umu), str(exe)]
+    cmd = [str(umu), str(exe), *(wine_arg(a) for a in args)]
     from ichalaunch.game.cpu_topology import vcache_pin_enabled
 
-    if vcache_pin_enabled():
+    if for_game and vcache_pin_enabled():
         from ichalaunch.game.cpu_topology import taskset_prefix
 
         affinity_argv = taskset_prefix()
@@ -332,6 +381,76 @@ def launch_windows_exe(exe: Path, cwd: Path) -> subprocess.Popen:
         if sink is not None:
             # The child holds its own descriptor; this one has done its job.
             sink.close()
+
+
+# umu builds the Wine prefix on first use and may fetch the Steam Linux Runtime
+# before it runs anything, so a patcher whose own work takes a second can sit
+# behind minutes of setup on a cold prefix. Generous on purpose: the point of
+# the limit is that a wedged run ends in a message instead of a spinner that
+# never stops, not that it ends quickly.
+WINDOWS_EXE_TIMEOUT = 900
+
+
+def run_windows_exe(
+    exe: Path,
+    cwd: Path,
+    args: Sequence[str] = (),
+    timeout: float = WINDOWS_EXE_TIMEOUT,
+) -> subprocess.CompletedProcess:
+    """Run *exe* to completion under umu, raising unless it exits cleanly.
+
+    The counterpart to launch_windows_exe, which starts the game and returns.
+    A command-line tool has to be waited for instead, because the caller's next
+    step reads what the tool wrote, and a non-zero exit has to be an exception
+    for the same reason: carrying on would inspect the state before the run.
+
+    Output is captured rather than sent to the launch log, so the exception can
+    quote what the tool complained about. Capturing also drains the pipes, which
+    matters because umu is chatty enough on a first run to fill one.
+    """
+    argv, env = build_launch_command(exe, cwd, args, for_game=False)
+    log.info("Running via umu: %s (proton=%s)", exe, env.get("PROTONPATH"))
+    try:
+        proc = subprocess.run(
+            argv,
+            cwd=str(cwd),
+            env=env,
+            shell=False,
+            capture_output=True,
+            text=True,
+            errors="replace",
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        # subprocess kills umu itself, but Proton's own children outlive it, so
+        # say what was left behind rather than implying the machine is clean.
+        raise RuntimeError(
+            f"{exe.name} did not finish within {int(timeout)} seconds under "
+            "Proton and was stopped. Wine processes may still be running; "
+            "the client has not been changed."
+        ) from exc
+
+    if proc.returncode != 0:
+        from ichalaunch.game.nampower_encrypt import redact_encryption_secrets
+
+        # This text reaches a user dialog and the app log, and umu or the tool
+        # may echo its environment on failure. Every other path that carries
+        # this stream is redacted; so is this one.
+        detail = redact_encryption_secrets(
+            _last_lines(proc.stderr) or _last_lines(proc.stdout)
+        )
+        suffix = f"\n\n{detail}" if detail else ""
+        raise RuntimeError(
+            f"{exe.name} failed under Proton with exit code "
+            f"{proc.returncode}.{suffix}"
+        )
+    return proc
+
+
+def _last_lines(text: str | None, limit: int = 12) -> str:
+    """The tail of a captured stream, for putting inside an error message."""
+    lines = [ln.rstrip() for ln in (text or "").splitlines() if ln.strip()]
+    return "\n".join(lines[-limit:])
 
 
 def is_linux() -> bool:

--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -6,7 +6,6 @@ import json
 import re
 import shutil
 import stat
-import subprocess
 import tempfile
 import time
 from dataclasses import dataclass, field
@@ -72,6 +71,7 @@ from ichalaunch.core.process import (
     download_file,
     file_in_use_hint,
     google_drive_url,
+    run_windows_exe,
     status_only,
     wow_exe_running,
 )
@@ -3030,7 +3030,11 @@ def install_mod(mod_id: str, progress: ProgressCb | None = None, *, prefer_lates
                 cmd = tweaks_patch_command(mod_id, vt, infile, opts)
                 status_only(progress, "Patching WoW.exe with Vanilla Tweaks...")
                 before_tweaked = tweaked_exe_snapshot(game)
-                subprocess.run(cmd, cwd=str(game), check=True)
+                # vanilla-tweaks.exe is a Windows PE, so off Windows this has to
+                # go through Proton. Running it directly raised OSError at exec
+                # time, which meant the headline feature of 1.3.0 could not work
+                # on Linux at all.
+                run_windows_exe(cmd, game)
                 tweaked = patched_exe_from_run(game, infile, wow, before_tweaked)
                 if tweaked is None:
                     raise FileNotFoundError(

--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -212,6 +212,23 @@ def migrate_legacy_pretty_night_sky_y(game_path: Path) -> bool:
     return True
 
 
+def swap_patched_client_exe(tweaked: Path, wow: Path) -> None:
+    """Put the patcher's output in place of the client binary, in one step.
+
+    Unlinking the client first meant that a rename which then failed left the
+    game with no client binary at all. That window is not theoretical: the
+    patched exe has just been written by an unsigned third-party patcher, which
+    is the single most likely moment for antivirus to hold it open, and the
+    unlink had already happened by then.
+
+    Path.replace is atomic within a directory on both Windows and Linux, so
+    WoW.exe is either the old build or the new one and never absent. A failure
+    now raises with the original still in place, which install_mod already
+    knows how to roll back.
+    """
+    tweaked.replace(wow)
+
+
 def _install_copy(src: Path, dest: Path, game_path: Path | None = None) -> None:
     """Copy into the game tree. DLLs/EXEs are never LoadLibrary'd; lock/AV → OSError skip."""
     if is_stock_data_mpq(dest):
@@ -2959,8 +2976,7 @@ def install_mod(mod_id: str, progress: ProgressCb | None = None, *, prefer_lates
                 if not tweaked.exists() and wow.stem != "WoW":
                     tweaked = game / "WoW_tweaked.exe"
                 if tweaked.exists():
-                    wow.unlink(missing_ok=True)
-                    tweaked.rename(wow)
+                    swap_patched_client_exe(tweaked, wow)
                 soft: list[str] = []
                 try:
                     if not validate_pe_binary(wow, min_size=_DLL_PE_MIN_BYTES):

--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -212,6 +212,64 @@ def migrate_legacy_pretty_night_sky_y(game_path: Path) -> bool:
     return True
 
 
+def tweaked_exe_snapshot(game: Path) -> dict[Path, tuple[int, float]]:
+    """Every ``*_tweaked.exe`` beside the client, with size and mtime.
+
+    Taken before the patcher runs so its output can be identified by what
+    actually changed rather than by guessing the filename it chose.
+    """
+    out: dict[Path, tuple[int, float]] = {}
+    try:
+        children = list(game.iterdir())
+    except OSError:
+        return out
+    for child in children:
+        if not child.name.lower().endswith("_tweaked.exe"):
+            continue
+        try:
+            if not child.is_file():
+                continue
+            st = child.stat()
+        except OSError:
+            continue
+        out[child] = (st.st_size, st.st_mtime)
+    return out
+
+
+def patched_exe_from_run(
+    game: Path,
+    infile: Path,
+    wow: Path,
+    before: dict[Path, tuple[int, float]],
+) -> Path | None:
+    """The executable the patcher just wrote, or None if it wrote nothing.
+
+    The patcher takes an input path and no output flag, so the name of its
+    output is whatever it derives from that input. Feeding it the stock backup,
+    which is what stops option changes from stacking, means the name follows the
+    backup and not the client. Named candidates are tried in that order first.
+
+    Only files that appeared or changed during this run are eligible. A
+    ``WoW_tweaked.exe`` left behind by an earlier run carries that run's
+    options, so installing it would quietly apply the wrong settings.
+
+    Anything else fresh is accepted as a last resort, so a filename change
+    upstream degrades into a working install rather than a silent no-op.
+    """
+    after = tweaked_exe_snapshot(game)
+    fresh = {path for path, meta in after.items() if before.get(path) != meta}
+    if not fresh:
+        return None
+    for candidate in (
+        game / f"{Path(infile).stem}_tweaked.exe",
+        game / f"{Path(wow).stem}_tweaked.exe",
+        game / "WoW_tweaked.exe",
+    ):
+        if candidate in fresh:
+            return candidate
+    return max(fresh, key=lambda path: after[path][1])
+
+
 def swap_patched_client_exe(tweaked: Path, wow: Path) -> None:
     """Put the patcher's output in place of the client binary, in one step.
 
@@ -2971,12 +3029,16 @@ def install_mod(mod_id: str, progress: ProgressCb | None = None, *, prefer_lates
                 )
                 cmd = tweaks_patch_command(mod_id, vt, infile, opts)
                 status_only(progress, "Patching WoW.exe with Vanilla Tweaks...")
+                before_tweaked = tweaked_exe_snapshot(game)
                 subprocess.run(cmd, cwd=str(game), check=True)
-                tweaked = game / f"{wow.stem}_tweaked.exe"
-                if not tweaked.exists() and wow.stem != "WoW":
-                    tweaked = game / "WoW_tweaked.exe"
-                if tweaked.exists():
-                    swap_patched_client_exe(tweaked, wow)
+                tweaked = patched_exe_from_run(game, infile, wow, before_tweaked)
+                if tweaked is None:
+                    raise FileNotFoundError(
+                        "Vanilla Tweaks exited successfully but wrote no patched "
+                        f"executable beside {infile.name}, so the client is "
+                        "unchanged."
+                    )
+                swap_patched_client_exe(tweaked, wow)
                 soft: list[str] = []
                 try:
                     if not validate_pe_binary(wow, min_size=_DLL_PE_MIN_BYTES):

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -560,6 +560,52 @@ def test_vanilla_tweaks_disable_clears_pending():
     print("OK vanilla tweaks disable clears pending")
 
 
+def test_vanilla_tweaks_exe_swap_is_atomic():
+    """A failed patched-exe swap leaves the client binary in place, not missing."""
+    from ichalaunch.mods.installer import swap_patched_client_exe
+
+    with tempfile.TemporaryDirectory() as td:
+        game = Path(td)
+        wow = game / "WoW.exe"
+        tweaked = game / "WoW_tweaked.exe"
+
+        wow.write_bytes(b"MZ" + b"old" * 64)
+        tweaked.write_bytes(b"MZ" + b"new" * 64)
+        original = wow.read_bytes()
+
+        # Happy path: the patched build lands and the scratch file is consumed.
+        swap_patched_client_exe(tweaked, wow)
+        assert wow.is_file()
+        assert wow.read_bytes().startswith(b"MZ" + b"new")
+        assert not tweaked.exists()
+
+        # Failure path, which is the regression this guards. Unlinking first
+        # left the game with no WoW.exe whenever the rename afterwards failed.
+        # A one-step replace cannot produce that state.
+        wow.write_bytes(original)
+        tweaked.write_bytes(b"MZ" + b"new" * 64)
+        real_replace = Path.replace
+
+        def refuse(self, target):
+            raise OSError(32, "The process cannot access the file")
+
+        Path.replace = refuse
+        try:
+            failed = False
+            try:
+                swap_patched_client_exe(tweaked, wow)
+            except OSError:
+                failed = True
+            assert failed, "a swap that cannot complete must raise, not pass silently"
+        finally:
+            Path.replace = real_replace
+
+        assert wow.is_file(), "WoW.exe must survive a swap that could not complete"
+        assert wow.read_bytes() == original, "the surviving WoW.exe must be the old build"
+        assert tweaked.is_file(), "the patched build must survive for a retry"
+    print("OK vanilla tweaks exe swap is atomic")
+
+
 def test_hand_patched_wow_exe_is_not_vanilla_tweaks():
     """Play must not restore stock WoW.exe over a hand-patched client (#280)."""
     from ichalaunch.config.settings import settings as s
@@ -12393,6 +12439,7 @@ def _run_smoke_tests():
     test_dlls_txt()
     test_detect_state()
     test_vanilla_tweaks_disable_clears_pending()
+    test_vanilla_tweaks_exe_swap_is_atomic()
     test_hand_patched_wow_exe_is_not_vanilla_tweaks()
     test_apply_desired_state_guard()
     test_mod_remove_desired_state()

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -606,6 +606,60 @@ def test_vanilla_tweaks_exe_swap_is_atomic():
     print("OK vanilla tweaks exe swap is atomic")
 
 
+def test_vanilla_tweaks_patcher_output_is_identified_or_fails():
+    """The patched exe is found by what the run wrote, and a no-op run is not success."""
+    import time as _time
+
+    from ichalaunch.mods.installer import patched_exe_from_run, tweaked_exe_snapshot
+
+    with tempfile.TemporaryDirectory() as td:
+        game = Path(td)
+        wow = game / "WoW.exe"
+        backup = game / "WoW-OriginalBackup.exe"
+        wow.write_bytes(b"MZ" + b"client" * 32)
+        backup.write_bytes(b"MZ" + b"stock" * 32)
+
+        # The real case. The patcher is fed the stock backup so option changes do
+        # not stack, so it names its output after the backup, not after WoW.exe.
+        before = tweaked_exe_snapshot(game)
+        out = game / "WoW-OriginalBackup_tweaked.exe"
+        out.write_bytes(b"MZ" + b"patched" * 32)
+        assert patched_exe_from_run(game, backup, wow, before) == out
+        out.unlink()
+
+        # A patcher that names its output after the client is also handled.
+        before = tweaked_exe_snapshot(game)
+        alt = game / "WoW_tweaked.exe"
+        alt.write_bytes(b"MZ" + b"patched" * 32)
+        assert patched_exe_from_run(game, backup, wow, before) == alt
+
+        # A stale file from an earlier run carries that run's options. A run that
+        # writes nothing must report nothing rather than reinstalling it.
+        before = tweaked_exe_snapshot(game)
+        assert patched_exe_from_run(game, backup, wow, before) is None
+
+        # Stale present and a fresh one written: the fresh one wins.
+        before = tweaked_exe_snapshot(game)
+        _time.sleep(0.01)
+        fresh = game / "WoW-OriginalBackup_tweaked.exe"
+        fresh.write_bytes(b"MZ" + b"newer" * 32)
+        assert patched_exe_from_run(game, backup, wow, before) == fresh
+        fresh.unlink()
+
+        # A name nobody predicted is still accepted, so an upstream rename
+        # degrades to a working install instead of a silent no-op.
+        before = tweaked_exe_snapshot(game)
+        odd = game / "vanillatweaks-output_tweaked.exe"
+        odd.write_bytes(b"MZ" + b"odd" * 32)
+        assert patched_exe_from_run(game, backup, wow, before) == odd
+        odd.unlink()
+
+        # An empty game folder is not a crash.
+        assert patched_exe_from_run(game, backup, wow, tweaked_exe_snapshot(game)) is None
+        assert tweaked_exe_snapshot(game / "does-not-exist") == {}
+    print("OK vanilla tweaks patcher output is identified or fails")
+
+
 def test_hand_patched_wow_exe_is_not_vanilla_tweaks():
     """Play must not restore stock WoW.exe over a hand-patched client (#280)."""
     from ichalaunch.config.settings import settings as s
@@ -12440,6 +12494,7 @@ def _run_smoke_tests():
     test_detect_state()
     test_vanilla_tweaks_disable_clears_pending()
     test_vanilla_tweaks_exe_swap_is_atomic()
+    test_vanilla_tweaks_patcher_output_is_identified_or_fails()
     test_hand_patched_wow_exe_is_not_vanilla_tweaks()
     test_apply_desired_state_guard()
     test_mod_remove_desired_state()

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -11400,6 +11400,155 @@ def test_linux_proton_launch_resolution():
     print("OK linux proton launch resolution")
 
 
+def test_windows_exe_runs_through_proton_and_blocks():
+    """The Vanilla Tweaks patcher is a PE, so off Windows it must go via Proton.
+
+    Runs a stand-in for umu-run (a shell script, never wine) to prove the call
+    passes the patcher's flags through, waits for the exit, turns a non-zero
+    exit and a hang into errors, and does not pin a patcher to the V-Cache CCD.
+    """
+    import inspect
+    import os
+    import stat as _stat
+
+    from ichalaunch.core.process import run_windows_exe as dispatch
+    from ichalaunch.game import proton
+    from ichalaunch.mods import installer
+
+    # The installer must call the dispatcher, not exec the PE itself.
+    src = inspect.getsource(installer.install_mod)
+    assert "run_windows_exe(cmd, game)" in src, "exe_patch does not dispatch"
+    assert "subprocess.run(cmd" not in src, "exe_patch still execs the PE directly"
+    # The Windows branch of the dispatcher stays a direct, checked run.
+    dsrc = inspect.getsource(dispatch)
+    assert 'sys.platform == "win32"' in dsrc, dsrc
+    assert "subprocess.run(argv, cwd=str(cwd), check=True)" in dsrc, dsrc
+
+    if sys.platform == "win32":
+        print("OK windows exe runs through proton and blocks (skipped on Windows)")
+        return
+
+    class _Stub:
+        def __init__(self, d):
+            self.d = dict(d)
+
+        def get(self, k, default=None):
+            return self.d.get(k, default)
+
+        def set(self, k, v):
+            self.d[k] = v
+
+    def _script(path, body):
+        path.write_text("#!/bin/sh\n" + body)
+        path.chmod(path.stat().st_mode | _stat.S_IXUSR)
+        return path
+
+    real = proton.settings
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            game = root / "WoW"
+            game.mkdir()
+            infile = game / "WoW-OriginalBackup.exe"
+            infile.write_bytes(b"MZ" + b"\0" * 64)
+            patcher = root / "vanilla-tweaks.exe"
+            patcher.write_bytes(b"MZ" + b"\0" * 64)
+            build = root / "GE-Proton10-34"
+            build.mkdir()
+            (build / "toolmanifest.vdf").write_text("x")
+
+            seen = root / "argv.txt"
+            ok = _script(root / "umu-ok", f"printf '%s\\n' \"$@\" > {seen}\nexit 0\n")
+            bad = _script(root / "umu-bad", "echo 'boom: bad prefix' 1>&2\nexit 3\n")
+            slow = _script(root / "umu-slow", "exec sleep 30\n")
+
+            def _use(umu):
+                proton.settings = _Stub({
+                    "linux_umu_path": str(umu),
+                    "linux_proton_path": str(build),
+                    "linux_use_latest_proton": False,
+                    "linux_wineprefix": str(root / "prefix"),
+                })
+
+            # A clean run blocks, so its output is already on disk on return.
+            _use(ok)
+            argv = ["--farclip", "777", str(infile)]
+            proc = proton.run_windows_exe(patcher, game, argv)
+            assert proc.returncode == 0
+            passed = seen.read_text().splitlines()
+            assert passed[0] == str(patcher), passed
+            assert passed[1:3] == ["--farclip", "777"], passed
+            # The infile is named on the drive Wine always maps to /, rather
+            # than left to resolve against whatever drive the cwd landed on.
+            assert passed[3] == "Z:" + str(infile).replace("/", "\\"), passed
+
+            # Nothing is pinned: narrowing a patcher's affinity only slows it.
+            cmd, env = proton.build_launch_command(patcher, game, argv, for_game=False)
+
+            # A tool never carries the client's encryption key, even when the
+            # setting is on and even when one is already in this environment.
+            import ichalaunch.game.nampower_encrypt as ne
+
+            os.environ[ne.WOW_ENCRYPTION_ENV] = "inherited-secret-value"
+            try:
+                _, tool_env = proton.build_launch_command(patcher, game, argv, for_game=False)
+                assert ne.WOW_ENCRYPTION_ENV not in tool_env, tool_env.get(ne.WOW_ENCRYPTION_ENV)
+            finally:
+                os.environ.pop(ne.WOW_ENCRYPTION_ENV, None)
+
+            # Captured tool output reaches a dialog and the log, so it goes
+            # through the same redactor every other path for this stream uses.
+            assert "redact_encryption_secrets" in inspect.getsource(proton.run_windows_exe)
+            assert cmd[0] == str(ok), cmd
+            assert env["PROTONPATH"] == str(build)
+
+            # A failed patch is an error, and says what the tool complained of.
+            _use(bad)
+            try:
+                proton.run_windows_exe(patcher, game, argv)
+                raise AssertionError("expected RuntimeError on non-zero exit")
+            except RuntimeError as exc:
+                assert "exit code 3" in str(exc), str(exc)
+                assert "boom: bad prefix" in str(exc), str(exc)
+
+            # A hang ends in a message, never a silent success.
+            _use(slow)
+            try:
+                proton.run_windows_exe(patcher, game, argv, timeout=2)
+                raise AssertionError("expected RuntimeError on timeout")
+            except RuntimeError as exc:
+                assert "did not finish" in str(exc), str(exc)
+                assert "has not been changed" in str(exc), str(exc)
+
+            # And the dispatcher routes here rather than exec'ing the PE.
+            _use(ok)
+            os.remove(seen)
+            dispatch([str(patcher), *argv], game)
+            assert seen.read_text().splitlines()[0] == str(patcher)
+
+            # Windows is untouched: the same argv, the same cwd string and the
+            # same check=True that the call site used before Proton entered it,
+            # and proton.py is never imported there.
+            import subprocess as _sp
+
+            calls = []
+            real_run = _sp.run
+            real_platform = sys.platform
+            try:
+                _sp.run = lambda *a, **kw: calls.append((a, kw))
+                sys.platform = "win32"
+                dispatch([str(patcher), *argv], game)
+            finally:
+                _sp.run = real_run
+                sys.platform = real_platform
+            assert calls == [(([str(patcher), *argv],),
+                             {"cwd": str(game), "check": True})], calls
+    finally:
+        proton.settings = real
+
+    print("OK windows exe runs through proton and blocks")
+
+
 def test_linux_wow64_default_on_when_supported():
     """New WoW64 is on by default, probed per build, and never set blind.
 
@@ -12613,6 +12762,7 @@ def _run_smoke_tests():
     test_owned_paths_are_comparison_keys_not_filenames()
     test_client_exe_probe_is_case_insensitive()
     test_linux_proton_launch_resolution()
+    test_windows_exe_runs_through_proton_and_blocks()
     test_linux_wow64_default_on_when_supported()
     test_linux_wow64_settings_checkbox()
     test_x3d_vcache_ccd_selection()


### PR DESCRIPTION
vanilla-tweaks.exe is a Windows PE, and install_mod's exe_patch branch handed
it straight to subprocess.run. Off Windows the kernel refuses to exec it
(ENOEXEC, unless the user happens to carry a binfmt_misc wine registration),
so the call raised at exec time. It failed safe, since the stock backup is
written before the run and the swap only happens after, but it meant the
headline feature of 1.3.0, on by default and reachable from both Apply and
Play, could never do anything on Linux.

The launcher already owns the mechanism: launch_windows_exe drives a PE
through umu-launcher with the pinned Proton build and the launcher's own
prefix. It was the wrong shape for a patcher, though. It returns a Popen and
does not wait, and it takes no arguments for the program itself, while the
patcher needs its flags and the very next statement reads what the run wrote
beside the input file.

build_launch_command therefore grows an args sequence and a pin_cpu switch, so
argv and environment are still composed in one place. Pinning is skipped for
tools: the V-Cache CCD pin is a frame-rate measure for the game, and narrowing
a patcher's affinity only slows it down. A new proton.run_windows_exe blocks on
that command, captures output so a failure can quote what the tool said, and
turns both a non-zero exit and a hang into a clear error rather than letting
the caller inspect a client that was never patched. The timeout is 900 seconds
because umu builds the prefix and may fetch the Steam Linux Runtime before the
patcher runs at all.

Arguments that are absolute paths to existing files are named on drive Z:,
which Wine maps to /. They worked before only because the working directory
happened to land on that same drive, which is a detail nothing here controls.

core.process.run_windows_exe dispatches the way launch_exe does. On Windows it
is the same subprocess.run(argv, cwd=str(cwd), check=True) the call site used
before, with the same argv and the same cwd string, and proton.py is not
imported on that branch. The new test asserts that equivalence by stubbing
subprocess.run under a win32 platform, and drives the Linux path against a
shell stand-in for umu-run rather than wine.

---

**Stacked on #342 and #345**, which touch the same lines. The first two of the three commits here are those
PRs. Merging them first leaves this one showing only its own commit.

Merges clean onto 7837c1c.

Verification, and what it does NOT cover. The test stands in three shell scripts for umu-run (one recording
argv and exiting 0, one writing to stderr and exiting 3, one hanging) and asserts the flags arrive in order,
the infile arrives in Z: form, a non-zero exit raises quoting the tool's own stderr, a hang raises saying the
client was not changed, and that win32 still takes a plain checked subprocess.run. It fails against the
unfixed code, and each half of the fix is independently necessary to it. Twenty existing tests over the
touched files pass, including every test covering the V-Cache pin, the frame cap and the WoW64 flag.

**No wine, umu, Proton or game process was run at any point.** So everything up to the exec boundary is
verified and the end-to-end claim, that Tweaks now actually patches WoW.exe on Linux, is NOT. Somebody with
a real umu install needs to run one Apply. Windows is unaffected by construction, but is likewise untested
on Windows hardware.

Four things a reviewer should weigh rather than take on trust:

The Z: rewrite assumes Wine's standing default that drive Z: maps to /. That holds for the prefix the
launcher creates, but a user pointing linux_wineprefix at an existing prefix with Z: removed would get a
path the patcher cannot open. Before this change the argument depended on the working directory landing on
Z: instead, which is a weaker guarantee, so I read this as an improvement rather than a new risk.

The 900 second timeout is a judgement call, not a measurement, because a cold umu first run has to build a
prefix. If it is too short the failure is loud rather than silent. On timeout subprocess kills umu-run, but
Proton's descendants can outlive it, and the message says so rather than implying the machine is clean.

On Linux an Apply or a Play-time sync can now block for up to that timeout where it previously failed in
milliseconds. It runs on a worker thread so the UI does not freeze, but the busy dialog has no progress and
no cancel.

The patcher never receives WOW_ENCRYPTION_KEY, and its captured output is passed through
redact_encryption_secrets before it can reach a dialog or the log. Routing the tool through
build_launch_command would otherwise have handed a third-party binary the key, and put it one env dump away
from a log a user pastes into a bug report.