### PR TITLE
Verify the three files fetched live from master, or do not use them

### DIFF
--- a/ichalaunch/addons/catalog.py
+++ b/ichalaunch/addons/catalog.py
@@ -27,6 +27,7 @@ import requests
 from ichalaunch.config.settings import appdata_root, settings
 from ichalaunch.core.logging_setup import log
 from ichalaunch.core.paths import data_file
+from ichalaunch.core.signed_fetch import fetch_verified_text
 
 DEFAULT_CATALOG_URL = (
     "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/"
@@ -148,15 +149,19 @@ def fetch_remote_catalog(url: str | None = None) -> list[dict[str, Any]] | None:
     target = (url or catalog_url()).strip()
     if not target:
         return None
-    try:
-        r = requests.get(target, headers=_UA, timeout=_FETCH_TIMEOUT_SEC)
-    except requests.RequestException as exc:
-        log.info("Addon catalog fetch failed: %s", exc)
+    # The catalog decides where every addon is installed and updated from, and a
+    # push to it reaches players faster than a signed release does. So it is
+    # fetched the same way an update is: verified, or not used at all. A refusal
+    # falls through to the cache and then to the copy inside the signed exe.
+    text = fetch_verified_text(
+        target,
+        timeout=_FETCH_TIMEOUT_SEC,
+        headers=_UA,
+        label="addon catalog",
+    )
+    if text is None:
         return None
-    if r.status_code != 200 or not (r.text or "").strip():
-        log.info("Addon catalog HTTP %s from %s", r.status_code, target)
-        return None
-    entries = parse_catalog_text(r.text)
+    entries = parse_catalog_text(text)
     if catalog_entry_count(entries) == 0:
         return None
     return entries

--- a/ichalaunch/addons/tip_index.py
+++ b/ichalaunch/addons/tip_index.py
@@ -23,6 +23,7 @@ from ichalaunch.addons.git_refs import GitRefs, newest_version_tag, repo_cache_k
 from ichalaunch.config.settings import appdata_root, settings
 from ichalaunch.core.logging_setup import log
 from ichalaunch.core.paths import data_file
+from ichalaunch.core.signed_fetch import fetch_verified_text
 
 DEFAULT_TIPS_URL = (
     "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/"
@@ -273,15 +274,17 @@ def fetch_remote_index(url: str | None = None) -> dict[str, Any] | None:
     target = (url or tips_url()).strip()
     if not target:
         return None
-    try:
-        r = requests.get(target, headers=_UA, timeout=_FETCH_TIMEOUT_SEC)
-    except requests.RequestException as exc:
-        log.info("Addon tip index fetch failed: %s", exc)
+    # Same reasoning as the addon catalog: fetched live, replaces what shipped,
+    # so it is verified or it is not used.
+    text = fetch_verified_text(
+        target,
+        timeout=_FETCH_TIMEOUT_SEC,
+        headers=_UA,
+        label="addon tip index",
+    )
+    if text is None:
         return None
-    if r.status_code != 200 or not (r.text or "").strip():
-        log.info("Addon tip index HTTP %s from %s", r.status_code, target)
-        return None
-    index = parse_index_text(r.text)
+    index = parse_index_text(text)
     if index_repo_count(index) == 0:
         return None
     if not index.get("source"):

--- a/ichalaunch/core/signed_fetch.py
+++ b/ichalaunch/core/signed_fetch.py
@@ -1,0 +1,139 @@
+"""Fetch a file over the network only if a pinned key signed it.
+
+Why this exists
+---------------
+The launcher refuses a self-update that is not signed (``core.self_update``) and
+refuses a mod download that does not match a digest pinned inside the signed
+executable (``mods.verify``). Both of those protect a path that ends in bytes
+being written to disk.
+
+The catalogs are a third path, and until now an unguarded one. ``addons.json``
+and ``addon_tips.json`` are fetched live from a raw hosting URL every fifteen
+minutes, and a successful fetch replaces what shipped in the executable. That
+makes the catalog a **faster and quieter route to every player than a release
+is**: a push reaches everyone within the cache window, with no build, no release
+artefact, and nothing signed anywhere along the way.
+
+The catalog is not inert data either. Entries name the repository an addon is
+installed from and updated from, so whoever controls the catalog controls where
+a player's addons come from.
+
+What this does
+--------------
+Fetches ``<url>`` and ``<url>.sig``, checks the payload against the keys pinned
+in ``core.signing``, and returns the text only if that succeeds. Any failure
+returns ``None``: no keys, no signature published, a signature that verifies
+under no pinned key, a truncated download, a network error.
+
+Why returning ``None`` is the safe direction here
+-------------------------------------------------
+Unlike a failed update, a failed catalog fetch is not fatal and must not be
+loud. The caller falls back to its cache and then to the copy bundled in the
+signed executable, so the player keeps a working, trusted catalog and simply
+stops receiving new entries until the signature is fixed. Refusing to update is
+a much better failure than accepting an unverified update.
+
+⚠️ Deployment note. Signatures have to be published before a build carrying this
+code ships, or remote catalog refresh silently stops for everyone on that build.
+``tools/sign.py`` already signs an arbitrary file:
+
+    python tools/sign.py --key keys/ichalaunch-key1.pem ichalaunch/data/addons.json
+
+and the resulting ``addons.json.sig`` must sit beside the file at the fetch URL.
+"""
+
+from __future__ import annotations
+
+import requests
+
+from ichalaunch.core.logging_setup import log
+from ichalaunch.core.signing import (
+    SIGNATURE_SUFFIX,
+    Signature,
+    SignatureError,
+    signing_is_configured,
+    verify_bytes,
+)
+
+# A signature sidecar is a small JSON object. Anything larger is not one, and
+# refusing early keeps a hostile host from streaming an unbounded body at us.
+_MAX_SIGNATURE_BYTES = 8 * 1024
+
+
+def signature_url_for(url: str) -> str:
+    """Where the detached signature for a fetched file lives."""
+    return url + SIGNATURE_SUFFIX
+
+
+def fetch_verified_text(
+    url: str,
+    *,
+    timeout: float,
+    headers: dict[str, str] | None = None,
+    label: str = "file",
+) -> str | None:
+    """Return the body of *url*, but only if a pinned key signed those bytes.
+
+    Returns ``None`` on every failure. Callers are expected to fall back to a
+    cached or bundled copy rather than treating this as an error.
+
+    The bytes that are verified are the same bytes that are returned. The text
+    is decoded from them afterwards, so there is no window in which one copy is
+    checked and a different copy is used.
+    """
+    if not signing_is_configured():
+        log.warning(
+            "Refusing to fetch %s: this build pins no signing keys, so a remote "
+            "%s cannot be verified. Using the bundled copy.",
+            label,
+            label,
+        )
+        return None
+
+    try:
+        response = requests.get(url, headers=headers, timeout=timeout)
+    except requests.RequestException as exc:
+        log.info("%s fetch failed: %s", label, exc)
+        return None
+    if response.status_code != 200 or not response.content:
+        log.info("%s HTTP %s from %s", label, response.status_code, url)
+        return None
+    payload = response.content
+
+    sig_url = signature_url_for(url)
+    try:
+        sig_response = requests.get(sig_url, headers=headers, timeout=timeout)
+    except requests.RequestException as exc:
+        log.warning("%s signature fetch failed (%s); keeping the bundled copy", label, exc)
+        return None
+    if sig_response.status_code != 200:
+        log.warning(
+            "%s is not signed: HTTP %s for %s. Keeping the bundled copy rather "
+            "than trusting an unsigned catalog.",
+            label,
+            sig_response.status_code,
+            sig_url,
+        )
+        return None
+    if len(sig_response.content) > _MAX_SIGNATURE_BYTES:
+        log.warning("%s signature is implausibly large; refusing", label)
+        return None
+
+    try:
+        key_id = verify_bytes(payload, Signature.parse(sig_response.content))
+    except SignatureError as exc:
+        log.warning(
+            "Refusing remote %s: %s. The bundled copy will be used instead.",
+            label,
+            exc,
+        )
+        return None
+
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        log.warning("Refusing remote %s: verified bytes are not UTF-8 (%s)", label, exc)
+        return None
+
+    log.info("Verified remote %s against pinned key %s", label, key_id[:12])
+    return text

--- a/ichalaunch/ui/home_art.py
+++ b/ichalaunch/ui/home_art.py
@@ -21,6 +21,7 @@ import requests
 from ichalaunch.config.settings import appdata_root, settings
 from ichalaunch.core.logging_setup import log
 from ichalaunch.core.paths import data_file, theme_file
+from ichalaunch.core.signed_fetch import fetch_verified_text
 
 DEFAULT_HOME_ART_URL = (
     "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/"
@@ -211,15 +212,18 @@ def fetch_remote_home_art(url: str | None = None) -> dict[str, Any] | None:
     target = (url or home_art_url()).strip()
     if not target:
         return None
-    try:
-        r = requests.get(target, headers=_UA, timeout=_FETCH_TIMEOUT_SEC)
-    except requests.RequestException as exc:
-        log.info("Home art fetch failed: %s", exc)
+    # The manifest chooses which images the launcher shows and what text sits
+    # beside them, so it is a place to put a convincing message in front of every
+    # player. Verified like the other two live files, or not used.
+    text = fetch_verified_text(
+        target,
+        timeout=_FETCH_TIMEOUT_SEC,
+        headers=_UA,
+        label="home art manifest",
+    )
+    if text is None:
         return None
-    if r.status_code != 200 or not (r.text or "").strip():
-        log.info("Home art HTTP %s from %s", r.status_code, target)
-        return None
-    manifest = parse_home_art_text(r.text)
+    manifest = parse_home_art_text(text)
     if home_art_slide_count(manifest) == 0:
         return None
     return manifest

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -9967,6 +9967,103 @@ def test_launcher_release_cache():
     print("OK launcher release cache")
 
 
+
+def test_live_catalogs_are_signed_or_not_used():
+    """The three files fetched live from master must verify or be refused."""
+    import base64
+    import inspect
+    import json as _json
+    from unittest.mock import patch
+
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives import serialization
+
+    from ichalaunch.core import signed_fetch as SF
+    from ichalaunch.addons import catalog as C
+    from ichalaunch.addons import tip_index as T
+    from ichalaunch.ui import home_art as H
+
+    priv = Ed25519PrivateKey.generate()
+    pub_b64 = base64.b64encode(
+        priv.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+    ).decode()
+
+    body = b'[{"name": "Thing", "folder": "Thing", "repo": "https://github.com/o/r"}]'
+
+    def sidecar(payload, key_b64):
+        return _json.dumps(
+            {"key_id": key_b64, "sig": base64.b64encode(priv.sign(payload)).decode()}
+        ).encode()
+
+    class Resp:
+        def __init__(self, content, status=200):
+            self.content = content
+            self.status_code = status
+            self.text = content.decode("utf-8", "replace")
+
+    def responder(payload, sig, *, sig_status=200):
+        def _get(url, **_kw):
+            if url.endswith(".sig"):
+                return Resp(sig, sig_status)
+            return Resp(payload)
+        return _get
+
+    with patch("ichalaunch.core.signing.PINNED_KEYS", (pub_b64,)):
+        # Signed by a pinned key -> the bytes come back.
+        with patch.object(SF.requests, "get", responder(body, sidecar(body, pub_b64))):
+            assert SF.fetch_verified_text("https://x/y.json", timeout=1) == body.decode()
+
+        # Body altered after signing -> refused.
+        with patch.object(SF.requests, "get", responder(b'[{"name":"Evil"}]', sidecar(body, pub_b64))):
+            assert SF.fetch_verified_text("https://x/y.json", timeout=1) is None
+
+        # No signature published -> refused. The sidecar body here is a VALID
+        # signature, so the only thing that can reject this is the status check.
+        # Without that assertion the test passes for the wrong reason: an empty
+        # body fails to parse and returns None whether or not status is checked.
+        with patch.object(
+            SF.requests, "get", responder(body, sidecar(body, pub_b64), sig_status=404)
+        ):
+            assert SF.fetch_verified_text("https://x/y.json", timeout=1) is None
+
+        # An implausibly large sidecar is refused before it is parsed, so a
+        # hostile host cannot stream an unbounded body at us.
+        with patch.object(SF.requests, "get", responder(body, b"x" * (9 * 1024))):
+            assert SF.fetch_verified_text("https://x/y.json", timeout=1) is None
+
+        # Signed by a key this build does not pin -> refused.
+        other = Ed25519PrivateKey.generate()
+        rogue = _json.dumps({
+            "key_id": pub_b64,
+            "sig": base64.b64encode(other.sign(body)).decode(),
+        }).encode()
+        with patch.object(SF.requests, "get", responder(body, rogue)):
+            assert SF.fetch_verified_text("https://x/y.json", timeout=1) is None
+
+    # With no keys pinned, nothing remote is accepted, and nothing is requested.
+    # verify_bytes would refuse anyway, so the guard is only worth having if it
+    # also stops the round trip. Assert the thing the guard actually buys.
+    with patch("ichalaunch.core.signing.PINNED_KEYS", ()):
+        calls = []
+
+        def counting_get(url, **kw):
+            calls.append(url)
+            return responder(body, sidecar(body, pub_b64))(url, **kw)
+
+        with patch.object(SF.requests, "get", counting_get):
+            assert SF.fetch_verified_text("https://x/y.json", timeout=1) is None
+        assert calls == [], f"asked the network for a file it could never verify: {calls}"
+
+    # All three live fetchers must route through the verifier, not requests.get.
+    for mod, fn in ((C, "fetch_remote_catalog"), (T, "fetch_remote_index"), (H, "fetch_remote_home_art")):
+        src = inspect.getsource(getattr(mod, fn))
+        assert "fetch_verified_text" in src, f"{fn} does not verify what it fetches"
+        assert "requests.get" not in src, f"{fn} still fetches without verifying"
+    print("OK live catalogs are signed or not used")
+
 def test_update_signature_verification():
     """Signed-update verification: fails closed in every direction."""
     import base64
@@ -17304,6 +17401,7 @@ def _run_smoke_tests():
     test_linux_game_running_guard()
     test_detect_and_installer_drop_unused_imports()
     test_update_signature_verification()
+    test_live_catalogs_are_signed_or_not_used()
     test_update_signing_keys_are_pinned()
     test_signature_sidecar_url_and_unverified_exe_is_deleted()
     test_home_art_width_fit_is_centred()


### PR DESCRIPTION
The launcher refuses an unsigned self-update and, with the mod pinning change,
refuses a mod download that does not match a digest carried inside the signed
executable. Both of those guard a path that ends in bytes on disk.

There is a third path and it was unguarded. addons.json, addon_tips.json and
home_art.json are fetched from raw.githubusercontent.com every fifteen minutes,
and a successful fetch replaces what shipped in the exe. The only acceptance
test was HTTP 200 plus one parseable entry.

That makes the catalog a faster and quieter route to every player than a release
is. A push to master reaches everyone inside the cache window with no build, no
release artefact and nothing signed at any point. The signed self-update and the
pinned mod digests both sit behind a channel that has neither.

It is not inert data either. Catalog entries name the repository each addon is
installed from and updated from, so whoever controls the catalog controls where
a player's addons come from.

What changed

A small helper, core/signed_fetch.py, fetches a URL and its .sig sidecar,
verifies the payload against the keys already pinned in core/signing.py, and
returns the text only if that succeeds. All three fetchers now go through it,
and a test asserts that none of them calls requests.get directly, so a fourth
live file added later cannot quietly skip the check.

Every failure returns None rather than raising: no keys pinned, no signature
published, a signature that verifies under no pinned key, an oversized sidecar,
a network error. The caller then falls back to its cache and then to the copy
bundled in the signed exe, which is the behaviour that already existed for an
offline start. So the failure mode is a stale catalog, never an unverified one,
and players are not stranded by a signing mistake.

DEPLOYMENT, PLEASE READ BEFORE MERGING

The signatures have to be published before or alongside a build carrying this,
or remote catalog refresh stops for everyone on that build. Nothing breaks and
nothing is lost, the launcher just runs on the bundled catalog and says so in
the log, but new addon entries would stop appearing and it would be a confusing
thing to debug later.

tools/sign.py already signs an arbitrary file, so no new tooling is needed:

  python tools/sign.py --key keys/ichalaunch-key1.pem ichalaunch/data/addons.json
  python tools/sign.py --key keys/ichalaunch-key1.pem ichalaunch/data/addon_tips.json
  python tools/sign.py --key keys/ichalaunch-key1.pem ichalaunch/data/home_art.json

Each .sig has to sit beside its file at the fetch URL. Since addon_tips.json is
rewritten hourly by a workflow, that workflow will need to sign its output, and
the signing key must not go into CI. If that is a problem, the honest options
are to drop the hourly rewrite to something a person runs, or to accept that
tips go stale between manual signings. Worth deciding before this merges.

What this does not do

The appdata cache is not separately verified. An attacker who can write files
into the user's appdata directory already has code execution on that machine,
so a signature check there protects nothing that is not already lost. Verified
content is what gets cached, which is the part that matters.

Tests

One test, covering: a valid signature accepted, a body altered after signing
refused, a missing signature refused, a signature from an unpinned key refused,
and no network request at all when the build pins no keys.

Five mutations were tried. Four were caught: skipping verification, accepting a
missing signature, dropping the no-keys guard, and reverting a fetcher to a
plain request. The fifth, removing the sidecar size bound, was not caught, and I
would rather say so than pad the test: with the bound gone an oversized sidecar
still fails to parse, so nothing observable changes. It is a bound on what gets
parsed, not a check the result depends on.

The missing-signature and no-keys cases both needed strengthening after the
mutation run, because the first versions passed for the wrong reason.
