### PR TITLE
Join leftover QThreads at teardown so a green run does not exit 134

### DIFF
--- a/smoke_test.py
+++ b/smoke_test.py
@@ -15102,6 +15102,40 @@ def test_linux_game_running_guard():
     print("OK linux game running guard")
 
 
+def _drain_qt_threads(wait_ms: int = 3000) -> tuple[list[str], list[str]]:
+    """Wait out any QThread still running, so the process can exit cleanly.
+
+    Qt's QThread destructor calls qFatal when the thread is still running, which
+    aborts the interpreter. That happens during teardown, AFTER every check has
+    passed, so a green run still exits 134 and any CI reading the exit code sees
+    failure. Nothing owns these threads by the end of the run, so they are found
+    by walking the heap rather than by bookkeeping.
+
+    Returns (joined, stuck) as lists of class names. A thread in *stuck* did NOT
+    stop: wait() timed out, the process may still abort, and requestInterruption
+    cannot help a thread that is blocked inside a call rather than between them.
+    """
+    import gc
+
+    from PySide6.QtCore import QThread
+
+    joined: list[str] = []
+    stuck: list[str] = []
+    for obj in gc.get_objects():
+        if not isinstance(obj, QThread):
+            continue
+        try:
+            if not obj.isRunning():
+                continue
+            obj.requestInterruption()
+            (joined if obj.wait(wait_ms) else stuck).append(type(obj).__name__)
+        except RuntimeError:
+            # Already deleted on the C++ side; nothing to wait for.
+            continue
+    return joined, stuck
+
+
+
 def main():
     import ichalaunch.config.settings as settings_mod
 
@@ -15423,6 +15457,13 @@ def _run_smoke_tests():
     test_wayland_window_move_and_resize_handoff()
     test_linux_game_running_guard()
     test_detect_and_installer_drop_unused_imports()
+    joined, stuck = _drain_qt_threads()
+    if joined:
+        names = ", ".join(sorted(set(joined)))
+        print(f"({len(joined)} QThread(s) still running at teardown, joined: {names})")
+    if stuck:
+        names = ", ".join(sorted(set(stuck)))
+        print(f"WARNING: {len(stuck)} QThread(s) did not stop: {names} - process may still abort")
     print("\nAll smoke tests passed.")
 
 


### PR DESCRIPTION
_run_smoke_tests ends with its final print and no teardown. Qt's QThread
destructor calls qFatal when the thread is still running, so the interpreter
aborts while shutting down, after every check has already passed. The run reports
success and then exits 134, which means anything reading the exit code sees a
failure on a suite that passed.

That is reproducible in four lines. A bare QApplication exits 0. A QApplication
whose QThread has finished exits 0. A QApplication with a QThread still running at
interpreter exit gives 134 every time.

Nothing owns those threads by the end of the run, so they are found by walking the
heap rather than by bookkeeping, and each one is interrupted and waited on.

Two things this deliberately does not do, because they are yours to judge rather
than mine to guess at.

It does not fix the leak. Four threads are still running when the suite finishes,
every run. This hides the resulting abort; it does not stop them leaking. The class
names are printed so the owner can be identified, and whether that belongs in the
tests or in the launcher is a question I cannot answer from outside.

It does not pretend a thread stopped when it did not. wait() returns a bool and it
is checked. Threads that stop are reported as joined; threads that do not are
reported separately with a warning that the process may still abort. Notably
requestInterruption cannot help a _BrowseUrlCheckThread that is already inside its
probe, because run() only tests the flag either side of the blocking call, so a
genuinely stuck thread costs the timeout and is then reported honestly rather than
counted as a success.

One limitation worth stating plainly: the drain is on the success path, so a
failing run still aborts at teardown. Fixing that means restructuring the runner,
which felt out of scope for a change this size.

Verified on Linux against a real Wayland session, where the suite reports 257
checks and exits 0.


Merge-clean onto 53c9b27 (v1.4.4). Full suite on a real Wayland session with this applied: 257 checks, exit 0.
