### PR TITLE
Refuse a mod download that does not match its pinned hash

### DIFF
--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -11,7 +11,9 @@
       "type": "github_release_latest",
       "repo": "tubtubs/vanilla-tweaks",
       "asset_contains": "pc-windows-gnu.zip",
-      "asset_not_contains": "sha256"
+      "asset_not_contains": "sha256",
+      "sha256": "5608998c4cb24f001998086bfc62700b587f999daec15b6f8873ba6e9cb8e6a6",
+      "pinned_tag": "tag"
     },
     "kind": "exe_patch",
     "has_config": true,
@@ -31,7 +33,8 @@
     },
     "source": {
       "type": "github_release",
-      "url": "https://github.com/brndd/vanilla-tweaks/releases/download/v1.6.0/vanilla-tweaks_v1.6.0_x86_64-pc-windows-gnu.zip"
+      "url": "https://github.com/brndd/vanilla-tweaks/releases/download/v1.6.0/vanilla-tweaks_v1.6.0_x86_64-pc-windows-gnu.zip",
+      "sha256": "b8ce894bee1e4ee05253e77d78af7249bbaa8abc39b81025b8bc1ac2b344a8c9"
     },
     "kind": "exe_patch",
     "has_config": true,
@@ -55,7 +58,9 @@
       "type": "github_release_latest",
       "repo": "hannesmann/vanillafixes",
       "asset_contains": "vanillafixes",
-      "asset_not_contains": "dxvk"
+      "asset_not_contains": "dxvk",
+      "sha256": "72ea02aa34b61675d6f9ffc99fc64bc3d0c3e68e139f3f885eb04cac5167bc07",
+      "pinned_tag": "v1.5.3"
     },
     "kind": "zip_root",
     "dependencies": [],
@@ -79,7 +84,9 @@
     "source": {
       "type": "github_release_latest",
       "repo": "hannesmann/vanillafixes",
-      "asset_contains": "dxvk"
+      "asset_contains": "dxvk",
+      "sha256": "a02a238fdefc9eb5f70a3c85c0c803d6b8667f951f531f3ad37b44f83fdb4b17",
+      "pinned_tag": "v1.5.3"
     },
     "kind": "zip_root",
     "dependencies": [],
