### PR TITLE
Scope the Linux running-client check to the install, not to a name prefix

### DIFF
--- a/ichalaunch/core/process.py
+++ b/ichalaunch/core/process.py
@@ -332,14 +332,23 @@ def _arg_names_client(arg: str, needle: str) -> bool:
     The exe name has to sit behind a separator, so an argument that merely
     mentions WoW.exe in prose (a shell command, an editor buffer, a log line)
     cannot trip the guard. With a known game directory the same argument must
-    also carry that directory, which is the scoping guarantee.
+    also carry that directory as a path prefix, which is the scoping guarantee.
     """
     if not any(arg == name or arg.endswith(f"/{name}") for name in CLIENT_PROCESS_NAMES):
         # The argument has to END with the exe name. Requiring only that it
         # appears leaves "/games/wow/wow.exe.bak" and a log line quoting the
         # path matching just as well as the client itself.
         return False
-    return needle in arg if needle else True
+    root = needle.rstrip("/")
+    if not root:
+        return True
+    # The separator is part of the test because the game directory has to be a
+    # path PREFIX, not merely a substring. Without it an install at
+    # ".../RavenCraft" also matches a client running from ".../RavenCraft2", so
+    # one install refuses to accept changes while a different one is running.
+    # _path_is_under takes the same care on the Windows side, appending os.sep
+    # before it compares.
+    return f"{root}/" in arg
 
 
 def _configured_game_dir() -> Path | None:

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -14763,6 +14763,12 @@ def test_linux_game_running_guard():
     assert not procmod._arg_names_client("/games/rc/wow.exe.bak", "/games/rc")
     assert not procmod._arg_names_client("/games/rc/wow.exe.log", "/games/rc")
     assert not procmod._arg_names_client("/elsewhere/wow.exe", "/games/rc")
+    # A sibling whose name merely STARTS with the configured one is a different
+    # install. Without the separator these pass as a match and the launcher
+    # refuses to work on "rc" whenever "rc2" happens to be running.
+    assert not procmod._arg_names_client("/games/rc2/wow.exe", "/games/rc")
+    assert not procmod._arg_names_client("/games/rc-ptr/wow.exe", "/games/rc")
+    assert procmod._arg_names_client("/games/rc/wow.exe", "/games/rc/")
     assert procmod._arg_names_client("end task on wow.exe if listed", "") is False
     assert procmod._arg_names_client(
         "end task on wow.exe if listed", procmod._norm_cmdline("/games/rc")
@@ -14777,8 +14783,13 @@ def test_linux_game_running_guard():
     with tempfile.TemporaryDirectory() as tmp:
         game = Path(tmp) / "RavenCraft"
         other = Path(tmp) / "Elsewhere"
+        # "Elsewhere" shares no prefix with "RavenCraft", so it cannot show a
+        # substring match. A second install beside the first is the case that
+        # can, and running two side by side is ordinary on Linux.
+        sibling = Path(tmp) / "RavenCraft2"
         game.mkdir(parents=True)
         other.mkdir(parents=True)
+        sibling.mkdir(parents=True)
         wow = game / "WoW.exe"
         cmdlines = {"42": f"{wow}\x00".encode("utf-8")}
 
@@ -14799,6 +14810,14 @@ def test_linux_game_running_guard():
             with patch("builtins.open", fake_open):
                 assert procmod._proc_client_running(game) is True
                 assert procmod._proc_client_running(other) is False
+                # The configured install is the SIBLING; the client on /proc
+                # belongs to the shorter-named one. Nothing is running for the
+                # sibling, so this has to be False in both directions.
+                assert procmod._proc_client_running(sibling) is False
+                cmdlines["42"] = f"{sibling / 'WoW.exe'}\x00".encode("utf-8")
+                assert procmod._proc_client_running(sibling) is True
+                assert procmod._proc_client_running(game) is False
+                cmdlines["42"] = f"{wow}\x00".encode("utf-8")
                 wine_style = "Z:" + str(wow).replace("/", "\\")
                 assert procmod._norm_cmdline(str(game)).rstrip("/") in procmod._norm_cmdline(
                     wine_style


### PR DESCRIPTION
_arg_names_client already required an argv entry to END with a client exe name,
so a backup file or a log line quoting the path could not trip the guard. The
game directory half of the test stayed a bare substring, and a directory name is
a prefix of every longer name beginning with it. An install at .../RavenCraft
therefore matched a client running from .../RavenCraft2, and the launcher
refused to touch one install because a different one was running.

Two installs side by side is ordinary on Linux, where a second copy costs
nothing and is the usual way to keep a stable client while testing another.

The separator is now part of the comparison, which is what _path_is_under does a
few lines up for Windows image paths: it appends os.sep before comparing rather
than trusting a prefix match. Needles arrive from _proc_client_running already
stripped of a trailing slash; the strip is repeated in the helper so it is also
correct when called directly, which is how the tests reach it.

The existing coverage could not catch this. Its negative case was an "Elsewhere"
directory, which shares no prefix with "RavenCraft" and so passes on the old code
and the new alike. The fixture now carries a real sibling install and asserts
both directions, because the fault is one-directional: the shorter name wrongly
matches the longer, never the reverse. It is a false positive only, so it could
never let the launcher write to a live client.

Verified on Linux against live /proc, driving real processes with a crafted
argv[0] rather than mocks: the sibling case returns False where it returned True,
the client and VanillaFixes of the configured install still return True, and an
unrelated install and a .bak beside the client stay False. Full suite green at
252 checks.


Merge-clean onto 111c258 (v1.4.3): zero conflict markers via merge-tree. Full smoke suite green at 252 checks on Linux.
