### PR TITLE
Centre a width-fit Home slide instead of pinning it to the banner

### DIFF
--- a/ichalaunch/ui/widgets/talent_bg.py
+++ b/ichalaunch/ui/widgets/talent_bg.py
@@ -458,13 +458,22 @@ class TalentFrameBackground(QWidget):
             nudge_x = int(slide.get("nudge_x") or 0)
             nudge_y = int(slide.get("nudge_y") or 0)
             if str(slide.get("fit") or "") == "width":
-                # Full width, no L/R crop — honor unusual AR; pin to banner.
+                # Full width, no L/R crop — honor unusual AR; centre the rest.
+                #
+                # A width-fit slide is wider in aspect than the brand rect, so
+                # scaling it to the width always leaves a vertical remainder:
+                # the featured 2:1 slide paints 542 tall in a 745 tall column.
+                # Pinning to the banner banked all 203px of that above the
+                # frame, which reads as a picture that has slipped down its
+                # wall. Splitting the remainder is the only option that does
+                # not crop: cover fills the rect but takes ~14% off each side,
+                # and the featured slide carries its caption out there.
                 dest_w = max(1, w - shrink_w) if shrink_w else w
                 scaled = src.scaledToWidth(
                     dest_w, Qt.TransformationMode.SmoothTransformation
                 )
                 x = (w - scaled.width()) // 2
-                y = h - scaled.height()
+                y = max(0, (h - scaled.height()) // 2)
             else:
                 # Cover the brand rect (center crop). Widget itself is
                 # bottom-tucked to the nav banner.

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -15165,6 +15165,50 @@ def test_detect_and_installer_drop_unused_imports():
     print("OK detect/installer carry no unused module-level imports")
 
 
+def test_home_art_width_fit_is_centred():
+    """A width-fit slide splits its leftover height instead of banking it on top."""
+    from PySide6.QtCore import QPoint
+    from PySide6.QtGui import QImage, QPainter
+    from PySide6.QtWidgets import QApplication
+
+    from ichalaunch.ui.widgets.talent_bg import TalentFrameBackground
+
+    app = QApplication.instance() or QApplication([])
+    del app
+
+    # The featured slide is 2:1 in a rect that is not, so scaling it to the
+    # width always leaves a vertical remainder. Bottom-pinning put all of it
+    # above the frame, which read as a picture that had slipped down its wall.
+    w, h = 880, 660
+    art = TalentFrameBackground()
+    art.set_frame(0, 0, w, h)
+    art.resize(w, h)
+
+    img = QImage(w, h, QImage.Format.Format_ARGB32)
+    img.fill(0)
+    painter = QPainter(img)
+    art.render(painter, QPoint(0, 0))
+    painter.end()
+
+    def row_is_painted(y: int) -> bool:
+        return any(img.pixelColor(x, y).alpha() > 8 for x in range(0, w, 16))
+
+    painted = [y for y in range(h) if row_is_painted(y)]
+    assert painted, "nothing was painted"
+    top_band = painted[0]
+    bottom_band = h - 1 - painted[-1]
+
+    # Bottom-pinned put the whole remainder above the frame and nothing below,
+    # so the test that matters is that both bands are substantial.
+    assert top_band > 40, f"no real band above the picture (top={top_band})"
+    assert bottom_band > 40, f"picture is still pinned to the bottom (bottom={bottom_band})"
+    # Not equal to the pixel: the edge mask feathers the top softly and the
+    # bottom hard, so where "painted" starts differs by a few rows at each end.
+    ratio = min(top_band, bottom_band) / max(top_band, bottom_band)
+    assert ratio > 0.8, f"bands are not a split: {top_band} vs {bottom_band}"
+    print("OK home art width-fit slide is vertically centred")
+
+
 def _run_smoke_tests():
     test_catalogs()
     test_tls_ca_env_sanitizer()
@@ -15423,6 +15467,7 @@ def _run_smoke_tests():
     test_wayland_window_move_and_resize_handoff()
     test_linux_game_running_guard()
     test_detect_and_installer_drop_unused_imports()
+    test_home_art_width_fit_is_centred()
     print("\nAll smoke tests passed.")
 
 


### PR DESCRIPTION
The featured Home slide is 1024x512, exactly 2:1. The brand rect it sits in is nearer 1.46:1, so scaling the art to the width always leaves a vertical remainder: about 542px of picture in a 745px column, with roughly 200px left over.

`fit: width` pinned the picture to the bottom, so all of that remainder sat above the frame. On screen it reads as a picture that has slipped down its wall rather than one hung on it.

This splits the remainder instead, so the frame sits in the middle of the column.

I tried `cover` first, which fills the rect completely. It is the wrong answer here: at this aspect ratio it crops about 14% off each side, and this slide carries its caption text out there, so the crop eats into it. Centring is the only option that cannot damage the artwork.

Test renders the slide and asserts there is a clear band above and below, within 20% of each other. Bottom pinned would give the whole remainder on top and nothing underneath, which is what the test fails on if this regresses.
