### PR TITLE
Test the Wayland handoff against a stubbed platform instead of the developer's desktop

### DIFF
--- a/smoke_test.py
+++ b/smoke_test.py
@@ -14974,15 +14974,41 @@ def test_wayland_window_move_and_resize_handoff():
         def platformName():
             raise AssertionError("platformName must not be read without an instance")
 
+    class _FakeApp:
+        """An application exists and reports the platform it was given."""
+
+        def __init__(self, name):
+            self._name = name
+
+        def instance(self):
+            return self
+
+        def platformName(self):
+            return self._name
+
     try:
         mw._SYSTEM_WINDOW_MOVE = None
         mw.QGuiApplication = _NoApp
         assert mw._use_system_window_move() is False
         assert mw._SYSTEM_WINDOW_MOVE is None, "a pre-application answer must not be cached"
 
-        mw.QGuiApplication = real_qgui
-        assert mw._use_system_window_move() is False
-        assert mw._SYSTEM_WINDOW_MOVE is False
+        # Drive both branches from a stubbed platformName rather than from the
+        # real session. Asking the live QGuiApplication asserts that the machine
+        # running the suite is not on Wayland, which is a fact about the
+        # developer's desktop and not about the code: it passes on Windows, X11
+        # and the offscreen platform, and fails on a Wayland session, where this
+        # is the very feature under test.
+        for name, expected in (
+            ("windows", False),
+            ("xcb", False),
+            ("offscreen", False),
+            ("wayland", True),
+            ("wayland-egl", True),
+        ):
+            mw._SYSTEM_WINDOW_MOVE = None
+            mw.QGuiApplication = _FakeApp(name)
+            assert mw._use_system_window_move() is expected, name
+            assert mw._SYSTEM_WINDOW_MOVE is expected, name
     finally:
         mw.QGuiApplication = real_qgui
         mw._SYSTEM_WINDOW_MOVE = real_cache


### PR DESCRIPTION
test_wayland_window_move_and_resize_handoff restored the real QGuiApplication and
then asserted that _use_system_window_move() returns False. That asserts the machine
running the suite is not on Wayland, which is a fact about the developer's desktop
rather than about the code. It passes on Windows, on X11, and under the offscreen
platform, and it fails on a Wayland session, which is the one place the feature it
covers actually does anything.

The failure is not a soft one. The suite aborts there, so on a Wayland desktop the
remaining tests never run at all.

Both branches now come from a stubbed platformName rather than from the live
session, so the answer follows the platform under test instead of the host. That is
strictly more coverage than before: the loop drives windows, xcb and offscreen
through the False branch and wayland and wayland-egl through the True branch, and
it also pins the memoised value each time. wayland-egl in particular was never
exercised, even though matching it is the reason the guard uses startswith rather
than an equality test.

The pre-application case is unchanged and still asserts that nothing is cached
before an instance exists.

Verified on Linux. The test passes on a real Wayland session and under
QT_QPA_PLATFORM=offscreen, and it still fails as intended when the guard is forced
to return False, naming the platform that broke. Full suite green under offscreen
at 257 checks.

One thing worth flagging rather than leaving to be discovered: this removes the
first blocker on a Wayland desktop but not the only one. With it applied the suite
now reaches test 223 and stops at
test_cancel_git_url_checks_orphans_running_threads, an assertion about a thread
still being alive. That one passes in isolation on both platforms, so it looks like
an ordering or timing race that the real platform exposes and offscreen hides. It
is untouched here and is not related to this change, but nobody could see it before
because the suite never got that far.


Merge-clean onto 53c9b27 (v1.4.4). Full suite green under offscreen at 257 checks.
