### PR TITLE
Show where in the gallery you are

### DIFF
--- a/ichalaunch/ui/pages/home.py
+++ b/ichalaunch/ui/pages/home.py
@@ -19,6 +19,7 @@ from ichalaunch.core.paths import theme_file
 from ichalaunch.game.launcher import detect_game, is_installed
 from ichalaunch.mods.installer import detect_actual_state, load_mod_catalog
 from ichalaunch.ui.widgets.common import SpellbookPageButton, open_url_in_browser
+from ichalaunch.ui.widgets.gallery_dots import GalleryDots
 from ichalaunch.ui.widgets.glue_panel_button import GLUE_BTN_H, GluePanelButton
 from ichalaunch.ui.widgets.mods_forest_bg import HomeModsCard
 from ichalaunch.ui.widgets.talent_bg import TalentFrameBackground
@@ -62,6 +63,8 @@ _ART_BOTTOM_INSET_PX = 0
 _ART_BANNER_TUCK_PX = 12
 # Inset of the gallery page arrows from the art's own left/right edges.
 _ART_ARROW_PAD_PX = 10
+# Gap between the position row and the MoA wordmark it sits above.
+_ART_DOTS_GAP_PX = 6
 # MoA wordmark prefer width, centered along the art bottom.
 _MOA_ART_LOGO_W = 190  # ~5% under prior 200px prefer width
 # Pad from art bottom for the MoA wordmark.
@@ -189,6 +192,12 @@ class HomePage(QWidget):
         self.art_prev.clicked.connect(lambda: self.talent_bg.step(-1))
         self.art_next.clicked.connect(lambda: self.talent_bg.step(1))
 
+        self.art_dots = GalleryDots(self)
+        # turn_started fires when the turn begins, frame_changed when it lands
+        # and when the manifest reloads with a different slide count.
+        self.talent_bg.turn_started.connect(self._sync_gallery_dots)
+        self.talent_bg.frame_changed.connect(self._sync_gallery_dots)
+
         self.logo = QLabel(self)
         self.logo.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.logo.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
@@ -228,6 +237,7 @@ class HomePage(QWidget):
             self.logo,
             self.art_prev,
             self.art_next,
+            self.art_dots,
         )
 
     def _overlay_host(self) -> QWidget | None:
@@ -282,12 +292,23 @@ class HomePage(QWidget):
             return False
         return True
 
+    def _sync_gallery_dots(self) -> None:
+        dots = getattr(self, "art_dots", None)
+        if dots is None or not dots.isVisible():
+            return
+        dots.set_state(
+            self.talent_bg.slide_count(),
+            self.talent_bg.display_index(),
+            max(1, self.talent_bg.width()),
+        )
+
     def _set_chrome_visible(self, visible: bool) -> None:
         self.talent_bg.setVisible(visible)
         self.logo.setVisible(visible)
         pageable = visible and self.talent_bg.slide_count() > 1
         self.art_prev.setVisible(pageable)
         self.art_next.setVisible(pageable)
+        self.art_dots.setVisible(pageable)
         banner = self._nav_bottom_banner()
         if banner is not None:
             banner.update()
@@ -402,6 +423,15 @@ class HomePage(QWidget):
             art.x() + art.width() - arrow - _ART_ARROW_PAD_PX, arrow_y
         )
 
+        # --- position row, centred above the MoA wordmark ---
+        self.art_dots.set_state(
+            self.talent_bg.slide_count(), self.talent_bg.display_index(), art.width()
+        )
+        self.art_dots.move(
+            art.x() + (art.width() - self.art_dots.width()) // 2,
+            logo_y - self.art_dots.height() - _ART_DOTS_GAP_PX,
+        )
+
         self._set_chrome_visible(True)
 
         # Z-order (back → front on Root):
@@ -443,6 +473,7 @@ class HomePage(QWidget):
 
         self.art_prev.raise_()
         self.art_next.raise_()
