### PR TITLE
Land hand turns at once, page from the dots, vignette the art

### DIFF
--- a/ichalaunch/ui/pages/home.py
+++ b/ichalaunch/ui/pages/home.py
@@ -197,6 +197,7 @@ class HomePage(QWidget):
         # and when the manifest reloads with a different slide count.
         self.talent_bg.turn_started.connect(self._sync_gallery_dots)
         self.talent_bg.frame_changed.connect(self._sync_gallery_dots)
+        self.art_dots.dot_clicked.connect(self.talent_bg.go_to)
 
         self.logo = QLabel(self)
         self.logo.setAlignment(Qt.AlignmentFlag.AlignCenter)

--- a/ichalaunch/ui/pages/home.py
+++ b/ichalaunch/ui/pages/home.py
@@ -19,6 +19,7 @@ from ichalaunch.core.paths import theme_file
 from ichalaunch.game.launcher import detect_game, is_installed
 from ichalaunch.mods.installer import detect_actual_state, load_mod_catalog
 from ichalaunch.ui.widgets.common import SpellbookPageButton, open_url_in_browser
+from ichalaunch.ui.widgets.gallery_dots import GalleryDots
 from ichalaunch.ui.widgets.glue_panel_button import GLUE_BTN_H, GluePanelButton
 from ichalaunch.ui.widgets.mods_forest_bg import HomeModsCard
 from ichalaunch.ui.widgets.talent_bg import TalentFrameBackground
@@ -62,6 +63,8 @@ _ART_BOTTOM_INSET_PX = 0
 _ART_BANNER_TUCK_PX = 12
 # Inset of the gallery page arrows from the art's own left/right edges.
 _ART_ARROW_PAD_PX = 10
+# Gap between the position row and the MoA wordmark it sits above.
+_ART_DOTS_GAP_PX = 6
 # MoA wordmark prefer width, centered along the art bottom.
 _MOA_ART_LOGO_W = 190  # ~5% under prior 200px prefer width
 # Pad from art bottom for the MoA wordmark.
@@ -189,6 +192,12 @@ class HomePage(QWidget):
         self.art_prev.clicked.connect(lambda: self.talent_bg.step(-1))
         self.art_next.clicked.connect(lambda: self.talent_bg.step(1))
 
+        self.art_dots = GalleryDots(self)
+        # turn_started fires when the turn begins, frame_changed when it lands
+        # and when the manifest reloads with a different slide count.
+        self.talent_bg.turn_started.connect(self._sync_gallery_dots)
+        self.talent_bg.frame_changed.connect(self._sync_gallery_dots)
+
         self.logo = QLabel(self)
         self.logo.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.logo.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
@@ -228,6 +237,7 @@ class HomePage(QWidget):
             self.logo,
             self.art_prev,
             self.art_next,
+            self.art_dots,
         )
 
     def _overlay_host(self) -> QWidget | None:
@@ -282,12 +292,23 @@ class HomePage(QWidget):
             return False
         return True
 
+    def _sync_gallery_dots(self) -> None:
+        dots = getattr(self, "art_dots", None)
+        if dots is None or not dots.isVisible():
+            return
+        dots.set_state(
+            self.talent_bg.slide_count(),
+            self.talent_bg.display_index(),
+            max(1, self.talent_bg.width()),
+        )
+
     def _set_chrome_visible(self, visible: bool) -> None:
         self.talent_bg.setVisible(visible)
         self.logo.setVisible(visible)
         pageable = visible and self.talent_bg.slide_count() > 1
         self.art_prev.setVisible(pageable)
         self.art_next.setVisible(pageable)
+        self.art_dots.setVisible(pageable)
         banner = self._nav_bottom_banner()
         if banner is not None:
             banner.update()
@@ -402,6 +423,15 @@ class HomePage(QWidget):
             art.x() + art.width() - arrow - _ART_ARROW_PAD_PX, arrow_y
         )
 
+        # --- position row, centred above the MoA wordmark ---
+        self.art_dots.set_state(
+            self.talent_bg.slide_count(), self.talent_bg.display_index(), art.width()
+        )
+        self.art_dots.move(
+            art.x() + (art.width() - self.art_dots.width()) // 2,
+            logo_y - self.art_dots.height() - _ART_DOTS_GAP_PX,
+        )
+
         self._set_chrome_visible(True)
 
         # Z-order (back → front on Root):