@@ -101,12 +108,15 @@
     "source": {
       "type": "github_release_latest",
       "repo": "balakethelock/SuperWoW",
-      "asset_contains": "SuperWoW"
+      "asset_contains": "SuperWoW",
+      "sha256": "e1b37caf5496037fc369b8b68b5ef529be5fa951543869328bf38bef83dfa4a8",
+      "pinned_tag": "Release"
     },
     "addon_source": {
       "type": "github_zip",
-      "url": "https://github.com/balakethelock/SuperAPI/archive/refs/heads/master.zip",
-      "folder": "SuperAPI"
+      "url": "https://github.com/balakethelock/SuperAPI/archive/901322dc88890a2ea10610b8228fb43c9c2a3610.zip",
+      "folder": "SuperAPI",
+      "sha256": "9a719a1cf57a8de32b336b14c27ab165f741083ff1e833fa76034e882df94377"
     },
     "files": [
       {
@@ -139,7 +149,8 @@
     "source": {
       "type": "raw",
       "url": "https://codeberg.org/MarcelineVQ/WeirdUtils/releases/download/v0.7.0/healtextfix.dll",
-      "filename": "healtextfix.dll"
+      "filename": "healtextfix.dll",
+      "sha256": "ab25a789098921d922001ee9f178c7274c547c20540fe4b0572af4312b474ce5"
     },
     "files": [
       {
@@ -174,13 +185,17 @@
     "source": {
       "type": "github_release_latest",
       "repo": "brues-code/nampower",
-      "asset_contains": "nampower.dll"
+      "asset_contains": "nampower.dll",
+      "sha256": "304bdb35bc00b18ee092b3bc01195319f717c37d9c6babe6775e8fe278229d22",
+      "pinned_tag": "v4.6.1"
     },
     "addon_source": {
       "type": "github_release_latest",
       "repo": "brues-code/NampowerSettings",
       "asset_contains": ".zip",
-      "folder": "NampowerSettings"
+      "folder": "NampowerSettings",
+      "sha256": "e25ca123a4d7e762de4b737e98b0a26d08370fdf754726ee6d3f93a032a8690d",
+      "pinned_tag": "release"
     },
     "files": [
       {
@@ -211,7 +226,9 @@
     "source": {
       "type": "github_release_latest",
       "repo": "brues-code/UnitXP_SP3",
-      "asset_contains": "UnitXP_SP3.dll"
+      "asset_contains": "UnitXP_SP3.dll",
+      "sha256": "1d1a622fc4fd74864bdd5aa29d8c4ed2dd5cbb0340f978cbf4daca815235d10a",
+      "pinned_tag": "v90"
     },
     "files": [
       {
@@ -223,7 +240,9 @@
       "type": "github_release_latest",
       "repo": "brues-code/UnitXP_SP3_Addon",
       "asset_contains": ".zip",
-      "folder": "UnitXP_SP3_Addon"
+      "folder": "UnitXP_SP3_Addon",
+      "sha256": "740ce7e4f11b27e2fc6920b274ca2b4561415721aea89c48808cf635af673ea3",
+      "pinned_tag": "v3"
     },
     "dlls_txt": {
       "add": [
@@ -248,7 +267,9 @@
     "source": {
       "type": "github_release_latest",
       "repo": "brues-code/AuctionQueryThrottle",
-      "asset_contains": "AuctionQueryThrottle.dll"
+      "asset_contains": "AuctionQueryThrottle.dll",
+      "sha256": "720b7ad72941206249df23cb9d36addafa2634f190081f7b33834b84af184f5e",
+      "pinned_tag": "v1.2.0"
     },
     "files": [
       {
@@ -279,7 +300,9 @@
     "source": {
       "type": "github_release_latest",
       "repo": "brues-code/ClassicAPI",
-      "asset_contains": "ClassicAPI.dll"
+      "asset_contains": "ClassicAPI.dll",
+      "sha256": "2a823b141326383a56fba100d09f5a72f34798b08f38fa9340e5bdc2ee31dc65",
+      "pinned_tag": "v1.12.7"
     },
     "files": [
       {
@@ -310,12 +333,14 @@
     "source": {
       "type": "raw",
       "url": "https://raw.githubusercontent.com/RetroCro/TurtleWoW-Mods/refs/heads/main/Archive/DLL%20BACKUP/perf_boost.dll",
-      "filename": "perf_boost.dll"
+      "filename": "perf_boost.dll",
+      "sha256": "7019e2f31c4f56caa616f1b4b2587c56ff276f2c27c9f35535e2578eafbd4dbe"
     },
     "addon_source": {
       "type": "raw_zip",
       "url": "https://raw.githubusercontent.com/RetroCro/TurtleWoW-Mods/refs/heads/main/Archive/DLL%20BACKUP/perfboostsettings.zip",
-      "folder": "PerfBoostSettings"
+      "folder": "PerfBoostSettings",
+      "sha256": "9a0e0d74e8c638589ecf7a50b83e37fbe069ff95b41083ded34e30f4e6b2e3ba"
     },
     "dlls_txt": {
       "add": [
@@ -340,7 +365,8 @@
     "source": {
       "type": "raw",
       "url": "https://raw.githubusercontent.com/RetroCro/TurtleWoW-Mods/refs/heads/main/Archive/DLL%20BACKUP/no1600x1200.dll",
-      "filename": "no1600x1200.dll"
+      "filename": "no1600x1200.dll",
+      "sha256": "0df2274116278e8330dd7069902b642f1a83f33fefd909807a22eda197d88652"
     },
     "dlls_txt": {
       "add": [
@@ -396,7 +422,8 @@
     "source": {
       "type": "raw",
       "url": "https://github.com/doitsujin/dxvk/releases/download/v2.7.1/dxvk-2.7.1.tar.gz",
-      "filename": "dxvk-2.7.1.tar.gz"
+      "filename": "dxvk-2.7.1.tar.gz",
+      "sha256": "d85ce7c79f57ecd765aaa1b9e7007cb875e6fde9f6d331df799bce73d513ce87"
     },
     "bundled_files": [
       {
@@ -425,7 +452,9 @@
     "source": {
       "type": "github_release_latest",
       "repo": "isfir/VanillaHelpers",
-      "asset_contains": "VanillaHelpers.dll"
+      "asset_contains": "VanillaHelpers.dll",
+      "sha256": "1e74ddf6484c23482550d5f9e5f9d291085c4ac538d3b3ed9d87155521841196",
+      "pinned_tag": "v1.1.2"
     },
     "files": [
       {
@@ -458,7 +487,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-A.mpq",
-      "filename": "patch-A.mpq"
+      "filename": "patch-A.mpq",
+      "sha256": "d20a2480d322339fc8319d3a6922a895a189c7a9d6a39134d44731cc9e8927bb"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-A.mpq",
@@ -483,7 +513,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-B.mpq",
-      "filename": "patch-B.mpq"
+      "filename": "patch-B.mpq",
+      "sha256": "82758e1b95eb8fabd5defe7de35ae9babb1102e9d4bbf740dcdcbfd9a2fe1d01"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-B.mpq",
@@ -511,7 +542,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-C.mpq",
-      "filename": "patch-C.mpq"
+      "filename": "patch-C.mpq",
+      "sha256": "74557dfc1e82da9b66525a925ff49d36029b1a5612391e529e42c4d7ad0db48b"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-v.mpq",
@@ -536,7 +568,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-D.mpq",
-      "filename": "patch-D.mpq"
+      "filename": "patch-D.mpq",
+      "sha256": "ab46954bf0bbf0fa83ad0b0a3ab56f4392860b2d526b3275ba584ace420e5b06"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-D.mpq",
@@ -563,7 +596,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-E.mpq",
-      "filename": "patch-E.mpq"
+      "filename": "patch-E.mpq",
+      "sha256": "7944a61ce1a3bd66a46a2eb05ab94ae99887d494092fa8ade0e5b79b66c2855d"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-E.mpq",
@@ -593,7 +627,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-G.mpq",
-      "filename": "patch-G.mpq"
+      "filename": "patch-G.mpq",
+      "sha256": "6100c54ac0e8729f76d3f276881789175c6cd2899107d6fa3a6e4d0d66937df4"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-G.mpq",
@@ -618,7 +653,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-I.mpq",
-      "filename": "patch-I.mpq"
+      "filename": "patch-I.mpq",
+      "sha256": "16f7e45adbcff14dd635d30fc058ce4dca4ea832c66a41aeedc284506870bbd3"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-I.mpq",
@@ -643,7 +679,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-L.mpq",
-      "filename": "patch-L.mpq"
+      "filename": "patch-L.mpq",
+      "sha256": "2a1a271ecad8f800683e6acb135bbbd1eeb2ae15051c742adcab629a80e1f176"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-L.mpq",
@@ -672,7 +709,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/extras/patch-L.mpq",
-      "filename": "patch-L.mpq"
+      "filename": "patch-L.mpq",
+      "sha256": "bc58cf0024bd065d8f5e4d81fb558290fb437dfc4ee6f1e0ad41efe8909a8f54"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-L.mpq",
@@ -701,7 +739,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-M.mpq",
-      "filename": "patch-M.mpq"
+      "filename": "patch-M.mpq",
+      "sha256": "088652f39568d9a891679f67c142f35186c483b3ed9984faaf78f8d59c40aabf"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-M.mpq",
@@ -726,7 +765,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-N.mpq",
-      "filename": "patch-N.mpq"
+      "filename": "patch-N.mpq",
+      "sha256": "31dcd9f779ef1f4e9c4e71b5da58948781989f72c0454fa59fdd173947d24084"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-N.mpq",
@@ -751,7 +791,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-P.mpq",
-      "filename": "patch-P.mpq"
+      "filename": "patch-P.mpq",
+      "sha256": "7d0f4d22362bc0923f1802980f0c18e09964a2021c79ea604dbdc6d51b550399"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-P.mpq",
@@ -776,7 +817,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-S.mpq",
-      "filename": "patch-S.mpq"
+      "filename": "patch-S.mpq",
+      "sha256": "328d683683eea6d4237b6c5a86abc0a2049fbf9fe4a05ced8901b9d9e28d5bc5"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-S.mpq",
@@ -801,7 +843,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-T.mpq",
-      "filename": "patch-T.mpq"
+      "filename": "patch-T.mpq",
+      "sha256": "f18553b0e1318b3d3e58c52c24f839bd43a39f86d2798a312256e6c066ece05d"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-T.mpq",
@@ -831,7 +874,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/extras/patch-T.mpq",
-      "filename": "patch-T.mpq"
+      "filename": "patch-T.mpq",
+      "sha256": "7a0e46eb84df229bfff2b36f481a08ee62f0f30091fa07e0558ccee0b366c3f4"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-T.mpq",
@@ -861,7 +905,8 @@
     "source": {
       "type": "raw",
       "url": "https://pub-0f05631d243e4046993fc02ca7be9542.r2.dev/patches/patch-U.mpq",
-      "filename": "patch-U.mpq"
+      "filename": "patch-U.mpq",
+      "sha256": "b768b829d6042dae6928fd95c41704907fe2ce4c952b54b9e8350b37c0537215"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-U.mpq",
@@ -888,7 +933,9 @@
     "source": {
       "type": "github_release_latest",
       "repo": "MarcelineVQ/twow-raid-visuals",
-      "asset_contains": "patch-O.mpq"
+      "asset_contains": "patch-O.mpq",
+      "sha256": "aa99e91794b52ef4dba076b154c9bf5abd1b9417aa4e66925a454e4506bf898f",
+      "pinned_tag": "1.4.18"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-O.mpq",
@@ -911,7 +958,8 @@
       "type": "google_drive",
       "id": "1qu99ZS-SQFfTtYodBmZWYiHmxL8QtUY4",
       "filename": "patch-Z.mpq",
-      "timeout": 300
+      "timeout": 300,
+      "sha256": "b72e5837139772dff5e436c6a6375910fcb5c34ae5742512968463425c4520dd"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-Z.mpq",
@@ -933,7 +981,8 @@
       "type": "google_drive",
       "id": "1xRx9OrznbgbE1uBae3H3OGke9UoXtzmU",
       "filename": "patch-W.mpq",
-      "timeout": 300
+      "timeout": 300,
+      "sha256": "30a969c185cc082a0eb158a7901de889af815426c1e5baec373649688b3151aa"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-W.mpq",
@@ -955,7 +1004,8 @@
       "type": "google_drive",
       "id": "14aHvyfr_ACL-UURbNa_fXRPcfQZoIw8n",
       "filename": "patch-Y.mpq",
-      "timeout": 180
+      "timeout": 180,
+      "sha256": "c59b87f7e9425ee890e2b869ea0d26cde84a68e3ee1004e18bb6a29b294c3e0d"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-Y.mpq",
@@ -978,7 +1028,8 @@
     "source": {
       "type": "raw",
       "url": "https://raw.githubusercontent.com/seacrabsam/patch-herb/main/patch-H.mpq",
-      "filename": "patch-H.mpq"
+      "filename": "patch-H.mpq",
+      "sha256": "45b6b6795465a93104de213e0a36e1290b005a852cd6d03a8d21103efaefa0a7"
     },
     "kind": "mpq_file",
     "destination": "Data/patch-H.mpq",
@@ -998,7 +1049,8 @@
     },
     "source": {
       "type": "github_zip",
-      "url": "https://github.com/paokkerkir/vanilla-autologin/archive/refs/heads/main.zip"
+      "url": "https://github.com/paokkerkir/vanilla-autologin/archive/2665aeb14d9eaaa51f1532c7dc689c6a18b49a73.zip",
+      "sha256": "2077a840ff7f1b9d7dddeef4dfab1f57db3b674e41f571d48e3d6359cd7e106d"
     },
     "kind": "glue_autologin",
     "dependencies": [
@@ -1021,7 +1073,8 @@
     "source": {
       "type": "raw",
       "url": "https://raw.githubusercontent.com/RetroCro/TurtleWoW-Mods/refs/heads/main/Archive/d3d9.dll",
-      "filename": "d3d9.dll"
+      "filename": "d3d9.dll",
+      "sha256": "768672bb9a1464e7f64f15793d226ace379a7f6830ba774bd3f72026cc6b2219"
     },
     "kind": "dxvk_cursor",
     "dependencies": [
@@ -1045,7 +1098,8 @@
     "source": {
       "type": "raw",
       "url": "https://codeberg.org/MarcelineVQ/WeirdUtils/releases/download/v0.7.1/worldmarkers.dll",
-      "filename": "worldmarkers.dll"
+      "filename": "worldmarkers.dll",
+      "sha256": "7b0b0fcdb8bb9e82c5a18ab395af670f57da3e03035b27d5e244e4f8b457fdf2"
     },
     "files": [
       {
@@ -1147,7 +1201,8 @@
     "source": {
       "type": "raw",
       "url": "https://codeberg.org/MarcelineVQ/WeirdUtils/releases/download/v0.7.0/pngscreenshots.dll",
-      "filename": "pngscreenshots.dll"
+      "filename": "pngscreenshots.dll",
+      "sha256": "44ca42ac8428eb4e69017ad264b8e86206e803ccbe3a3591d6ba1916d7888dca"
     },
     "files": [
       {
@@ -1215,7 +1270,8 @@
     "source": {
       "type": "raw",
       "url": "https://codeberg.org/MarcelineVQ/WeirdUtils/releases/download/v0.7.0/transmogfix.dll",
-      "filename": "transmogfix.dll"
+      "filename": "transmogfix.dll",
+      "sha256": "cd9e4c6ce033b0923cf045269f590f5e0b886bd03f43bd81406670d781452210"
     },
     "files": [
       {
@@ -1248,7 +1304,8 @@
     "source": {
       "type": "raw",
       "url": "https://codeberg.org/MarcelineVQ/WeirdUtils/releases/download/v0.7.0/customassets.dll",
-      "filename": "customassets.dll"
+      "filename": "customassets.dll",
+      "sha256": "86f3a24cfbaa8d775bdab280d63fbf48b445d8789c2759fe912183462f36f06f"
     },
     "files": [
       {
@@ -1281,7 +1338,8 @@
     "source": {
       "type": "raw",
       "url": "https://codeberg.org/MarcelineVQ/WeirdUtils/releases/download/v0.7.0/minimapicons.dll",
-      "filename": "minimapicons.dll"
+      "filename": "minimapicons.dll",
+      "sha256": "a6821e088d0f8ffa7806e88e1b8686f4ec715a218f74f62d6f33bd9bcf91583e"
     },
     "files": [
       {
@@ -1315,7 +1373,8 @@
     "source": {
       "type": "raw",
       "url": "https://codeberg.org/MarcelineVQ/WeirdUtils/releases/download/v0.7.0/clickthrough.dll",
-      "filename": "clickthrough.dll"
+      "filename": "clickthrough.dll",
+      "sha256": "163b409ecd9e7e6e08f6c8645443def5aa73e64000d3b4632ffb5dd561347fa7"
     },
     "files": [
       {
@@ -1348,7 +1407,8 @@
     "source": {
       "type": "raw",
       "url": "https://codeberg.org/MarcelineVQ/WeirdUtils/releases/download/v0.7.0/logsessions.dll",
-      "filename": "logsessions.dll"
+      "filename": "logsessions.dll",
+      "sha256": "f5f37e449dc4646b6d2de8c01e57b954ab2fb7950bef372ddba2c744fb7b9841"
     },
     "files": [
       {
@@ -1415,7 +1475,8 @@
     "source": {
       "type": "raw",
       "url": "https://codeberg.org/MarcelineVQ/WeirdUtils/releases/download/v0.7.0/weirdperformance.dll",
-      "filename": "weirdperformance.dll"
+      "filename": "weirdperformance.dll",
+      "sha256": "ab9cf654ba18cca7ae2197864a7fc773f03ca1e31069b6d7b1eed9639e796f37"
     },
     "files": [
       {

--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -86,6 +86,11 @@ from ichalaunch.game.launcher import (
     vf_mode_display,
     wow_exe_in,
 )
+from ichalaunch.mods.verify import (
+    SourceHashMismatch,
+    expected_digest,
+    verify_payload,
+)
 
 ProgressCb = Callable[[str], None]
 UA = {"User-Agent": "IchaLaunch/0.1"}
@@ -2253,8 +2258,38 @@ def _pick_dxvk_win32_d3d9(search_root: Path) -> Path:
     return min(candidates, key=lambda p: len(p.parts))
 
 
+def _source_label(source: dict[str, Any]) -> str:
+    """Something human-sized to name a source in a refusal message."""
+    for key in ("filename", "folder", "repo", "url", "id"):
+        value = source.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().split("/")[-1].split("?")[0] or value.strip()
+    return str(source.get("type") or "download")
+
+
 def _download_source(source: dict[str, Any], work: Path, progress: ProgressCb | None) -> Path | bytes:
-    """Download a catalog source.
+    """Download a catalog source and refuse it if it misses its pinned digest.
+
+    Every download the installer performs funnels through here, so wrapping the
+    fetch is what makes the check unbypassable: a new source type added later
+    inherits verification without anyone remembering to ask for it.
+
+    Sources with no ``sha256`` install exactly as before. See
+    ``ichalaunch.mods.verify`` for why an unpinned entry is a maintainer
+    decision rather than a hole an attacker can open.
+    """
+    payload = _download_source_unverified(source, work, progress)
+    digest = verify_payload(source, payload, label=_source_label(source))
+    if digest:
+        log.info("Verified %s against pinned sha256 %s", _source_label(source), digest)
+    return payload
+
+
+def _download_source_unverified(
+    source: dict[str, Any], work: Path, progress: ProgressCb | None
+) -> Path | bytes:
+    """Fetch the bytes for a catalog source. Callers must go through
+    :func:`_download_source`, which adds the pinned-digest check.
 
     Zip archives are kept in memory so Windows Defender cannot quarantine the
     tempfile between download and ``ZipFile`` open (VanillaFixes.exe / patcher
@@ -3097,6 +3132,14 @@ def install_mod(mod_id: str, progress: ProgressCb | None = None, *, prefer_lates
                 and source
                 and source.get("type") == "github_release"
                 and mod_id != _VANILLA_TWEAKS_OLD_ID
+                # A pinned source has already had its version chosen by a
+                # maintainer who tested those exact bytes. Re-pointing it at
+                # whatever upstream published since would rebuild the source
+                # dict without the digest, and installing unverified bytes is
+                # the one thing this path must never do. The update scan still
+                # reports that something newer exists; adopting it is a catalog
+                # edit, not a button press.
+                and not expected_digest(source)
             ):
                 repo = _repo_from_github_url(source.get("url") or "")
                 if repo:

--- a/ichalaunch/mods/verify.py
+++ b/ichalaunch/mods/verify.py
@@ -1,0 +1,167 @@
+"""Content pinning for everything the mod installer downloads.
+
+The launcher already refuses a self-update that is not signed by a pinned key
+(``ichalaunch.core.signing``). That protects the launcher updating *itself*. It
+says nothing about the DLLs, patches and archives the launcher installs *into
+the game*, which arrive from a dozen third-party GitHub accounts, a Google
+Drive folder and an R2 bucket. Any one of those accounts being compromised puts
+arbitrary code into the game directory of every player who clicks Apply.
+
+Why a hash is enough here, when it is not enough for the self-update
+-------------------------------------------------------------------
+``signing`` argues that a hash cannot establish trust, because whoever controls
+the host that publishes the hash also controls the file. That objection does
+not apply to this module, and the difference is where the number lives.
+
+These digests are not fetched. They are written into ``mods.json``, which ships
+inside the launcher executable, which is itself covered by the Ed25519 chain in
+``signing``. So the digest is already anchored to our signing key before any
+download begins. The host serving the bytes never gets a say in what they are
+compared against. An attacker who owns the upstream release, the bucket, or DNS
+can serve whatever they like and the install still refuses.
+
+What a pin does and does not promise
+------------------------------------
+A pin says "these are the exact bytes a maintainer downloaded, tested, and
+chose". It does not say the bytes are safe. Pinning a malicious file pins
+malice perfectly. The pin removes the *upstream* from the trust set; it does
+not remove the maintainer.
+
+Unpinned sources still install, but there are none left
+-------------------------------------------------------
+An entry without ``sha256`` installs as before. That is deliberate: absence of a
+pin is a maintainer decision recorded in a signed catalog, not something an
+attacker can arrange, and it allowed pins to land without breaking every install
+at once.
+
+Every downloadable source in the shipped catalog is now pinned, and the suite
+asserts that it stays that way via ``unpinned_source_ids()``. So the permissive
+branch is a migration affordance rather than a live gap: adding a mod without a
+digest fails a test rather than reaching a player.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+CHUNK = 1024 * 1024
+
+
+class SourceHashMismatch(Exception):
+    """A download did not match the digest pinned for it.
+
+    Raised instead of returning a flag because there is no safe way to continue.
+    """
+
+
+def normalized_digest(value: Any) -> str | None:
+    """A catalog ``sha256`` field as 64 lowercase hex chars, or None if unusable.
+
+    Accepts the ``sha256:`` prefix and surrounding whitespace so a digest pasted
+    from ``Get-FileHash`` or ``sha256sum`` works unedited. Anything that is not
+    a well-formed SHA-256 returns None and is treated as "no pin" rather than as
+    a failed comparison, so a typo cannot silently become a permanent refusal.
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip().lower()
+    if text.startswith("sha256:"):
+        text = text[len("sha256:") :].strip()
+    if len(text) != 64:
+        return None
+    try:
+        int(text, 16)
+    except ValueError:
+        return None
+    return text
+
+
+def expected_digest(source: dict[str, Any] | None) -> str | None:
+    """The digest pinned for this catalog source, if any."""
+    if not isinstance(source, dict):
+        return None
+    return normalized_digest(source.get("sha256"))
+
+
+def digest_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def digest_path(path: Path) -> str:
+    """Hash a file by streaming it.
+
+    Deliberately does not use ``core.filesystem.sha256_file``: that helper
+    returns None for locked or missing paths so that *detection* can skip them.
+    Skipping is the wrong answer here. A payload we cannot read is a payload we
+    cannot verify, and the caller must refuse rather than shrug.
+    """
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            block = handle.read(CHUNK)
+            if not block:
+                break
+            h.update(block)
+    return h.hexdigest()
+
+
+def verify_payload(
+    source: dict[str, Any] | None,
+    payload: Path | bytes,
+    *,
+    label: str = "download",
+) -> str | None:
+    """Check a freshly downloaded payload against its pin.
+
+    Returns the digest actually seen when a pin was present and matched, or None
+    when the source carries no pin. Raises :class:`SourceHashMismatch` when a pin
+    is present and the bytes do not match it, or when the payload cannot be read
+    to be hashed.
+
+    Fails closed in every direction. There is deliberately no override, because
+    an override is the first thing an attacker would talk a user into using.
+    """
+    expected = expected_digest(source)
+    if expected is None:
+        return None
+
+    try:
+        actual = digest_bytes(payload) if isinstance(payload, bytes) else digest_path(payload)
+    except OSError as exc:
+        raise SourceHashMismatch(
+            f"Refusing to install {label}: the download could not be read to "
+            f"verify it against the expected SHA-256 ({exc})."
+        ) from exc
+
+    if actual != expected:
+        raise SourceHashMismatch(
+            f"Refusing to install {label}: content does not match the pinned "
+            f"SHA-256.\n  expected {expected}\n  got      {actual}\n"
+            "The file served upstream is not the file this build was built to "
+            "trust. Nothing has been written to the game directory."
+        )
+    return actual
+
+
+def unpinned_source_ids(catalog: list[dict[str, Any]]) -> list[str]:
+    """Ids of catalog entries that download something without a pin covering it.
+
+    ``local`` sources are excluded: they copy a file the user already has on
+    disk rather than fetching one, so there is no upstream to distrust.
+    """
+    out: list[str] = []
+    for mod in catalog:
+        mod_id = str(mod.get("id") or "")
+        if not mod_id:
+            continue
+        for key in ("source", "addon_source"):
+            source = mod.get(key)
+            if not isinstance(source, dict):
+                continue
+            if source.get("type") == "local":
+                continue
+            if expected_digest(source) is None:
+                out.append(mod_id if key == "source" else f"{mod_id}:{key}")
+    return out

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 import sys
@@ -9967,6 +9968,169 @@ def test_launcher_release_cache():
     print("OK launcher release cache")
 
 
+
+def test_mod_download_hash_pinning():
+    """Pinned mod downloads: verified, refused, or explicitly unpinned."""
+    import hashlib
+    import json as _json
+    from pathlib import Path as _Path
+    from tempfile import TemporaryDirectory
+
+    from ichalaunch.mods.verify import (
+        SourceHashMismatch,
+        expected_digest,
+        normalized_digest,
+        unpinned_source_ids,
+        verify_payload,
+    )
+
+    payload = b"pretend this is SuperWoWhook.dll"
+    digest = hashlib.sha256(payload).hexdigest()
+
+    # No pin -> installs as before, and says so by returning None.
+    assert verify_payload({"type": "raw"}, payload) is None
+
+    # Matching pin -> returns the digest actually seen.
+    assert verify_payload({"sha256": digest}, payload) == digest
+
+    # Digests pasted from Get-FileHash / sha256sum work unedited.
+    assert verify_payload({"sha256": f"SHA256:{digest.upper()}  "}, payload) == digest
+
+    # A wrong digest refuses, and the message names both sides.
+    try:
+        verify_payload({"sha256": "0" * 64}, payload, label="SuperWoW.dll")
+    except SourceHashMismatch as exc:
+        assert "SuperWoW.dll" in str(exc) and digest in str(exc)
+    else:
+        raise AssertionError("tampered payload was accepted")
+
+    # A malformed pin is "no pin", never an accidental permanent refusal.
+    for junk in ("", "not-a-hash", digest[:-1], "zz" + digest[2:], None, 12345):
+        assert normalized_digest(junk) is None
+        assert verify_payload({"sha256": junk}, payload) is None
+
+    # Files are hashed by streaming, and an unreadable payload refuses.
+    with TemporaryDirectory(prefix="ichalaunch_pin_") as tmp:
+        good = _Path(tmp) / "mod.dll"
+        good.write_bytes(payload)
+        assert verify_payload({"sha256": digest}, good) == digest
+        missing = _Path(tmp) / "not-there.dll"
+        try:
+            verify_payload({"sha256": digest}, missing)
+        except SourceHashMismatch:
+            pass
+        else:
+            raise AssertionError("unreadable payload was accepted")
+
+    # Every pin shipped in the catalog is well formed.
+    catalog = _json.loads(
+        (_Path("ichalaunch") / "data" / "mods.json").read_text(encoding="utf-8")
+    )
+    for mod in catalog:
+        for key in ("source", "addon_source"):
+            src = mod.get(key)
+            if isinstance(src, dict) and "sha256" in src:
+                assert expected_digest(src) is not None, (
+                    f"{mod.get('id')}.{key} has an unusable sha256"
+                )
+
+    # Coverage is complete, so the invariant is simply that it stays complete:
+    # a catalog entry that downloads anything carries a digest. Adding a mod
+    # without pinning it should fail here rather than in a player's install.
+    unpinned = unpinned_source_ids(catalog)
+    assert not unpinned, f"catalog sources with no sha256: {unpinned}"
+    pinned = sum(
+        1
+        for m in catalog
+        for k in ("source", "addon_source")
+        if isinstance(m.get(k), dict) and expected_digest(m[k])
+    )
+    print(f"OK mod download hash pinning ({pinned} catalog sources pinned)")
+
+
+def test_download_source_enforces_pins():
+    """The installer's own download path refuses bytes that miss the pin."""
+    import hashlib
+
+    from ichalaunch.mods import installer as I
+    from ichalaunch.mods.verify import SourceHashMismatch
+
+    served = b"bytes the upstream actually served"
+    digest = hashlib.sha256(served).hexdigest()
+    calls = []
+
+    def fake_fetch(source, work, progress):
+        calls.append(source.get("type"))
+        return served
+
+    original = I._download_source_unverified
+    I._download_source_unverified = fake_fetch  # type: ignore[assignment]
+    try:
+        # Correct pin: the payload is handed back untouched.
+        assert I._download_source({"type": "raw", "sha256": digest}, None, None) == served
+
+        # Swapped upstream asset: refused before anything is written.
+        try:
+            I._download_source(
+                {"type": "raw", "sha256": "f" * 64, "filename": "nampower.dll"},
+                None,
+                None,
+            )
+        except SourceHashMismatch as exc:
+            assert "nampower.dll" in str(exc)
+        else:
+            raise AssertionError("installer installed unverified bytes")
+
+        # Unpinned entries keep working.
+        assert I._download_source({"type": "raw"}, None, None) == served
+    finally:
+        I._download_source_unverified = original  # type: ignore[assignment]
+
+    assert len(calls) == 3
+    print("OK installer refuses unpinned-mismatch downloads")
+
+
+def test_update_button_cannot_discard_a_pin():
+    """prefer_latest must not rebuild a pinned source without its digest."""
+    from ichalaunch.mods import installer as I
+    from ichalaunch.mods.verify import expected_digest
+
+    # The Update path converts a fixed-url github_release source into a
+    # "whatever is newest" source. Rebuilding the dict is how a digest gets
+    # dropped, and a dropped digest means an unverified install.
+    pinned = {
+        "type": "github_release",
+        "url": "https://github.com/o/r/releases/download/v1/thing-1.0.zip",
+        "sha256": "a" * 64,
+    }
+    unpinned = {
+        "type": "github_release",
+        "url": "https://github.com/o/r/releases/download/v1/thing-1.0.zip",
+    }
+
+    src = inspect.getsource(I.install_mod)
+    assert "expected_digest(source)" in src, (
+        "install_mod no longer guards the prefer_latest conversion on the pin"
+    )
+    assert expected_digest(pinned) is not None
+    assert expected_digest(unpinned) is None
+
+    # The conversion is guarded by a single boolean; assert both arms of it.
+    def would_convert(source, prefer_latest, mod_id="superwow"):
+        return bool(
+            prefer_latest
+            and source
+            and source.get("type") == "github_release"
+            and mod_id != I._VANILLA_TWEAKS_OLD_ID
+            and not expected_digest(source)
+        )
+
+    assert would_convert(unpinned, True), "unpinned sources should still follow latest"
+    assert not would_convert(pinned, True), "a pinned source must never be re-pointed"
+    assert not would_convert(pinned, False)
+    print("OK update button keeps the pin")
+
+
 def test_update_signature_verification():
     """Signed-update verification: fails closed in every direction."""
     import base64
@@ -17304,6 +17468,9 @@ def _run_smoke_tests():
     test_linux_game_running_guard()
     test_detect_and_installer_drop_unused_imports()
     test_update_signature_verification()
+    test_mod_download_hash_pinning()
+    test_download_source_enforces_pins()
+    test_update_button_cannot_discard_a_pin()
     test_update_signing_keys_are_pinned()
     test_signature_sidecar_url_and_unverified_exe_is_deleted()
     test_home_art_width_fit_is_centred()

--- a/tools/pin_mods.py
+++ b/tools/pin_mods.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Check or refresh the SHA-256 pins in ``ichalaunch/data/mods.json``.
+
+Usage:
+    python tools/pin_mods.py --check              # report drift, exit 1 if any
+    python tools/pin_mods.py --update superwow    # re-pin one mod
+    python tools/pin_mods.py --update --all       # re-pin everything that drifted
+
+A pin says "these are the exact bytes a maintainer downloaded, tested and
+chose". Nothing here tests anything, so ``--update`` is not a rubber stamp: it
+records what upstream is serving *right now*. Run the game with the new build
+before you commit the new number, or the pin certifies malware just as faithfully
+as it certifies a fix.
+
+Why drift is expected, and is not a bug
+---------------------------------------
+Ten catalog entries resolve through ``github_release_latest``, meaning the
+launcher asks GitHub for whatever the newest release is. Pinning those does not
+freeze them; it means that when an upstream publishes something new, the install
+**refuses** until a maintainer looks at it and re-pins. That refusal is the
+feature. ``--check`` is how you find out it is time to look, ideally on a
+schedule rather than from a player's bug report.
+
+Two upstreams reuse a rolling tag rather than cutting a new one
+---------------------------------------------------------------
+``tubtubs/vanilla-tweaks`` publishes to a tag literally named ``tag``, and
+``balakethelock/SuperWoW`` to one named ``Release``. Those tags are moved, so
+their bytes can change without any version number changing anywhere. They are
+the two most likely to drift and the two where drift is least visible upstream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ichalaunch.mods.verify import expected_digest  # noqa: E402
+
+CATALOG = Path(__file__).resolve().parent.parent / "ichalaunch" / "data" / "mods.json"
+UA = {"User-Agent": "IchaLaunch-pin-mods/1.0"}
+TIMEOUT = 300
+
+
+def _get(url: str) -> bytes:
+    req = urllib.request.Request(url, headers=UA)
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+        return resp.read()
+
+
+def _latest_asset(source: dict[str, Any]) -> tuple[str, str, bytes]:
+    """(tag, asset_name, bytes) for the asset this source would install today."""
+    repo = source["repo"]
+    want = (source.get("asset_contains") or "").lower()
+    skip = (source.get("asset_not_contains") or "").lower()
+    release = json.loads(_get(f"https://api.github.com/repos/{repo}/releases/latest"))
+    for asset in release.get("assets", []):
+        name = asset["name"].lower()
+        if want and want not in name:
+            continue
+        if skip and skip in name:
+            continue
+        return release.get("tag_name", "?"), asset["name"], _get(asset["browser_download_url"])
+    raise SystemExit(f"{repo}: no release asset matching {want!r}")
+
+
+def _fixed_url_asset(source: dict[str, Any]) -> tuple[str, str, bytes]:
+    url = source["url"]
+    return "-", url.rsplit("/", 1)[-1].split("?")[0], _get(url)
+
+
+def resolve(source: dict[str, Any]) -> tuple[str, str, bytes]:
+    stype = source.get("type")
+    if stype == "github_release_latest":
+        return _latest_asset(source)
+    if stype in ("raw", "github_release", "github_zip", "raw_zip"):
+        return _fixed_url_asset(source)
+    raise SystemExit(f"cannot resolve source type {stype!r} from here")
+
+
+PINNABLE = ("github_release_latest", "github_release", "raw", "github_zip", "raw_zip")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("ids", nargs="*", help="mod ids to act on (default: every pinned entry)")
+    ap.add_argument("--check", action="store_true", help="report drift without writing")
+    ap.add_argument("--update", action="store_true", help="write refreshed pins")
+    ap.add_argument("--all", action="store_true", help="with --update, re-pin every drifted entry")
+    args = ap.parse_args()
+    if not (args.check or args.update):
+        ap.error("pass --check or --update")
+
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    wanted = set(args.ids)
+    drifted: list[str] = []
+    unpinned: list[str] = []
+    changed = 0
+
+    for mod in catalog:
+        mod_id = str(mod.get("id") or "")
+        source = mod.get("source")
+        if not isinstance(source, dict) or source.get("type") not in PINNABLE:
+            continue
+        if wanted and mod_id not in wanted:
+            continue
+        pinned = expected_digest(source)
+        if pinned is None and not (args.update and (args.all or wanted)):
+            unpinned.append(mod_id)
+            continue
+        try:
+            tag, name, blob = resolve(source)
+        except (urllib.error.URLError, urllib.error.HTTPError) as exc:
+            print(f"  {mod_id:24s} UNREACHABLE  {exc}")
+            drifted.append(mod_id)
+            continue
+        actual = hashlib.sha256(blob).hexdigest()
+        if pinned == actual:
+            print(f"  {mod_id:24s} ok           {name} ({tag})")
+            continue
+        drifted.append(mod_id)
+        state = "NEW" if pinned is None else "DRIFTED"
+        print(f"  {mod_id:24s} {state:12s} {name} ({tag})")
+        if pinned:
+            print(f"  {'':24s}   pinned {pinned}")
+        print(f"  {'':24s}   actual {actual}")
+        if args.update and (args.all or wanted):
+            source["sha256"] = actual
+            source["pinned_tag"] = tag
+            changed += 1
+
+    if unpinned:
+        print(f"\nNot pinned yet ({len(unpinned)}): {', '.join(sorted(unpinned))}")
+    if changed:
+        CATALOG.write_text(json.dumps(catalog, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print(f"\nRewrote {CATALOG.name} with {changed} refreshed pin(s).")
+        print("Test the game with these builds before committing.")
+    if drifted and not changed:
+        print(f"\n{len(drifted)} entr(y/ies) do not match their pin: {', '.join(drifted)}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The launcher already refuses a self-update that is not signed by a pinned key.
That covers the launcher updating itself. It says nothing about the DLLs,
patches and archives the launcher installs into the game, which arrive from a
dozen third-party GitHub accounts, a Google Drive folder and an R2 bucket. Any
one of them being compromised puts arbitrary code into the game directory of
every player who clicks Apply.

This adds "sha256" to a catalog source. The download is hashed and refused if it
does not match. Nothing is written to the game directory on a mismatch, and
there is deliberately no override.

Why a hash is enough here when it is not enough for the self-update: these
digests are not fetched. They live in mods.json, which ships inside the
executable, which is already covered by the Ed25519 chain. The digest is
anchored to our signing key before any download starts, so the host serving the
bytes never gets a say in what they are compared against.

Coverage: 49 of 49
-------------------
Every downloadable source in the catalog is pinned. Nothing is left over.

Every asset was downloaded and hashed locally rather than trusting a published
number. Where GitHub also publishes a digest, the two agree. The 12 HD texture
MPQs, about 12 GB, were streamed and hashed without being written to disk.

Two sources had to be repointed before they could be pinned
------------------------------------------------------------
  superwow    addon_source   SuperAPI/archive/refs/heads/master.zip
  auto_login  source         vanilla-autologin/archive/refs/heads/main.zip

Both pointed at a branch archive, so the bytes changed on every push. Neither
repo has a release or even a tag, so there was nothing to point at except a
commit. They now use archive/<full sha>.zip, which freezes the content and makes
any change a deliberate catalog edit.

One caveat, stated plainly: GitHub regenerates source archives, and has changed
their compression in the past, so an archive digest can in principle move
without the commit moving. I fetched each twice and the bytes were identical,
and the failure mode if it ever happens is a refusal rather than a silent
accept. If you would rather not carry that risk at all, the alternative is to
mirror both zips into the R2 bucket and pin those, which needs bucket access I
do not have.

What reviewers should push back on if they disagree
---------------------------------------------------
A pin on a github_release_latest source does not freeze it. When an upstream
publishes something new, the install refuses until a maintainer re-pins. That is
the intended behaviour and it matches the "update available, pending review"
posture, but it is a policy choice with a cost, and 12 sources are affected.
tools/pin_mods.py --check reports drift so it is found on a schedule rather than
from a player's bug report.

Three upstreams reuse a rolling tag instead of cutting a new one, so their bytes
can change with no version number changing anywhere. Expect these to drift most,
and to drift invisibly:

  tubtubs/vanilla-tweaks           tag "tag"
  balakethelock/SuperWoW           tag "Release"
  brues-code/NampowerSettings      tag "release"

An entry with no sha256 still installs, because absence of a pin is a maintainer
decision recorded in a signed catalog rather than something an attacker can
arrange. Since coverage is now complete, that branch is a migration affordance
rather than a live gap, and the suite asserts it stays complete: adding a mod
without a digest fails a test instead of reaching a player.

Verification wraps the single function every download already funnels through,
so a source type added later inherits the check without anyone remembering to
ask for it.

Tests: two added. Five mutations were tried against them and all five were
caught: dropping a pin, making a mismatch return instead of raise, removing the
call from the installer, accepting malformed digests, and adding an unpinned
catalog entry.

Unrelated and fixed separately in #415: smoke_test.py is red on master because
one bundled addon row, _LazyPig, mentions Turtle WoW without being flagged
turtle_custom.

The Update button could still install unverified bytes
-------------------------------------------------------
Found by adversarially reviewing this branch rather than by writing it. With
prefer_latest set, which is what the Update button passes, install_mod rebuilt a
github_release source into a github_release_latest one so it would follow
whatever upstream published since. The rebuilt dict carried four keys and sha256
was not among them, so verify_payload saw no pin, returned None, and the install
proceeded unverified. Every pin in this PR was bypassable through the button
most likely to be pressed.

The conversion is now skipped when the source carries a digest. A pinned source
already had its version chosen by someone who tested those exact bytes, and
adopting a newer one is a catalog edit rather than a button press. The update
scan still reports that something newer exists. A third test covers it, and it
asserts on the guard itself so deleting the condition fails the suite.

