### PR TITLE
Refuse an addon install that resolves outside the AddOns folder

### DIFF
--- a/ichalaunch/core/filesystem.py
+++ b/ichalaunch/core/filesystem.py
@@ -1142,6 +1142,40 @@ def rename_addon_folder_to_toc(
     )
 
 
+class AddonDestinationRefused(Exception):
+    """An addon asked to be installed somewhere that is not its own folder."""
+
+
+def _require_direct_child(addons_dir: Path, dest: Path, dest_name: str) -> None:
+    """Refuse a destination that is not a folder directly inside AddOns.
+
+    The destination folder name comes from the ``.toc`` filename found INSIDE a
+    downloaded archive, so it is attacker controlled for any catalog entry.
+    A ``.toc`` named ``".. .toc"`` yields the stem ``".. "``, which ``.strip()``
+    turns into ``".."``, which makes the destination the Interface folder. The
+    next line removes the destination before copying, so installing that addon
+    would delete every installed addon and the player's saved variables.
+
+    This is checked structurally rather than by rejecting known-bad names. A
+    blocklist has to anticipate the next trick (trailing dots, reserved device
+    names, separators, unicode that normalises to a separator on one platform).
+    Requiring that the resolved destination be a direct child of AddOns holds
+    without knowing what the trick is.
+    """
+    try:
+        root = addons_dir.resolve()
+        target = dest.resolve()
+    except OSError as exc:  # pragma: no cover - unreadable mount
+        raise AddonDestinationRefused(
+            f"Refusing to install {dest_name!r}: destination could not be resolved ({exc})."
+        ) from exc
+    if target == root or target.parent != root:
+        raise AddonDestinationRefused(
+            f"Refusing to install {dest_name!r}: it resolves to {target}, which is not a "
+            f"folder inside {root}. Nothing has been removed or written."
+        )
+
+
 def place_install_addon_root(
     root: Path,
     addons_dir: Path,
@@ -1161,6 +1195,7 @@ def place_install_addon_root(
     dest_name = (canonical or dest_name or root.name).strip() or root.name
 
     dest = addons_dir / dest_name
+    _require_direct_child(addons_dir, dest, dest_name)
     if dest.exists():
         safe_remove(dest)
     copy_tree(root, dest)

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -9967,6 +9967,56 @@ def test_launcher_release_cache():
     print("OK launcher release cache")
 
 
+
+def test_addon_install_cannot_escape_the_addons_folder():
+    """A .toc name inside a downloaded zip must not aim the installer at Interface."""
+    import shutil
+    import tempfile
+    from pathlib import Path as _P
+
+    from ichalaunch.core.filesystem import (
+        AddonDestinationRefused,
+        place_install_addon_root,
+    )
+
+    with tempfile.TemporaryDirectory(prefix="ichalaunch_esc_") as tmp:
+        base = _P(tmp)
+        interface = base / "Interface"
+        addons = interface / "AddOns"
+        addons.mkdir(parents=True)
+        (interface / "FrameXML").mkdir()
+        keep = addons / "RealAddon"
+        keep.mkdir()
+        (keep / "RealAddon.toc").write_text("## Interface: 11200", encoding="utf-8")
+
+        # The destination folder is taken from the .toc filename found inside the
+        # archive, and ".. " strips to "..", which points one level up at Interface.
+        # place_install_addon_root removes the destination before copying, so
+        # accepting this would delete every addon and the saved variables with them.
+        for hostile in (".. .toc", " .. .toc"):
+            payload = base / "payload"
+            payload.mkdir()
+            (payload / hostile).write_text("## Interface: 11200", encoding="utf-8")
+            try:
+                place_install_addon_root(payload, addons, "innocent-looking-name")
+            except AddonDestinationRefused:
+                pass
+            else:
+                raise AssertionError(f"{hostile!r} was accepted as a destination")
+            shutil.rmtree(payload)
+
+        assert interface.is_dir(), "Interface was removed"
+        assert (interface / "FrameXML").is_dir(), "FrameXML was removed"
+        assert keep.is_dir(), "an unrelated installed addon was removed"
+
+        # An ordinary addon still installs under its .toc stem.
+        good = base / "good"
+        good.mkdir()
+        (good / "Nice.toc").write_text("## Interface: 11200", encoding="utf-8")
+        name, mismatch = place_install_addon_root(good, addons, "ignored")
+        assert name == "Nice" and (addons / "Nice").is_dir(), "normal install broke"
+    print("OK addon install stays inside AddOns")
+
 def test_update_signature_verification():
     """Signed-update verification: fails closed in every direction."""
     import base64
@@ -17304,6 +17354,7 @@ def _run_smoke_tests():
     test_linux_game_running_guard()
     test_detect_and_installer_drop_unused_imports()
     test_update_signature_verification()
+    test_addon_install_cannot_escape_the_addons_folder()
     test_update_signing_keys_are_pinned()
     test_signature_sidecar_url_and_unverified_exe_is_deleted()
     test_home_art_width_fit_is_centred()


### PR DESCRIPTION
Installing a catalog addon can delete the player's entire Interface folder,
including every other addon and all saved variables. Any of the 1030 catalog
entries can trigger it, because the trigger lives in the downloaded archive
rather than in the catalog row.

The path, in place_install_addon_root (ichalaunch/core/filesystem.py):

  canonical = canonical_addon_folder_name(root)      # stem of the .toc in the zip
  dest_name = (canonical or dest_name or root.name).strip() or root.name
  dest = addons_dir / dest_name
  if dest.exists():
      safe_remove(dest)                              # robust_rmtree

The destination folder name is taken from the .toc filename found INSIDE the
downloaded archive, so it is controlled by whoever publishes the addon. A .toc
named ".. .toc" has the stem ".. ", and the .strip() on the next line turns that
into "..". The destination becomes AddOns/.., which is Interface, and the line
that clears the destination before copying removes it.

Reproduced against master, in a temporary tree:

  addons before:          BigWigs, RealAddon, pfQuest
  AddOns exists after:    False
  FrameXML exists after:  False
  saved vars survived:    False

The install then fails with FileNotFoundError, after the deletion.

The fix checks structurally rather than by name. A blocklist of bad names has to
anticipate the next variant: trailing dots as well as spaces, separators,
reserved device names, unicode that normalises to a separator on one platform
but not another. Requiring that the resolved destination be a direct child of
AddOns holds without knowing which trick is being tried, and it is three lines.

Normal installs are unaffected. The .toc stem is still the source of truth and
still wins over the catalog name, which is what the surrounding docstring
promises.

One test, which asserts both hostile spellings are refused, that an unrelated
installed addon and FrameXML both survive the attempt, and that an ordinary
addon still installs under its stem. Removing the guard fails it.
