### PR TITLE
Refuse a launcher update that is not signed by a pinned key

### DIFF
--- a/IchaLaunch.spec
+++ b/IchaLaunch.spec
@@ -16,6 +16,8 @@ datas = [
 ]
 binaries: list[tuple[str, str]] = []
 hiddenimports = [
+    # Ed25519 verification for signed launcher updates.
+    "cryptography.hazmat.bindings._rust",
     "PySide6.QtCore",
     "PySide6.QtGui",
     "PySide6.QtWidgets",

--- a/ichalaunch/core/self_update.py
+++ b/ichalaunch/core/self_update.py
@@ -368,6 +368,67 @@ def _write_windows_replace_script(*, pid: int, src: Path, dest: Path) -> Path:
     return script
 
 
+SIGNATURE_ASSET_SUFFIX = ".sig"
+
+
+def _signature_url_for(info: "LauncherReleaseInfo") -> str:
+    """Where the detached signature for this release asset lives.
+
+    By convention the release carries ``IchaLaunch.exe`` and
+    ``IchaLaunch.exe.sig`` side by side, so the signature URL is the asset URL
+    plus a suffix. Publishing both is one extra upload in the release step.
+    """
+    return f"{info.download_url}{SIGNATURE_ASSET_SUFFIX}" if info.download_url else ""
+
+
+def _verify_staged_update(staged: Path, info: "LauncherReleaseInfo") -> None:
+    """Refuse to install a launcher build we cannot prove came from us.
+
+    This is the control that makes every other failure in the update path
+    survivable. Without it the only thing standing between a compromised
+    release credential and code execution on every player's machine is TLS to
+    GitHub, and TLS authenticates the server rather than the artefact.
+
+    Fails closed in every direction: no pinned keys, no signature asset, an
+    unreadable signature, or a signature that verifies under no trusted key all
+    raise. There is deliberately no override.
+    """
+    from ichalaunch.core.signing import (
+        Signature,
+        SignatureError,
+        signing_is_configured,
+        verify_bytes,
+    )
+
+    if not signing_is_configured():
+        raise SignatureError(
+            "This build pins no update-signing keys, so it cannot verify a "
+            "launcher update. Download the new version manually instead."
+        )
+
+    sig_url = _signature_url_for(info)
+    if not sig_url:
+        raise SignatureError("Release has no signature URL to check against")
+
+    sig_path = staged.with_name(staged.name + SIGNATURE_ASSET_SUFFIX)
+    try:
+        _download_asset(sig_url, sig_path)
+        signature = Signature.parse(sig_path.read_bytes())
+        key_id = verify_bytes(staged.read_bytes(), signature)
+    except SignatureError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - a missing/unreadable sig is a failure
+        raise SignatureError(
+            f"Could not fetch or read the signature for {info.asset_name}: {exc}"
+        ) from exc
+    finally:
+        try:
+            sig_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+    log.info("Launcher update %s verified against pinned key %s…", info.tag, key_id[:12])
+
+
 def download_and_stage_update(
     info: LauncherReleaseInfo,
     progress: ProgressCb | None = None,
@@ -390,6 +451,17 @@ def download_and_stage_update(
         known_total=info.asset_size,
     )
     _validate_pe_exe(tmp)
+    status_only(progress, "Verifying signature…")
+    try:
+        _verify_staged_update(tmp, info)
+    except Exception:
+        # Never leave an unverified executable lying in temp where a later step,
+        # or a user, could mistake it for a good build.
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
     status_only(progress, "Preparing installer…")
     return tmp
 

--- a/ichalaunch/core/signing.py
+++ b/ichalaunch/core/signing.py
@@ -1,0 +1,178 @@
+"""Ed25519 signature verification for anything the launcher installs.
+
+The rule this module exists to enforce: **the launcher trusts a signature, never
+a server.** Once a payload is covered by a signature from a key pinned below, it
+does not matter whether it arrived over HTTPS, from a CDN, from a torrent swarm,
+from a mirror, or from a stranger's USB stick. Everything that moves bytes
+becomes untrusted plumbing.
+
+A hash alone cannot do this job. A hash proves the bytes match a number; it says
+nothing about who chose the number. Whoever controls the host that publishes the
+hash also controls the file, so an attacker holding the release credential, the
+bucket keys, or DNS simply rewrites both. TLS authenticates the *server*, not the
+artefact. A hash detects corruption. A signature detects tampering.
+
+Why several pinned keys
+-----------------------
+A pinned key cannot revoke itself through the channel it controls. If exactly one
+key is pinned and it leaks, recovery means every player manually re-downloading
+over an unauthenticated channel, which is precisely what an attacker
+impersonates. So more than one key is pinned from the first release, only the
+first is ever used to sign, and the rest stay offline in different hands. On
+compromise a backup key signs a payload that names the bad key in ``revoke``,
+and clients drop it permanently.
+
+**Pinning extra keys costs nothing today and cannot be retrofitted later.**
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Pinned public keys. Raw Ed25519 public keys, 32 bytes, base64.
+#
+# Generate with tools/keygen.py, which emits all three at once and never writes
+# a private key anywhere but the path you name.
+#
+#   key 1  active signer
+#   key 2  offline backup, held by a different person, on removable media
+#   key 3  offline backup, held by a third person / printed
+#
+# Publish these fingerprints in the repo README, on the server's site, and in a
+# pinned message, so that a key swap in the repository alone is visible.
+# ---------------------------------------------------------------------------
+PINNED_KEYS: tuple[str, ...] = (
+    # PLACEHOLDER - replace before the first signed release. Empty tuple means
+    # verification cannot succeed, which is the correct failure direction.
+)
+
+SIGNATURE_SUFFIX = ".sig"
+
+
+class SignatureError(Exception):
+    """Raised when a payload is not covered by a trusted signature.
+
+    Callers must let this propagate. There is deliberately no 'continue anyway'
+    path and no --insecure flag: an update that cannot be verified is an update
+    that does not get installed.
+    """
+
+
+@dataclass(frozen=True)
+class Signature:
+    """A detached signature and the key that is claimed to have made it."""
+
+    key_id: str
+    signature: bytes
+
+    @classmethod
+    def parse(cls, raw: bytes | str) -> "Signature":
+        """Read the sidecar format: one JSON object, no comments, no options.
+
+        ``{"key_id": "<b64 pubkey>", "sig": "<b64 signature>"}``
+
+        Deliberately not PGP: keyrings, expiry surprises, and a verify that
+        succeeds for any key the machine happens to know are all traps for a
+        small team.
+        """
+        try:
+            text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+            obj = json.loads(text)
+            key_id = str(obj["key_id"]).strip()
+            signature = base64.b64decode(str(obj["sig"]).strip(), validate=True)
+        except Exception as exc:  # noqa: BLE001 - any malformed input is a failure
+            raise SignatureError(f"Signature file is not readable: {exc}") from exc
+        if len(signature) != 64:
+            raise SignatureError(
+                f"Signature is {len(signature)} bytes, expected 64 (Ed25519)"
+            )
+        return cls(key_id=key_id, signature=signature)
+
+
+def _load_public_key(b64: str):
+    """One pinned key as a cryptography public-key object."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    try:
+        raw = base64.b64decode(b64.strip(), validate=True)
+    except Exception as exc:  # noqa: BLE001
+        raise SignatureError(f"Pinned key is not valid base64: {exc}") from exc
+    if len(raw) != 32:
+        raise SignatureError(f"Pinned key is {len(raw)} bytes, expected 32 (Ed25519)")
+    return Ed25519PublicKey.from_public_bytes(raw)
+
+
+def trusted_keys(revoked: frozenset[str] = frozenset()) -> tuple[str, ...]:
+    """Pinned keys minus any that have been revoked by a signed payload."""
+    return tuple(k for k in PINNED_KEYS if k.strip() and k.strip() not in revoked)
+
+
+def verify_bytes(
+    payload: bytes,
+    signature: Signature,
+    *,
+    revoked: frozenset[str] = frozenset(),
+) -> str:
+    """Return the key id that signed *payload*, or raise ``SignatureError``.
+
+    The claimed ``key_id`` selects which pinned key to try, but it is not itself
+    trusted: an attacker can write anything there. It only narrows the search,
+    and a signature that verifies under no pinned key fails regardless.
+    """
+    from cryptography.exceptions import InvalidSignature
+
+    candidates = trusted_keys(revoked)
+    if not candidates:
+        raise SignatureError(
+            "No trusted signing keys are pinned in this build, so nothing can be "
+            "verified. This launcher will not install unverified updates."
+        )
+
+    ordered = [k for k in candidates if k.strip() == signature.key_id]
+    ordered += [k for k in candidates if k.strip() != signature.key_id]
+
+    for key_b64 in ordered:
+        try:
+            _load_public_key(key_b64).verify(signature.signature, payload)
+        except InvalidSignature:
+            continue
+        except SignatureError:
+            continue
+        return key_b64.strip()
+
+    raise SignatureError(
+        "Signature does not match any trusted key. The file was modified after "
+        "signing, or it was signed by a key this launcher does not trust."
+    )
+
+
+def verify_file(
+    path: Path,
+    sig_path: Path | None = None,
+    *,
+    revoked: frozenset[str] = frozenset(),
+) -> str:
+    """Verify *path* against its detached sidecar. Returns the signing key id.
+
+    Reads the payload once, from the same path the caller is about to use, so
+    there is no window between verifying one copy and installing another.
+    """
+    sig_path = sig_path or path.with_name(path.name + SIGNATURE_SUFFIX)
+    if not sig_path.is_file():
+        raise SignatureError(
+            f"No signature found beside {path.name}. Expected {sig_path.name}."
+        )
+    return verify_bytes(path.read_bytes(), Signature.parse(sig_path.read_bytes()), revoked=revoked)
+
+
+def signing_is_configured() -> bool:
+    """True when this build pins at least one key.
+
+    Lets callers give a clear message during the changeover, rather than a
+    confusing verification failure, while PINNED_KEYS is still empty.
+    """
+    return any(k.strip() for k in PINNED_KEYS)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-﻿PySide6>=6.6
+PySide6>=6.6
 requests>=2.31
 certifi
 PyInstaller>=6.0
+# Ed25519 verification for signed launcher updates (core/signing.py).
+cryptography>=42

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -15102,6 +15102,98 @@ def test_linux_game_running_guard():
     print("OK linux game running guard")
 
 
+def test_update_signature_verification():
+    """Signed-update verification: fails closed in every direction."""
+    import base64
+    import json
+    from unittest.mock import patch
+
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    import ichalaunch.core.signing as signing
+    from ichalaunch.core.signing import Signature, SignatureError
+
+    def keypair():
+        priv = Ed25519PrivateKey.generate()
+        raw = priv.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        return priv, base64.b64encode(raw).decode()
+
+    def sidecar(priv, payload, key_id):
+        return json.dumps(
+            {"key_id": key_id, "sig": base64.b64encode(priv.sign(payload)).decode()}
+        ).encode()
+
+    good_priv, good_pub = keypair()
+    evil_priv, evil_pub = keypair()
+    backup_priv, backup_pub = keypair()
+    payload = b"pretend this is IchaLaunch.exe" * 100
+
+    # An empty pin set must make verification IMPOSSIBLE, never skipped. A build
+    # that trusts nothing refuses to self-update rather than accepting anything.
+    with patch.object(signing, "PINNED_KEYS", ()):
+        assert signing.signing_is_configured() is False
+        try:
+            signing.verify_bytes(payload, Signature.parse(sidecar(good_priv, payload, good_pub)))
+            raise AssertionError("empty PINNED_KEYS accepted a signature")
+        except SignatureError:
+            pass
+
+    with patch.object(signing, "PINNED_KEYS", (good_pub, backup_pub)):
+        assert signing.signing_is_configured() is True
+        assert signing.verify_bytes(
+            payload, Signature.parse(sidecar(good_priv, payload, good_pub))
+        ) == good_pub
+        # A backup key is trusted too; that is the point of pinning spares.
+        assert signing.verify_bytes(
+            payload, Signature.parse(sidecar(backup_priv, payload, backup_pub))
+        ) == backup_pub
+
+        def rejects(label, payload_, raw_sig, **kw):
+            try:
+                signing.verify_bytes(payload_, Signature.parse(raw_sig), **kw)
+            except SignatureError:
+                return
+            raise AssertionError(label)
+
+        rejects("accepted a modified payload", payload + b"x", sidecar(good_priv, payload, good_pub))
+        rejects("accepted an untrusted key", payload, sidecar(evil_priv, payload, evil_pub))
+        # key_id is a HINT, not a credential: claiming a trusted id must not help.
+        rejects(
+            "a forged key_id was believed",
+            payload,
+            json.dumps(
+                {"key_id": good_pub, "sig": base64.b64encode(evil_priv.sign(payload)).decode()}
+            ).encode(),
+        )
+        # A revoked key stops being trusted even though it is still pinned.
+        rejects(
+            "a revoked key was accepted",
+            payload,
+            sidecar(good_priv, payload, good_pub),
+            revoked=frozenset({good_pub}),
+        )
+
+        # Malformed sidecars are failures, not warnings.
+        for bad in (
+            b"",
+            b"{}",
+            b"not json",
+            json.dumps({"key_id": good_pub, "sig": "!!"}).encode(),
+            json.dumps({"key_id": good_pub, "sig": base64.b64encode(b"short").decode()}).encode(),
+        ):
+            try:
+                Signature.parse(bad)
+                raise AssertionError(f"parsed a malformed signature: {bad!r}")
+            except SignatureError:
+                pass
+
+    print("OK update signature verification")
+
+
 def main():
     import ichalaunch.config.settings as settings_mod
 
@@ -15423,6 +15515,7 @@ def _run_smoke_tests():
     test_wayland_window_move_and_resize_handoff()
     test_linux_game_running_guard()
     test_detect_and_installer_drop_unused_imports()
+    test_update_signature_verification()
     print("\nAll smoke tests passed.")
 
 

--- a/tools/keygen.py
+++ b/tools/keygen.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Generate the launcher's update-signing keys. Run this ONCE, before the first
+signed release.
+
+Three keypairs are generated, not one. All three public keys get pinned in the
+launcher; only key 1 is ever used to sign. Keys 2 and 3 go offline, in different
+people's hands.
+
+Why three, and why now
+----------------------
+A pinned key cannot revoke itself through the channel it controls. Pin only one
+key, and if it leaks the recovery path is every player manually re-downloading
+over an unauthenticated channel, which is exactly what an attacker impersonates.
+With backups pinned, key 2 signs a release that names key 1 as revoked and
+players recover automatically.
+
+**Pinning spare keys costs nothing today and cannot be added afterwards.** Every
+launcher already in the wild only trusts the keys it shipped with.
+
+Usage:
+    python tools/keygen.py --out ./keys
+
+Then paste the printed PINNED_KEYS block into ichalaunch/core/signing.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import getpass
+import os
+import stat
+import sys
+from pathlib import Path
+
+KEY_COUNT = 3
+ROLES = {
+    1: "ACTIVE SIGNER  - used for every release. Keep on the signing machine.",
+    2: "BACKUP         - offline, held by a DIFFERENT person, on removable media.",
+    3: "BACKUP         - offline, held by a THIRD person. Paper copy is fine.",
+}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", type=Path, default=Path("keys"), help="directory for private keys")
+    ap.add_argument("--force", action="store_true", help="overwrite existing key files")
+    args = ap.parse_args()
+
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    out: Path = args.out
+    out.mkdir(parents=True, exist_ok=True)
+
+    existing = [p for p in (out / f"ichalaunch-key{i}.pem" for i in range(1, KEY_COUNT + 1)) if p.exists()]
+    if existing and not args.force:
+        print("Refusing to overwrite existing keys:", file=sys.stderr)
+        for p in existing:
+            print(f"  {p}", file=sys.stderr)
+        print("\nRe-running would invalidate every signature made so far.", file=sys.stderr)
+        print("Pass --force only if you are certain.", file=sys.stderr)
+        return 1
+
+    print("Each private key is encrypted with a password. Use a different one per key,")
+    print("and store them in a password manager. Losing a password loses that key.\n")
+
+    publics: list[str] = []
+    for i in range(1, KEY_COUNT + 1):
+        print(f"--- key {i}: {ROLES[i]}")
+        while True:
+            pw = getpass.getpass(f"    password for key {i}: ")
+            if len(pw) < 12:
+                print("    too short; use at least 12 characters.")
+                continue
+            if pw == getpass.getpass(f"    confirm password for key {i}: "):
+                break
+            print("    passwords did not match.")
+
+        priv = Ed25519PrivateKey.generate()
+        pem = priv.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.BestAvailableEncryption(pw.encode()),
+        )
+        path = out / f"ichalaunch-key{i}.pem"
+        path.write_bytes(pem)
+        try:
+            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)  # 0600
+        except OSError:
+            pass
+
+        raw = priv.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        publics.append(base64.b64encode(raw).decode())
+        print(f"    wrote {path}\n")
+
+    print("=" * 72)
+    print("Paste this into ichalaunch/core/signing.py, replacing PINNED_KEYS:\n")
+    print("PINNED_KEYS: tuple[str, ...] = (")
+    for i, pub in enumerate(publics, start=1):
+        print(f'    # key {i} - {ROLES[i].split("-")[0].strip()}')
+        print(f'    "{pub}",')
+    print(")")
+    print("=" * 72)
+    print("\nAlso publish these fingerprints where players can compare them:")
+    print("the repository README, the server's website, and a pinned message.")
+    print("A key swapped in the repo alone should be visible somewhere else.\n")
+    print("NOW, before you forget:")
+    print(f"  - move {out}/ichalaunch-key2.pem and key3.pem OFF this machine")
+    print("  - give key 2 to someone else, on removable media")
+    print("  - never put any of these in CI secrets, a repo, or a cloud drive")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sign.py
+++ b/tools/sign.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Sign a release artefact so the launcher will accept it.
+
+Usage:
+    python tools/sign.py --key keys/ichalaunch-key1.pem dist/IchaLaunch.exe
+
+Writes ``dist/IchaLaunch.exe.sig`` beside it. Upload BOTH to the release.
+
+Fails closed
+------------
+Before it exits, this re-verifies its own output using the exact same verifier
+the launcher imports, against the keys actually pinned in this checkout. So a
+signature made with a key nobody trusts, or a mismatched file, is caught here
+rather than by every player at once.
+
+The private key never leaves this machine and is never read by CI. If signing
+ever moves into a GitHub Action, the scheme is worthless: anyone who can push a
+workflow file can read the secret, which reduces "trusted release" back to
+"whoever has repo access".
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import getpass
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("target", type=Path, help="file to sign")
+    ap.add_argument("--key", type=Path, required=True, help="private key PEM from keygen.py")
+    ap.add_argument("--out", type=Path, default=None, help="signature path (default: <target>.sig)")
+    args = ap.parse_args()
+
+    from cryptography.hazmat.primitives import serialization
+
+    from ichalaunch.core.signing import (
+        Signature,
+        SignatureError,
+        signing_is_configured,
+        verify_bytes,
+    )
+
+    if not args.target.is_file():
+        print(f"No such file: {args.target}", file=sys.stderr)
+        return 1
+    if not args.key.is_file():
+        print(f"No such key: {args.key}", file=sys.stderr)
+        return 1
+
+    payload = args.target.read_bytes()
+    pw = getpass.getpass(f"password for {args.key.name}: ").encode()
+    try:
+        priv = serialization.load_pem_private_key(args.key.read_bytes(), password=pw)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Could not unlock the key: {exc}", file=sys.stderr)
+        return 1
+
+    pub_raw = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    key_id = base64.b64encode(pub_raw).decode()
+    sig = priv.sign(payload)
+
+    sidecar = json.dumps(
+        {"key_id": key_id, "sig": base64.b64encode(sig).decode()},
+        indent=2,
+    ) + "\n"
+
+    # Verify BEFORE writing anything, using the launcher's own code path.
+    if not signing_is_configured():
+        print(
+            "This checkout pins no keys in ichalaunch/core/signing.py, so the "
+            "signature cannot be checked and no launcher would accept it.\n"
+            "Run tools/keygen.py and paste PINNED_KEYS in first.",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        used = verify_bytes(payload, Signature.parse(sidecar))
+    except SignatureError as exc:
+        print(f"Refusing to write a signature the launcher would reject: {exc}", file=sys.stderr)
+        return 1
+
+    out = args.out or args.target.with_name(args.target.name + ".sig")
+    out.write_text(sidecar, encoding="utf-8")
+    print(f"  signed  {args.target}")
+    print(f"  wrote   {out}")
+    print(f"  key     {used[:16]}…  (verified against the pinned set)")
+    print("\nUpload BOTH files to the release. A release without its .sig will be")
+    print("refused by every launcher that has this verification.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
self_update.py downloads a replacement IchaLaunch.exe from a GitHub release and
hands it to apply_windows_self_replace, which overwrites the running executable
and relaunches. The only check between the download and that swap is

    if dest.stat().st_size < 1024:
        raise RuntimeError("Downloaded launcher update looks too small")

plus an MZ header test. So the trust anchor is TLS to GitHub and the release
credential, and nothing else. Anyone able to publish to that release, whether by
a leaked token, a compromised account, or a workflow change, reaches every
player's machine on their next launch with no interaction required.

TLS authenticates the server, not the artefact. A hash published beside the file
does not fix it either, because whoever can replace the file can replace the
hash. The artefact has to carry its own proof, so this adds a detached Ed25519
signature checked against public keys compiled into the launcher. Once that
holds, the release host, any mirror, and any future CDN become untrusted
plumbing rather than things that have to be defended.

The new module is core/signing.py. It fails closed in every direction: no pinned
keys, a missing .sig asset, an unreadable sidecar, or a signature that verifies
under no trusted key all raise, and a staged executable that fails is deleted
rather than left in temp where it might be mistaken for a good build. There is
no override flag, deliberately.

Three points that are easy to get wrong and are handled here:

The claimed key_id in the sidecar is a hint, not a credential. It only decides
which pinned key to try first; a signature made with an untrusted key is refused
however it labels itself.

More than one key is pinned from the start. A pinned key cannot revoke itself
through the channel it controls, so with a single key a leak means every player
re-downloading manually over an unauthenticated channel, which is exactly what
an attacker would impersonate. With spares pinned, a backup key can sign a
release that names the bad one in revoke. This cannot be retrofitted later,
because launchers already in the wild trust only the keys they shipped with.

Signing never happens in CI. tools/sign.py runs locally, and re-verifies its own
output through the same code path the launcher uses before it writes anything.
If the key lived in an Actions secret, anyone who could push a workflow file
could read it, and "trusted release" would collapse back to "has repo access".

PINNED_KEYS ships empty, so this build cannot self-update yet and says so
plainly. Run tools/keygen.py, paste the block it prints, and publish the
fingerprints somewhere other than this repository so a key swapped here alone is
visible. Releases then carry IchaLaunch.exe and IchaLaunch.exe.sig together.

cryptography is added to requirements and to the PyInstaller hiddenimports.
Tested on Linux: the new smoke test covers the happy path, a backup key, a
tampered payload, an untrusted key, a forged key_id, a revoked key, and five
malformed sidecars. The Windows replace path is unchanged and still needs a
Windows run to confirm end to end.


Merge-clean onto 53c9b27 (v1.4.4). New smoke test passes; the Windows self-replace path is unchanged and still wants a Windows run to confirm end to end.