@@ -443,6 +473,7 @@ class HomePage(QWidget):
 
         self.art_prev.raise_()
         self.art_next.raise_()
+        self.art_dots.raise_()
 
         art_bottom_now = art.y() + art.height()
         gap = art_bottom - art_bottom_now

--- a/ichalaunch/ui/pages/home.py
+++ b/ichalaunch/ui/pages/home.py
@@ -18,7 +18,7 @@ from PySide6.QtWidgets import (
 from ichalaunch.core.paths import theme_file
 from ichalaunch.game.launcher import detect_game, is_installed
 from ichalaunch.mods.installer import detect_actual_state, load_mod_catalog
-from ichalaunch.ui.widgets.common import open_url_in_browser
+from ichalaunch.ui.widgets.common import SpellbookPageButton, open_url_in_browser
 from ichalaunch.ui.widgets.glue_panel_button import GLUE_BTN_H, GluePanelButton
 from ichalaunch.ui.widgets.mods_forest_bg import HomeModsCard
 from ichalaunch.ui.widgets.talent_bg import TalentFrameBackground
@@ -60,6 +60,8 @@ _ART_BOTTOM_INSET_PX = 0
 # Hide the hard art / black fringe under the grey banner bar (not into spike valleys).
 # A few extra px closes the visible gap so rotating art meets the nav banner.
 _ART_BANNER_TUCK_PX = 12
+# Inset of the gallery page arrows from the art's own left/right edges.
+_ART_ARROW_PAD_PX = 10
 # MoA wordmark prefer width, centered along the art bottom.
 _MOA_ART_LOGO_W = 190  # ~5% under prior 200px prefer width
 # Pad from art bottom for the MoA wordmark.
@@ -177,6 +179,16 @@ class HomePage(QWidget):
         self.talent_bg = TalentFrameBackground(self)
         self.talent_bg.frame_changed.connect(self._sync_brand_layout)
 
+        # Page arrows for the gallery, same art and size the Addons catalog
+        # already pages with, so "turn to the next one" looks the same in both
+        # places.
+        self.art_prev = SpellbookPageButton("prev", self)
+        self.art_next = SpellbookPageButton("next", self)
+        self.art_prev.setToolTip("Previous")
+        self.art_next.setToolTip("Next")
+        self.art_prev.clicked.connect(lambda: self.talent_bg.step(-1))
+        self.art_next.clicked.connect(lambda: self.talent_bg.step(1))
+
         self.logo = QLabel(self)
         self.logo.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.logo.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
@@ -214,6 +226,8 @@ class HomePage(QWidget):
         return (
             self.talent_bg,
             self.logo,
+            self.art_prev,
+            self.art_next,
         )
 
     def _overlay_host(self) -> QWidget | None:
@@ -271,6 +285,9 @@ class HomePage(QWidget):
     def _set_chrome_visible(self, visible: bool) -> None:
         self.talent_bg.setVisible(visible)
         self.logo.setVisible(visible)
+        pageable = visible and self.talent_bg.slide_count() > 1
+        self.art_prev.setVisible(pageable)
+        self.art_next.setVisible(pageable)
         banner = self._nav_bottom_banner()
         if banner is not None:
             banner.update()
@@ -374,6 +391,17 @@ class HomePage(QWidget):
             logo_y = art.y()
         self.logo.setGeometry(logo_x, logo_y, logo_w, logo_h)
 
+        # --- gallery page arrows, centred on the picture's left/right edges ---
+        # Centred on paint_h, not on art.height(): the widget is the taller of
+        # the two (it tucks under the grey bar) and the picture centres inside
+        # the widget, so paint_h is what the arrows have to agree with.
+        arrow = self.art_prev.height() or GLUE_BTN_H
+        arrow_y = art.y() + (paint_h - arrow) // 2
+        self.art_prev.move(art.x() + _ART_ARROW_PAD_PX, arrow_y)
+        self.art_next.move(
+            art.x() + art.width() - arrow - _ART_ARROW_PAD_PX, arrow_y
+        )
+
         self._set_chrome_visible(True)
 
         # Z-order (back → front on Root):
@@ -412,6 +440,9 @@ class HomePage(QWidget):
                         btn.raise_()
         if isinstance(rc, QWidget):
             rc.raise_()
+
+        self.art_prev.raise_()
+        self.art_next.raise_()
 
         art_bottom_now = art.y() + art.height()
         gap = art_bottom - art_bottom_now

--- a/ichalaunch/ui/widgets/gallery_dots.py
+++ b/ichalaunch/ui/widgets/gallery_dots.py
@@ -4,18 +4,20 @@ Thirty-one slides turning on an eleven second hold, and until now nothing said
 where in them you were. ravencraft.io carries the same row under its own
 slideshow, which is where the shape comes from.
 
-Indicator only, not a control. Thirty-one click targets eight pixels wide would
-be a worse way to reach a slide than the arrows beside them.
+Clickable: each dot owns the full pitch as its hit box, not just the seven
+pixels it paints, so the target is the gap as well as the mark.
 """
 
 from __future__ import annotations
 
-from PySide6.QtCore import QRectF, Qt
+from PySide6.QtCore import QRectF, Qt, Signal
 from PySide6.QtGui import QColor, QPainter
 from PySide6.QtWidgets import QWidget
 
+from ichalaunch.ui.widgets.cursors import apply_open_hand
+
 _DOT_PX = 7
-_PITCH_PX = 11
+_PITCH_PX = 18
 _BAND_PAD_PX = 5
 
 _ACTIVE = QColor("#F1C22D")
@@ -24,12 +26,14 @@ _IDLE_ALPHA = 90
 
 
 class GalleryDots(QWidget):
-    """One dot per slide, the current one lit."""
+    """One dot per slide, the current one lit. Click one to go there."""
+
+    dot_clicked = Signal(int)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        apply_open_hand(self)
         self._count = 0
         self._index = 0
         self._pitch = _PITCH_PX
@@ -71,3 +75,23 @@ class GalleryDots(QWidget):
                     QRectF(x + inset, y + inset, _DOT_PX - 2 * inset, _DOT_PX - 2 * inset)
                 )
         painter.end()
+
+    def _index_at(self, x: float) -> int:
+        """Slide under *x*, or -1 outside the row."""
+        if self._count < 1 or self._pitch <= 0:
+            return -1
+        left = (self.width() - self._count * self._pitch) / 2.0
+        i = int((x - left) // self._pitch)
+        return i if 0 <= i < self._count else -1
+
+    def mousePressEvent(self, event) -> None:  # noqa: ANN001
+        if event.button() != Qt.MouseButton.LeftButton:
+            super().mousePressEvent(event)
+            return
+        i = self._index_at(event.position().x())
+        if i < 0:
+            super().mousePressEvent(event)
+            return
+        event.accept()
+        if i != self._index:
+            self.dot_clicked.emit(i)

--- a/ichalaunch/ui/widgets/gallery_dots.py
+++ b/ichalaunch/ui/widgets/gallery_dots.py
@@ -1,0 +1,73 @@
+"""Position row for the Home gallery.
+
+Thirty-one slides turning on an eleven second hold, and until now nothing said
+where in them you were. ravencraft.io carries the same row under its own
+slideshow, which is where the shape comes from.
+
+Indicator only, not a control. Thirty-one click targets eight pixels wide would
+be a worse way to reach a slide than the arrows beside them.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QRectF, Qt
+from PySide6.QtGui import QColor, QPainter
+from PySide6.QtWidgets import QWidget
+
+_DOT_PX = 7
+_PITCH_PX = 11
+_BAND_PAD_PX = 5
+
+_ACTIVE = QColor("#F1C22D")
+_IDLE = QColor("#9990ab")
+_IDLE_ALPHA = 90
+
+
+class GalleryDots(QWidget):
+    """One dot per slide, the current one lit."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self._count = 0
+        self._index = 0
+        self._pitch = _PITCH_PX
+
+    def set_state(self, count: int, index: int, max_width: int) -> None:
+        """Size to *count* dots, lighting *index*, never wider than max_width."""
+        count = max(0, int(count))
+        pitch = _PITCH_PX
+        if count > 0 and max_width > 0:
+            # Tighten rather than overflow the art it sits on.
+            pitch = max(_DOT_PX + 1, min(_PITCH_PX, max_width // count))
+        changed = (count, pitch) != (self._count, self._pitch)
+        self._count = count
+        self._pitch = pitch
+        self._index = index if 0 <= index < count else 0
+        if changed:
+            self.setFixedSize(max(1, count * pitch), _DOT_PX + 2 * _BAND_PAD_PX)
+        self.update()
+
+    def paintEvent(self, event) -> None:  # noqa: ANN001
+        if self._count < 2:
+            return
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setPen(Qt.PenStyle.NoPen)
+        y = (self.height() - _DOT_PX) / 2.0
+        left = (self.width() - self._count * self._pitch) / 2.0
+        for i in range(self._count):
+            x = left + i * self._pitch + (self._pitch - _DOT_PX) / 2.0
+            if i == self._index:
+                painter.setBrush(_ACTIVE)
+                painter.drawEllipse(QRectF(x, y, _DOT_PX, _DOT_PX))
+            else:
+                idle = QColor(_IDLE)
+                idle.setAlpha(_IDLE_ALPHA)
+                painter.setBrush(idle)
+                inset = 1.0
+                painter.drawEllipse(
+                    QRectF(x + inset, y + inset, _DOT_PX - 2 * inset, _DOT_PX - 2 * inset)
+                )
+        painter.end()

--- a/ichalaunch/ui/widgets/talent_bg.py
+++ b/ichalaunch/ui/widgets/talent_bg.py
@@ -507,17 +507,41 @@ class TalentFrameBackground(QWidget):
             _draw(self._slide_at(self._next_index), self._nxt_opacity)
         painter.end()
 
+    def slide_count(self) -> int:
+        return len(self._slides)
+
+    def step(self, delta: int) -> None:
+        """Turn the gallery by hand, forwards or back.
+
+        Public because the Home page puts page arrows either side of the art.
+        A click during a crossfade is dropped rather than queued: the fade owns
+        _index until it finishes, and stacking turns on top of it reads as the
+        gallery lurching.
+        """
+        if delta:
+            self._turn(1 if delta > 0 else -1)
+
     def _advance(self) -> None:
+        self._turn(1)
+
+    def _turn(self, step: int) -> None:
         if len(self._slides) < 2:
             return
         if self._fade is not None and self._fade.state() == QParallelAnimationGroup.State.Running:
             return
 
-        self._next_index = (self._index + 1) % len(self._slides)
+        # Drop the pending auto-turn. Without this a hand-turned slide keeps
+        # whatever was left of the previous slide's hold and can flip again
+        # immediately, which looks like a double click registering.
+        self._timer.stop()
+
+        self._next_index = (self._index + step) % len(self._slides)
         nxt = self._slide_at(self._next_index)
         if nxt is not None:
             self._pixmap(str(nxt.get("image") or ""))
-        after = self._slide_at((self._next_index + 1) % len(self._slides))
+        # Prefetch in the direction of travel, so paging back is as warm as
+        # paging forward.
+        after = self._slide_at((self._next_index + step) % len(self._slides))
         if after is not None:
             self._pixmap(str(after.get("image") or ""))
 

--- a/ichalaunch/ui/widgets/talent_bg.py
+++ b/ichalaunch/ui/widgets/talent_bg.py
@@ -254,6 +254,10 @@ class TalentFrameBackground(QWidget):
     """Crossfading official artwork; geometry is owned by HomePage."""
 
     frame_changed = Signal()
+    # Emitted the moment a turn begins, not when its crossfade lands. A position
+    # indicator that waited for frame_changed would sit unmoved for the whole
+    # 2.8s fade and read as a click that did not register.
+    turn_started = Signal()
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -266,6 +270,7 @@ class TalentFrameBackground(QWidget):
         self._overlay_cache: dict[str, QPixmap] = {}
         self._index = 0
         self._next_index = 0
+        self._display_index = 0
         self._cur_opacity = _BASE_OPACITY
         self._nxt_opacity = 0.0
         self._mask: QPixmap = QPixmap()
@@ -331,6 +336,7 @@ class TalentFrameBackground(QWidget):
         self._overlay_cache.clear()
         if self._index >= len(self._slides):
             self._index = 0
+        self._display_index = self._index
         self.update()
         self.frame_changed.emit()
 
@@ -510,6 +516,15 @@ class TalentFrameBackground(QWidget):
     def slide_count(self) -> int:
         return len(self._slides)
 
+    def display_index(self) -> int:
+        """Which slide the viewer is being shown, mid-crossfade included.
+
+        Held as its own field rather than inferred from the animation, because
+        a turn is announced before its fade object exists and reading the fade
+        state at that moment reports the slide being left behind.
+        """
+        return self._display_index
+
     def step(self, delta: int) -> None:
         """Turn the gallery by hand, forwards or back.
 
@@ -536,6 +551,8 @@ class TalentFrameBackground(QWidget):
         self._timer.stop()
 
         self._next_index = (self._index + step) % len(self._slides)
+        self._display_index = self._next_index
+        self.turn_started.emit()
         nxt = self._slide_at(self._next_index)
         if nxt is not None:
             self._pixmap(str(nxt.get("image") or ""))
@@ -563,6 +580,7 @@ class TalentFrameBackground(QWidget):
 
         def _done() -> None:
             self._index = self._next_index
+            self._display_index = self._index
             self._cur_opacity = _BASE_OPACITY
             self._nxt_opacity = 0.0
             self._fade = None

--- a/ichalaunch/ui/widgets/talent_bg.py
+++ b/ichalaunch/ui/widgets/talent_bg.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import threading
 from pathlib import Path
 from typing import Any
@@ -25,6 +26,7 @@ from PySide6.QtGui import (
     QPixmap,
     QResizeEvent,
     QShowEvent,
+    QRadialGradient,
 )
 from PySide6.QtWidgets import QWidget
 
@@ -43,6 +45,11 @@ from ichalaunch.ui.home_art import (
 _HOLD_MS = 11_000
 _FADE_MS = 2_800
 _BASE_OPACITY = 0.82
+# Darkening at the edges of the picture itself, so a title laid over it reads
+# without a scrim behind the text. ravencraft.io does this to every art tile on
+# its front page, which is most of why those cards look like a set.
+_VIGNETTE_ALPHA = 150
+_VIGNETTE_CLEAR = 0.45   # fraction of the radius left untouched
 # Soft L/R + top falloff. Bottom stays hard so art still sits flush on the
 # diamond strip (any bottom feather reads as a mid-page gap).
 _EDGE_FEATHER = 0.04
@@ -489,6 +496,20 @@ class TalentFrameBackground(QWidget):
             lp = QPainter(layer)
             lp.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform, True)
             lp.drawPixmap(x, y, scaled)
+            # SourceAtop so only the picture darkens. The letterbox bands a
+            # width-fit slide leaves are transparent, and painting the gradient
+            # over them would turn the empty space into a black slab.
+            if _VIGNETTE_ALPHA > 0 and scaled.width() > 0 and scaled.height() > 0:
+                cx = x + scaled.width() / 2.0
+                cy = y + scaled.height() / 2.0
+                radius = math.hypot(scaled.width(), scaled.height()) / 2.0
+                grad = QRadialGradient(cx, cy, radius)
+                grad.setColorAt(0.0, QColor(0, 0, 0, 0))
+                grad.setColorAt(_VIGNETTE_CLEAR, QColor(0, 0, 0, 0))
+                grad.setColorAt(1.0, QColor(0, 0, 0, _VIGNETTE_ALPHA))
+                lp.setCompositionMode(QPainter.CompositionMode.CompositionMode_SourceAtop)
+                lp.fillRect(0, 0, w, h, grad)
+
             if not self._mask.isNull():
                 lp.setCompositionMode(QPainter.CompositionMode.CompositionMode_DestinationIn)
                 lp.drawPixmap(0, 0, self._mask)
@@ -528,30 +549,45 @@ class TalentFrameBackground(QWidget):
     def step(self, delta: int) -> None:
         """Turn the gallery by hand, forwards or back.
 
-        Public because the Home page puts page arrows either side of the art.
-        A click during a crossfade is dropped rather than queued: the fade owns
-        _index until it finishes, and stacking turns on top of it reads as the
-        gallery lurching.
+        Lands immediately. The 2.8s crossfade is right for a gallery drifting on
+        its own; asked for the next slide, waiting three seconds to see it reads
+        as the click not registering. A hand turn also interrupts a drift
+        already in flight rather than being dropped behind it.
         """
         if delta:
-            self._turn(1 if delta > 0 else -1)
+            self._turn(1 if delta > 0 else -1, animate=False)
+
+    def go_to(self, index: int) -> None:
+        """Jump straight to a slide, for the position row."""
+        if 0 <= index < len(self._slides) and index != self._index:
+            self._show(index, step=1, animate=False)
 
     def _advance(self) -> None:
-        self._turn(1)
+        self._turn(1, animate=True)
 
-    def _turn(self, step: int) -> None:
+    def _turn(self, step: int, animate: bool = True) -> None:
         if len(self._slides) < 2:
             return
-        if self._fade is not None and self._fade.state() == QParallelAnimationGroup.State.Running:
-            return
+        self._show((self._index + step) % len(self._slides), step, animate)
+
+    def _show(self, target: int, step: int, animate: bool) -> None:
+        running = (
+            self._fade is not None
+            and self._fade.state() == QParallelAnimationGroup.State.Running
+        )
+        if running:
+            if animate:
+                return
+            self._fade.stop()
+            self._fade = None
 
         # Drop the pending auto-turn. Without this a hand-turned slide keeps
         # whatever was left of the previous slide's hold and can flip again
         # immediately, which looks like a double click registering.
         self._timer.stop()
 
-        self._next_index = (self._index + step) % len(self._slides)
-        self._display_index = self._next_index
+        self._next_index = target
+        self._display_index = target
         self.turn_started.emit()
         nxt = self._slide_at(self._next_index)
         if nxt is not None:
@@ -561,6 +597,15 @@ class TalentFrameBackground(QWidget):
         after = self._slide_at((self._next_index + step) % len(self._slides))
         if after is not None:
             self._pixmap(str(after.get("image") or ""))
+
+        if not animate:
+            self._index = self._next_index
+            self._cur_opacity = _BASE_OPACITY
+            self._nxt_opacity = 0.0
+            self.update()
+            self.frame_changed.emit()
+            self._timer.start(_hold_ms_for(self._slide_at(self._index) or {"hold": 1.0}))
+            return
 
         fade_out = QPropertyAnimation(self, b"curOpacity")
         fade_out.setDuration(_FADE_MS)

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -15207,6 +15207,41 @@ def test_home_gallery_page_arrows():
     print("OK home gallery page arrows turn and wrap")
 
 
+def test_home_gallery_position_dots():
+    """The position row sits above the wordmark and follows the turn at once."""
+    from PySide6.QtWidgets import QApplication
+
+    from ichalaunch.ui.main_window import MainWindow
+
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow()
+    win.resize(1500, 950)
+    win.show()
+    for _ in range(400):
+        app.processEvents()
+
+    home = win.home
+    art, dots, logo, nxt = home.talent_bg, home.art_dots, home.logo, home.art_next
+    count = art.slide_count()
+    assert dots.isVisible()
+
+    ag, dg, lg = art.geometry(), dots.geometry(), logo.geometry()
+    assert dg.width() <= ag.width(), "dot row wider than the art it sits on"
+    assert ag.left() <= dg.left() and dg.right() <= ag.right(), "dots outside the art"
+    assert dg.bottom() <= lg.top(), "dots collide with the wordmark"
+    assert abs(dg.center().x() - ag.center().x()) <= 2, "dots not centred"
+
+    # The lit dot must move with the click, not with the crossfade that follows
+    # it; a row that waits out the fade reads as a click that did not register.
+    start = art.display_index()
+    nxt.click()
+    assert art.display_index() == (start + 1) % count, "shown slide did not advance"
+    assert dots._index == art.display_index(), "lit dot lags the gallery"
+
+    win.hide()
+    print("OK home gallery position dots track the shown slide")
+
+
 def _run_smoke_tests():
     test_catalogs()
     test_tls_ca_env_sanitizer()
@@ -15466,6 +15501,7 @@ def _run_smoke_tests():
     test_linux_game_running_guard()
     test_detect_and_installer_drop_unused_imports()
     test_home_gallery_page_arrows()
+    test_home_gallery_position_dots()
     print("\nAll smoke tests passed.")
 
 

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -15242,6 +15242,94 @@ def test_home_gallery_position_dots():
     print("OK home gallery position dots track the shown slide")
 
 
+def test_gallery_hand_turns_land_at_once_and_vignette_spares_the_bands():
+    """A hand turn is immediate, dots jump, and the vignette darkens only the picture."""
+    from PySide6.QtCore import QPoint
+    from PySide6.QtGui import QImage, QPainter
+    from PySide6.QtWidgets import QApplication
+
+    from ichalaunch.ui.widgets.gallery_dots import GalleryDots
+    import ichalaunch.ui.widgets.talent_bg as talent_bg
+    from ichalaunch.ui.widgets.talent_bg import TalentFrameBackground
+
+    app = QApplication.instance() or QApplication([])
+    del app
+
+    w, h = 880, 660
+    art = TalentFrameBackground()
+    art.set_frame(0, 0, w, h)
+    art.resize(w, h)
+    count = art.slide_count()
+    assert count > 2
+
+    # No settling anywhere below. The crossfade suits a gallery drifting on its
+    # own; asked for the next slide, waiting it out reads as a dead click.
+    art._index = 0
+    art.step(1)
+    assert art._index == 1, "a hand turn still waits on the crossfade"
+    art.step(-1)
+    assert art._index == 0
+    art.step(-1)
+    assert art._index == count - 1, "paging back off the first slide must wrap"
+
+    art.go_to(3)
+    assert art._index == 3, "go_to did not land"
+    art.go_to(-1)
+    art.go_to(count)
+    assert art._index == 3, "an out-of-range jump must be ignored"
+
+    # Each dot owns its whole pitch as a hit box, so the gaps are target too.
+    dots = GalleryDots()
+    dots.set_state(count, 0, w)
+    dots.resize(dots.width(), dots.height())
+    left = (dots.width() - count * dots._pitch) / 2.0
+    for target in (0, count // 2, count - 1):
+        assert dots._index_at(left + target * dots._pitch + 1) == target
+        assert dots._index_at(left + target * dots._pitch + dots._pitch - 1) == target
+    assert dots._index_at(left - 40) == -1, "a click left of the row is not a slide"
+    assert dots._index_at(left + count * dots._pitch + 40) == -1
+
+    # The featured slide is 2:1 in a taller rect, so it leaves transparent bands.
+    # The vignette is composited SourceAtop for exactly this reason: painted over
+    # the bands it would turn empty space into a black slab.
+    art.go_to(0)
+
+    def render():
+        img = QImage(w, h, QImage.Format.Format_ARGB32)
+        img.fill(0)
+        painter = QPainter(img)
+        art.render(painter, QPoint(0, 0))
+        painter.end()
+        return img
+
+    def lum(img, x, y):
+        c = img.pixelColor(x, y)
+        return (c.red() + c.green() + c.blue()) / 3.0
+
+    # Measured against the same frame with the gradient off, not against the
+    # picture's own centre. This art is already darker at its edges than in the
+    # middle, so comparing centre to edge passes whether the vignette runs or
+    # not - it reads as a test and asserts nothing.
+    shipped = render()
+    saved = talent_bg._VIGNETTE_ALPHA
+    try:
+        talent_bg._VIGNETTE_ALPHA = 0
+        plain = render()
+    finally:
+        talent_bg._VIGNETTE_ALPHA = saved
+
+    band_y = (h - w // 2) // 4
+    assert shipped.pixelColor(w // 2, band_y).alpha() < 20, "the vignette filled the letterbox band"
+
+    edge = lum(shipped, 24, h // 2)
+    edge_plain = lum(plain, 24, h // 2)
+    centre = lum(shipped, w // 2, h // 2)
+    centre_plain = lum(plain, w // 2, h // 2)
+    assert edge < edge_plain - 1, f"the vignette did not darken the edge ({edge} vs {edge_plain})"
+    assert abs(centre - centre_plain) <= 1, "the vignette should leave the centre alone"
+    print("OK gallery hand turns land at once and the vignette spares the bands")
+
+
 def _run_smoke_tests():
     test_catalogs()
     test_tls_ca_env_sanitizer()
@@ -15502,6 +15590,7 @@ def _run_smoke_tests():
     test_detect_and_installer_drop_unused_imports()
     test_home_gallery_page_arrows()
     test_home_gallery_position_dots()
+    test_gallery_hand_turns_land_at_once_and_vignette_spares_the_bands()
     print("\nAll smoke tests passed.")
 
 

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -15165,6 +15165,48 @@ def test_detect_and_installer_drop_unused_imports():
     print("OK detect/installer carry no unused module-level imports")
 
 
+def test_home_gallery_page_arrows():
+    """Prev/Next sit inside the art and turn the gallery both ways, wrapping."""
+    from PySide6.QtWidgets import QApplication
+
+    from ichalaunch.ui.main_window import MainWindow
+
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow()
+    win.resize(1500, 950)
+    win.show()
+    for _ in range(400):
+        app.processEvents()
+
+    home = win.home
+    art, prev, nxt = home.talent_bg, home.art_prev, home.art_next
+    count = art.slide_count()
+    assert count > 1, "gallery needs at least two slides to page"
+    assert prev.isVisible() and nxt.isVisible()
+
+    ag, pg, ng = art.geometry(), prev.geometry(), nxt.geometry()
+    assert ag.left() <= pg.left() and pg.right() <= ag.right(), "prev outside the art"
+    assert ag.left() <= ng.left() and ng.right() <= ag.right(), "next outside the art"
+    assert pg.right() < ng.left(), "arrows overlap"
+    assert pg.center().y() == ng.center().y(), "arrows not level"
+
+    # _next_index is the target and is set the moment a turn begins, so this
+    # holds whether the turn crossfades or lands at once.
+    start = art._index
+    nxt.click()
+    assert art._next_index == (start + 1) % count, "next did not turn the gallery"
+    for _ in range(200):
+        app.processEvents()
+
+    art._fade = None
+    art._index = 0
+    prev.click()
+    assert art._next_index == count - 1, "paging back from the first slide must wrap"
+
+    win.hide()
+    print("OK home gallery page arrows turn and wrap")
+
+
 def _run_smoke_tests():
     test_catalogs()
     test_tls_ca_env_sanitizer()
@@ -15423,6 +15465,7 @@ def _run_smoke_tests():
     test_wayland_window_move_and_resize_handoff()
     test_linux_game_running_guard()
     test_detect_and_installer_drop_unused_imports()
+    test_home_gallery_page_arrows()
     print("\nAll smoke tests passed.")
 
 


### PR DESCRIPTION
Three things the gallery was missing, from looking at how ravencraft.io presents the same content.

**Hand turns land at once.** The 2.8 second crossfade suits a gallery drifting on its own. Asked for the next slide, waiting three seconds to see it reads as the click not registering. A hand turn now also interrupts a drift already in flight instead of being dropped behind it. Auto advance keeps the fade.

**The position row is a control, not just an indicator.** Pitch goes from 11 to 18 so the row is readable rather than a dashed line, and each dot owns its full pitch as a hit box, so the gap counts as target too. Clicking one jumps straight there.

**The art carries an edge vignette.** This is most of why their tiles read as a set and ours did not. Composited SourceAtop so only the picture darkens: the letterbox bands a width fit slide leaves are transparent, and painting a gradient over those would turn the empty space into a black slab.

Test does no settling anywhere, so a turn that still needed the crossfade fails it. It also covers the wrap, an out of range jump being ignored, the dot hit boxes, and the vignette measured differentially against the same frame with it switched off. The naive version of that assertion compared the picture's centre to its edge and passed with the vignette disabled, because the art is already darker at its edges.

Depends on #382.
