### PR TITLE
Hold the orphan-probe test's thread open instead of racing the scheduler

### DIFF
--- a/smoke_test.py
+++ b/smoke_test.py
@@ -12032,7 +12032,7 @@ def test_addons_all_filter_pagination_fully_loaded():
 def test_cancel_git_url_checks_orphans_running_threads():
     """Cancel must keep running QThreads alive — GC mid-run aborts Qt."""
     import gc
-    import time
+    import threading
     from unittest.mock import patch
 
     from PySide6.QtCore import QObject
@@ -12047,8 +12047,17 @@ def test_cancel_git_url_checks_orphans_running_threads():
     app = QApplication.instance() or QApplication([])
     owner = QObject()
 
+    # Hold the probe open until this test releases it, rather than racing a
+    # sleep. Every assertion below is about a thread that is STILL RUNNING, so
+    # a fixed delay makes them depend on the test body finishing first, which a
+    # loaded machine does not guarantee. The event removes the race instead of
+    # widening it, and keeps the intended path exercised on every run.
+    release_probe = threading.Event()
+    probe_entered = threading.Event()
+
     def _slow_reachable(url: str, *, timeout: float = 2.5) -> bool:  # noqa: ARG001
-        time.sleep(0.25)
+        probe_entered.set()
+        release_probe.wait(30)
         return True
 
     with patch(
@@ -12061,18 +12070,31 @@ def test_cancel_git_url_checks_orphans_running_threads():
         setattr(owner, "_git_url_check_gen", 1)
         setattr(owner, "_git_url_pending", thread._url)
         thread.start()
+        # Wait until run() is INSIDE the mocked probe. It tests
+        # isInterruptionRequested() before calling it (common.py:1231), and
+        # cancel_git_url_checks sets that flag, so a main thread that reaches
+        # cancel first makes run() return at that check without ever blocking.
+        # The thread then finishes, is reaped, and the assertions below fail on
+        # scheduling rather than on behaviour.
+        assert probe_entered.wait(10), "probe thread never reached the mocked call"
         assert thread.isRunning()
         alive = thread
-        cancel_git_url_checks(owner)
-        assert getattr(owner, "_git_url_threads", []) == []
-        assert alive in common._ORPHAN_GIT_URL_THREADS
-        # Drop every other ref and force GC — must not destroy the running QThread.
-        del thread
-        gc.collect()
-        assert common._shiboken_is_valid(alive)
-        # Still running (or just finished but not yet reaped from the orphan list).
-        assert alive.isRunning() or alive in common._ORPHAN_GIT_URL_THREADS
-        drain_orphan_git_url_threads(wait_ms=2000)
+        try:
+            cancel_git_url_checks(owner)
+            assert getattr(owner, "_git_url_threads", []) == []
+            assert alive in common._ORPHAN_GIT_URL_THREADS
+            # Drop every other ref and force GC — must not destroy the running QThread.
+            del thread
+            gc.collect()
+            assert common._shiboken_is_valid(alive)
+            # The event holds run() open, so this is now guaranteed rather than raced.
+            assert alive.isRunning()
+        finally:
+            # Release and join on every path. An assertion failing above must not
+            # leave the probe blocked: a running QThread at interpreter exit makes
+            # Qt abort the process, turning a readable test failure into SIGABRT.
+            release_probe.set()
+            drain_orphan_git_url_threads(wait_ms=2000)
         for _ in range(40):
             app.processEvents()
         assert alive not in common._ORPHAN_GIT_URL_THREADS


### PR DESCRIPTION
test_cancel_git_url_checks_orphans_running_threads mocked the probe with
time.sleep(0.25), then made four assertions about a thread that is still running.
That holds only while the sleep outlasts the rest of the test body, which a loaded
machine does not guarantee. Running the full suite on Linux, it failed there.

There are two races, and only the obvious one is the sleep. run() tests
isInterruptionRequested() at common.py:1231 before it calls the probe at 1235, and
cancel_git_url_checks sets that flag. So when the main thread reaches cancel before
the worker has executed line 1231, run() returns at that check without ever
blocking, the thread finishes, it is reaped, and the assertions fail on scheduling
rather than on behaviour. Widening the sleep does not help, because the thread never
reaches the sleep.

The probe now signals when it is entered and blocks on an event the test releases.
The test waits for that signal before cancelling, so the thread is provably past the
interruption check and inside the call. Both races close, and the assertion that had
been written as a disjunction becomes a plain isRunning() check because it is now
guaranteed.

Release and drain sit in a finally. If an assertion fails while the probe is held,
the thread is still running at interpreter exit and Qt aborts the process, which
would turn a readable failure into SIGABRT.

Verified by forcing the adverse ordering directly: without the entry gate the
orphaning fails 2 times in 12; with it, 12 of 12 pass. Also passes repeatedly in
isolation, sequentially and concurrently under load.


Merge-clean onto 53c9b27 (v1.4.4). Verified by forcing the adverse ordering (2/12 failures without the gate, 0/12 with) and by repeated isolated runs. A full-suite rerun with this exact revision is still outstanding; the earlier full-suite green run carried the previous, incomplete version of this fix.
