### PR TITLE
Let the Home gallery be paged by hand

### DIFF
--- a/ichalaunch/ui/pages/home.py
+++ b/ichalaunch/ui/pages/home.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import (
 from ichalaunch.core.paths import theme_file
 from ichalaunch.game.launcher import detect_game, is_installed
 from ichalaunch.mods.installer import detect_actual_state, load_mod_catalog
-from ichalaunch.ui.widgets.common import open_url_in_browser
+from ichalaunch.ui.widgets.common import SpellbookPageButton, open_url_in_browser
 from ichalaunch.ui.widgets.glue_panel_button import GLUE_BTN_H, GluePanelButton
 from ichalaunch.ui.widgets.mods_forest_bg import HomeModsCard
 from ichalaunch.ui.widgets.talent_bg import TalentFrameBackground
@@ -60,6 +60,8 @@ _ART_BOTTOM_INSET_PX = 0
 # Hide the hard art / black fringe under the grey banner bar (not into spike valleys).
 # A few extra px closes the visible gap so rotating art meets the nav banner.
 _ART_BANNER_TUCK_PX = 12
+# Inset of the gallery page arrows from the art's own left/right edges.
+_ART_ARROW_PAD_PX = 10
 # MoA wordmark prefer width, centered along the art bottom.
 _MOA_ART_LOGO_W = 190  # ~5% under prior 200px prefer width
 # Pad from art bottom for the MoA wordmark.
@@ -177,6 +179,16 @@ class HomePage(QWidget):
         self.talent_bg = TalentFrameBackground(self)
         self.talent_bg.frame_changed.connect(self._sync_brand_layout)
 
+        # Page arrows for the gallery, same art and size the Addons catalog
+        # already pages with, so "turn to the next one" looks the same in both
+        # places.
+        self.art_prev = SpellbookPageButton("prev", self)
+        self.art_next = SpellbookPageButton("next", self)
+        self.art_prev.setToolTip("Previous")
+        self.art_next.setToolTip("Next")
+        self.art_prev.clicked.connect(lambda: self.talent_bg.step(-1))
+        self.art_next.clicked.connect(lambda: self.talent_bg.step(1))
+
         self.logo = QLabel(self)
         self.logo.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.logo.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
@@ -214,6 +226,8 @@ class HomePage(QWidget):
         return (
             self.talent_bg,
             self.logo,
+            self.art_prev,
+            self.art_next,
         )
 
     def _overlay_host(self) -> QWidget | None:
@@ -271,6 +285,9 @@ class HomePage(QWidget):
     def _set_chrome_visible(self, visible: bool) -> None:
         self.talent_bg.setVisible(visible)
         self.logo.setVisible(visible)
+        pageable = visible and self.talent_bg.slide_count() > 1
+        self.art_prev.setVisible(pageable)
+        self.art_next.setVisible(pageable)
         banner = self._nav_bottom_banner()
         if banner is not None:
             banner.update()
@@ -374,6 +391,17 @@ class HomePage(QWidget):
             logo_y = art.y()
         self.logo.setGeometry(logo_x, logo_y, logo_w, logo_h)
 
+        # --- gallery page arrows, centred on the picture's left/right edges ---
+        # Centred on paint_h, not on art.height(): the widget is the taller of
+        # the two (it tucks under the grey bar) and the picture centres inside
+        # the widget, so paint_h is what the arrows have to agree with.
+        arrow = self.art_prev.height() or GLUE_BTN_H
+        arrow_y = art.y() + (paint_h - arrow) // 2
+        self.art_prev.move(art.x() + _ART_ARROW_PAD_PX, arrow_y)
+        self.art_next.move(
+            art.x() + art.width() - arrow - _ART_ARROW_PAD_PX, arrow_y
+        )
+
         self._set_chrome_visible(True)
 
         # Z-order (back → front on Root):
@@ -412,6 +440,9 @@ class HomePage(QWidget):
                         btn.raise_()
         if isinstance(rc, QWidget):
             rc.raise_()
+
+        self.art_prev.raise_()
+        self.art_next.raise_()
 
         art_bottom_now = art.y() + art.height()
         gap = art_bottom - art_bottom_now

--- a/ichalaunch/ui/widgets/talent_bg.py
+++ b/ichalaunch/ui/widgets/talent_bg.py
@@ -507,17 +507,41 @@ class TalentFrameBackground(QWidget):
             _draw(self._slide_at(self._next_index), self._nxt_opacity)
         painter.end()
 
+    def slide_count(self) -> int:
+        return len(self._slides)
+
+    def step(self, delta: int) -> None:
+        """Turn the gallery by hand, forwards or back.
+
+        Public because the Home page puts page arrows either side of the art.
+        A click during a crossfade is dropped rather than queued: the fade owns
+        _index until it finishes, and stacking turns on top of it reads as the
+        gallery lurching.
+        """
+        if delta:
+            self._turn(1 if delta > 0 else -1)
+
     def _advance(self) -> None:
+        self._turn(1)
+
+    def _turn(self, step: int) -> None:
         if len(self._slides) < 2:
             return
         if self._fade is not None and self._fade.state() == QParallelAnimationGroup.State.Running:
             return
 
-        self._next_index = (self._index + 1) % len(self._slides)
+        # Drop the pending auto-turn. Without this a hand-turned slide keeps
+        # whatever was left of the previous slide's hold and can flip again
+        # immediately, which looks like a double click registering.
+        self._timer.stop()
+
+        self._next_index = (self._index + step) % len(self._slides)
         nxt = self._slide_at(self._next_index)
         if nxt is not None:
             self._pixmap(str(nxt.get("image") or ""))
-        after = self._slide_at((self._next_index + 1) % len(self._slides))
+        # Prefetch in the direction of travel, so paging back is as warm as
+        # paging forward.
+        after = self._slide_at((self._next_index + step) % len(self._slides))
         if after is not None:
             self._pixmap(str(after.get("image") or ""))
 

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -15165,6 +15165,48 @@ def test_detect_and_installer_drop_unused_imports():
     print("OK detect/installer carry no unused module-level imports")
 
 
+def test_home_gallery_page_arrows():
+    """Prev/Next sit inside the art and turn the gallery both ways, wrapping."""
+    from PySide6.QtWidgets import QApplication
+
+    from ichalaunch.ui.main_window import MainWindow
+
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow()
+    win.resize(1500, 950)
+    win.show()
+    for _ in range(400):
+        app.processEvents()
+
+    home = win.home
+    art, prev, nxt = home.talent_bg, home.art_prev, home.art_next
+    count = art.slide_count()
+    assert count > 1, "gallery needs at least two slides to page"
+    assert prev.isVisible() and nxt.isVisible()
+
+    ag, pg, ng = art.geometry(), prev.geometry(), nxt.geometry()
+    assert ag.left() <= pg.left() and pg.right() <= ag.right(), "prev outside the art"
+    assert ag.left() <= ng.left() and ng.right() <= ag.right(), "next outside the art"
+    assert pg.right() < ng.left(), "arrows overlap"
+    assert pg.center().y() == ng.center().y(), "arrows not level"
+
+    # _next_index is the target and is set the moment a turn begins, so this
+    # holds whether the turn crossfades or lands at once.
+    start = art._index
+    nxt.click()
+    assert art._next_index == (start + 1) % count, "next did not turn the gallery"
+    for _ in range(200):
+        app.processEvents()
+
+    art._fade = None
+    art._index = 0
+    prev.click()
+    assert art._next_index == count - 1, "paging back from the first slide must wrap"
+
+    win.hide()
+    print("OK home gallery page arrows turn and wrap")
+
+
 def _run_smoke_tests():
     test_catalogs()
     test_tls_ca_env_sanitizer()
@@ -15423,6 +15465,7 @@ def _run_smoke_tests():
     test_wayland_window_move_and_resize_handoff()
     test_linux_game_running_guard()
     test_detect_and_installer_drop_unused_imports()
+    test_home_gallery_page_arrows()
     print("\nAll smoke tests passed.")
 
 


### PR DESCRIPTION
The Home gallery holds each slide for eleven seconds and only ever moves forward. With 31 slides, a player who wanted another look at something that had just gone past had to sit through the other thirty, which is about five and a half minutes.

This adds prev and next either side of the art, reusing `SpellbookPageButton`: the same page turn art and the same `GLUE_BTN_H` size the Addons catalog already pages with, so "turn to the next one" looks the same in both places.

Two details worth knowing:

A hand turn stops the pending auto turn, so a slide you chose gets a full eleven seconds rather than whatever was left of the one before it. Without that, a click can look like a double click registering.

Prefetch follows the direction of travel, so paging back is as warm as paging forward.

Test covers geometry inside the art, both directions, and the wrap off the first slide back to the last.