+        self.art_dots.raise_()
 
         art_bottom_now = art.y() + art.height()
         gap = art_bottom - art_bottom_now

--- a/ichalaunch/ui/pages/home.py
+++ b/ichalaunch/ui/pages/home.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import (
 from ichalaunch.core.paths import theme_file
 from ichalaunch.game.launcher import detect_game, is_installed
 from ichalaunch.mods.installer import detect_actual_state, load_mod_catalog
-from ichalaunch.ui.widgets.common import open_url_in_browser
+from ichalaunch.ui.widgets.common import SpellbookPageButton, open_url_in_browser
 from ichalaunch.ui.widgets.glue_panel_button import GLUE_BTN_H, GluePanelButton
 from ichalaunch.ui.widgets.mods_forest_bg import HomeModsCard
 from ichalaunch.ui.widgets.talent_bg import TalentFrameBackground
@@ -60,6 +60,8 @@ _ART_BOTTOM_INSET_PX = 0
 # Hide the hard art / black fringe under the grey banner bar (not into spike valleys).
 # A few extra px closes the visible gap so rotating art meets the nav banner.
 _ART_BANNER_TUCK_PX = 12
+# Inset of the gallery page arrows from the art's own left/right edges.
+_ART_ARROW_PAD_PX = 10
 # MoA wordmark prefer width, centered along the art bottom.
 _MOA_ART_LOGO_W = 190  # ~5% under prior 200px prefer width
 # Pad from art bottom for the MoA wordmark.
@@ -177,6 +179,16 @@ class HomePage(QWidget):
         self.talent_bg = TalentFrameBackground(self)
         self.talent_bg.frame_changed.connect(self._sync_brand_layout)
 
+        # Page arrows for the gallery, same art and size the Addons catalog
+        # already pages with, so "turn to the next one" looks the same in both
+        # places.
+        self.art_prev = SpellbookPageButton("prev", self)
+        self.art_next = SpellbookPageButton("next", self)
+        self.art_prev.setToolTip("Previous")
+        self.art_next.setToolTip("Next")
+        self.art_prev.clicked.connect(lambda: self.talent_bg.step(-1))
+        self.art_next.clicked.connect(lambda: self.talent_bg.step(1))
+
         self.logo = QLabel(self)
         self.logo.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.logo.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
@@ -214,6 +226,8 @@ class HomePage(QWidget):
         return (
             self.talent_bg,
             self.logo,
+            self.art_prev,
+            self.art_next,
         )
 
     def _overlay_host(self) -> QWidget | None:
@@ -271,6 +285,9 @@ class HomePage(QWidget):
     def _set_chrome_visible(self, visible: bool) -> None:
         self.talent_bg.setVisible(visible)
         self.logo.setVisible(visible)
+        pageable = visible and self.talent_bg.slide_count() > 1
+        self.art_prev.setVisible(pageable)
+        self.art_next.setVisible(pageable)
         banner = self._nav_bottom_banner()
         if banner is not None:
             banner.update()
@@ -374,6 +391,17 @@ class HomePage(QWidget):
             logo_y = art.y()
         self.logo.setGeometry(logo_x, logo_y, logo_w, logo_h)
 
+        # --- gallery page arrows, centred on the picture's left/right edges ---
+        # Centred on paint_h, not on art.height(): the widget is the taller of
+        # the two (it tucks under the grey bar) and the picture centres inside
+        # the widget, so paint_h is what the arrows have to agree with.
+        arrow = self.art_prev.height() or GLUE_BTN_H
+        arrow_y = art.y() + (paint_h - arrow) // 2
+        self.art_prev.move(art.x() + _ART_ARROW_PAD_PX, arrow_y)
+        self.art_next.move(
+            art.x() + art.width() - arrow - _ART_ARROW_PAD_PX, arrow_y
+        )
+
         self._set_chrome_visible(True)
 
         # Z-order (back → front on Root):
@@ -412,6 +440,9 @@ class HomePage(QWidget):
                         btn.raise_()
         if isinstance(rc, QWidget):
             rc.raise_()
+
+        self.art_prev.raise_()
+        self.art_next.raise_()
 
         art_bottom_now = art.y() + art.height()
         gap = art_bottom - art_bottom_now

--- a/ichalaunch/ui/widgets/gallery_dots.py
+++ b/ichalaunch/ui/widgets/gallery_dots.py
@@ -1,0 +1,73 @@
+"""Position row for the Home gallery.
+
+Thirty-one slides turning on an eleven second hold, and until now nothing said
+where in them you were. ravencraft.io carries the same row under its own
+slideshow, which is where the shape comes from.
+
+Indicator only, not a control. Thirty-one click targets eight pixels wide would
+be a worse way to reach a slide than the arrows beside them.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QRectF, Qt
+from PySide6.QtGui import QColor, QPainter
+from PySide6.QtWidgets import QWidget
+
+_DOT_PX = 7
+_PITCH_PX = 11
+_BAND_PAD_PX = 5
+
+_ACTIVE = QColor("#F1C22D")
+_IDLE = QColor("#9990ab")
+_IDLE_ALPHA = 90
+
+
+class GalleryDots(QWidget):
+    """One dot per slide, the current one lit."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self._count = 0
+        self._index = 0
+        self._pitch = _PITCH_PX
+
+    def set_state(self, count: int, index: int, max_width: int) -> None:
+        """Size to *count* dots, lighting *index*, never wider than max_width."""
+        count = max(0, int(count))
+        pitch = _PITCH_PX
+        if count > 0 and max_width > 0:
+            # Tighten rather than overflow the art it sits on.
+            pitch = max(_DOT_PX + 1, min(_PITCH_PX, max_width // count))
+        changed = (count, pitch) != (self._count, self._pitch)
+        self._count = count
+        self._pitch = pitch
+        self._index = index if 0 <= index < count else 0
+        if changed:
+            self.setFixedSize(max(1, count * pitch), _DOT_PX + 2 * _BAND_PAD_PX)
+        self.update()
+
+    def paintEvent(self, event) -> None:  # noqa: ANN001
+        if self._count < 2:
+            return
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setPen(Qt.PenStyle.NoPen)
+        y = (self.height() - _DOT_PX) / 2.0
+        left = (self.width() - self._count * self._pitch) / 2.0
+        for i in range(self._count):
+            x = left + i * self._pitch + (self._pitch - _DOT_PX) / 2.0
+            if i == self._index:
+                painter.setBrush(_ACTIVE)
+                painter.drawEllipse(QRectF(x, y, _DOT_PX, _DOT_PX))
+            else:
+                idle = QColor(_IDLE)
+                idle.setAlpha(_IDLE_ALPHA)
+                painter.setBrush(idle)
+                inset = 1.0
+                painter.drawEllipse(
+                    QRectF(x + inset, y + inset, _DOT_PX - 2 * inset, _DOT_PX - 2 * inset)
+                )
+        painter.end()

--- a/ichalaunch/ui/widgets/talent_bg.py
+++ b/ichalaunch/ui/widgets/talent_bg.py
@@ -507,17 +507,41 @@ class TalentFrameBackground(QWidget):
             _draw(self._slide_at(self._next_index), self._nxt_opacity)
         painter.end()
 
+    def slide_count(self) -> int:
+        return len(self._slides)
+
+    def step(self, delta: int) -> None:
+        """Turn the gallery by hand, forwards or back.
+
+        Public because the Home page puts page arrows either side of the art.
+        A click during a crossfade is dropped rather than queued: the fade owns
+        _index until it finishes, and stacking turns on top of it reads as the
+        gallery lurching.
+        """
+        if delta:
+            self._turn(1 if delta > 0 else -1)
+
     def _advance(self) -> None:
+        self._turn(1)
+
+    def _turn(self, step: int) -> None:
         if len(self._slides) < 2:
             return
         if self._fade is not None and self._fade.state() == QParallelAnimationGroup.State.Running:
             return
 
-        self._next_index = (self._index + 1) % len(self._slides)
+        # Drop the pending auto-turn. Without this a hand-turned slide keeps
+        # whatever was left of the previous slide's hold and can flip again
+        # immediately, which looks like a double click registering.
+        self._timer.stop()
+
+        self._next_index = (self._index + step) % len(self._slides)
         nxt = self._slide_at(self._next_index)
         if nxt is not None:
             self._pixmap(str(nxt.get("image") or ""))
-        after = self._slide_at((self._next_index + 1) % len(self._slides))
+        # Prefetch in the direction of travel, so paging back is as warm as
+        # paging forward.
+        after = self._slide_at((self._next_index + step) % len(self._slides))
         if after is not None:
             self._pixmap(str(after.get("image") or ""))
 

--- a/ichalaunch/ui/widgets/talent_bg.py
+++ b/ichalaunch/ui/widgets/talent_bg.py
@@ -254,6 +254,10 @@ class TalentFrameBackground(QWidget):
     """Crossfading official artwork; geometry is owned by HomePage."""
 
     frame_changed = Signal()
+    # Emitted the moment a turn begins, not when its crossfade lands. A position
+    # indicator that waited for frame_changed would sit unmoved for the whole
+    # 2.8s fade and read as a click that did not register.
+    turn_started = Signal()
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -266,6 +270,7 @@ class TalentFrameBackground(QWidget):
         self._overlay_cache: dict[str, QPixmap] = {}
         self._index = 0
         self._next_index = 0
+        self._display_index = 0
         self._cur_opacity = _BASE_OPACITY
         self._nxt_opacity = 0.0
         self._mask: QPixmap = QPixmap()
@@ -331,6 +336,7 @@ class TalentFrameBackground(QWidget):
         self._overlay_cache.clear()
         if self._index >= len(self._slides):
             self._index = 0
+        self._display_index = self._index
         self.update()
         self.frame_changed.emit()
 
@@ -510,6 +516,15 @@ class TalentFrameBackground(QWidget):
     def slide_count(self) -> int:
         return len(self._slides)
 
+    def display_index(self) -> int:
+        """Which slide the viewer is being shown, mid-crossfade included.
+
+        Held as its own field rather than inferred from the animation, because
+        a turn is announced before its fade object exists and reading the fade
+        state at that moment reports the slide being left behind.
+        """
+        return self._display_index
+
     def step(self, delta: int) -> None:
         """Turn the gallery by hand, forwards or back.
 
@@ -536,6 +551,8 @@ class TalentFrameBackground(QWidget):
         self._timer.stop()
 
         self._next_index = (self._index + step) % len(self._slides)
+        self._display_index = self._next_index
+        self.turn_started.emit()
         nxt = self._slide_at(self._next_index)
         if nxt is not None:
             self._pixmap(str(nxt.get("image") or ""))
@@ -563,6 +580,7 @@ class TalentFrameBackground(QWidget):
 
         def _done() -> None:
             self._index = self._next_index
+            self._display_index = self._index
             self._cur_opacity = _BASE_OPACITY
             self._nxt_opacity = 0.0
             self._fade = None

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -15207,6 +15207,41 @@ def test_home_gallery_page_arrows():
     print("OK home gallery page arrows turn and wrap")
 
 
+def test_home_gallery_position_dots():
+    """The position row sits above the wordmark and follows the turn at once."""
+    from PySide6.QtWidgets import QApplication
+
+    from ichalaunch.ui.main_window import MainWindow
+
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow()
+    win.resize(1500, 950)
+    win.show()
+    for _ in range(400):
+        app.processEvents()
+
+    home = win.home
+    art, dots, logo, nxt = home.talent_bg, home.art_dots, home.logo, home.art_next
+    count = art.slide_count()
+    assert dots.isVisible()
+
+    ag, dg, lg = art.geometry(), dots.geometry(), logo.geometry()
+    assert dg.width() <= ag.width(), "dot row wider than the art it sits on"
+    assert ag.left() <= dg.left() and dg.right() <= ag.right(), "dots outside the art"
+    assert dg.bottom() <= lg.top(), "dots collide with the wordmark"
+    assert abs(dg.center().x() - ag.center().x()) <= 2, "dots not centred"
+
+    # The lit dot must move with the click, not with the crossfade that follows
+    # it; a row that waits out the fade reads as a click that did not register.
+    start = art.display_index()
+    nxt.click()
+    assert art.display_index() == (start + 1) % count, "shown slide did not advance"
+    assert dots._index == art.display_index(), "lit dot lags the gallery"
+
+    win.hide()
+    print("OK home gallery position dots track the shown slide")
+
+
 def _run_smoke_tests():
     test_catalogs()
     test_tls_ca_env_sanitizer()
@@ -15466,6 +15501,7 @@ def _run_smoke_tests():
     test_linux_game_running_guard()
     test_detect_and_installer_drop_unused_imports()
     test_home_gallery_page_arrows()
+    test_home_gallery_position_dots()
     print("\nAll smoke tests passed.")
 
 

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -15165,6 +15165,48 @@ def test_detect_and_installer_drop_unused_imports():
     print("OK detect/installer carry no unused module-level imports")
 
 
+def test_home_gallery_page_arrows():
+    """Prev/Next sit inside the art and turn the gallery both ways, wrapping."""
+    from PySide6.QtWidgets import QApplication
+
+    from ichalaunch.ui.main_window import MainWindow
+
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow()
+    win.resize(1500, 950)
+    win.show()
+    for _ in range(400):
+        app.processEvents()
+
+    home = win.home
+    art, prev, nxt = home.talent_bg, home.art_prev, home.art_next
+    count = art.slide_count()
+    assert count > 1, "gallery needs at least two slides to page"
+    assert prev.isVisible() and nxt.isVisible()
+
+    ag, pg, ng = art.geometry(), prev.geometry(), nxt.geometry()
+    assert ag.left() <= pg.left() and pg.right() <= ag.right(), "prev outside the art"
+    assert ag.left() <= ng.left() and ng.right() <= ag.right(), "next outside the art"
+    assert pg.right() < ng.left(), "arrows overlap"
+    assert pg.center().y() == ng.center().y(), "arrows not level"
+
+    # _next_index is the target and is set the moment a turn begins, so this
+    # holds whether the turn crossfades or lands at once.
+    start = art._index
+    nxt.click()
+    assert art._next_index == (start + 1) % count, "next did not turn the gallery"
+    for _ in range(200):
+        app.processEvents()
+
+    art._fade = None
+    art._index = 0
+    prev.click()
+    assert art._next_index == count - 1, "paging back from the first slide must wrap"
+
+    win.hide()
+    print("OK home gallery page arrows turn and wrap")
+
+
 def _run_smoke_tests():
     test_catalogs()
     test_tls_ca_env_sanitizer()
@@ -15423,6 +15465,7 @@ def _run_smoke_tests():
     test_wayland_window_move_and_resize_handoff()
     test_linux_game_running_guard()
     test_detect_and_installer_drop_unused_imports()
+    test_home_gallery_page_arrows()
     print("\nAll smoke tests passed.")
 
 


### PR DESCRIPTION
Thirty one slides on an eleven second hold, and nothing said which one you were looking at.

One dot per slide, centred above the wordmark, current one lit. The row tightens its own spacing if the art is ever too narrow for the slide count, so it cannot overflow.

The lit dot follows `turn_started`, not `frame_changed`. The crossfade is 2.8 seconds, and a row that waited for it sat unmoved for the whole fade, which reads as a click that did not register.

Which slide is on show is held as its own field rather than read off the animation state. A turn is announced before its fade object exists, so reading the fade at that moment reports the slide being left behind. That cost me a wrong first implementation and is the reason the field exists.

Depends on #381. The extra commits in this PR belong to that one; review it first.
