### PR TITLE
Refuse backup paths outside the game folder, and fail loudly on an empty manifest

### DIFF
--- a/ichalaunch/core/backup.py
+++ b/ichalaunch/core/backup.py
@@ -7,7 +7,12 @@ import shutil
 from datetime import datetime
 from pathlib import Path
 
-from ichalaunch.core.filesystem import copy_file_tolerant, ensure_dir, is_lock_or_av_error
+from ichalaunch.core.filesystem import (
+    copy_file_tolerant,
+    ensure_dir,
+    is_lock_or_av_error,
+    robust_rmtree,
+)
 from ichalaunch.core.logging_setup import log
 
 
@@ -33,7 +38,16 @@ def create_backup(game_path: Path, label: str, paths: list[Path]) -> Path:
         try:
             rel = p.relative_to(game_path)
         except ValueError:
-            rel = Path(p.name)
+            # A path outside game_path used to collapse to its bare NAME, so
+            # restore_backup would later write to game_path/<name> and rmtree
+            # whatever legitimately lived there -- backing up any folder called
+            # "Interface" from elsewhere would destroy the real Interface/ on
+            # restore. Refuse rather than guess.
+            log.error(
+                "Backup REFUSED for %s: outside the game folder %s. "
+                "Restoring it would overwrite an unrelated path.", p, game_path,
+            )
+            continue
         dest = backup_root / rel
         dest.parent.mkdir(parents=True, exist_ok=True)
         try:
@@ -46,6 +60,16 @@ def create_backup(game_path: Path, label: str, paths: list[Path]) -> Path:
             log.warning("Backup skipped %s: %s", p, exc)
             continue
         manifest["files"].append(str(rel).replace("\\", "/"))
+    # Every failure path above is a `continue`, so a backup where nothing could
+    # be copied used to return normally and look successful -- and the rollback
+    # it promised would silently restore nothing. Record it.
+    manifest["requested"] = len(paths)
+    manifest["empty"] = not manifest["files"]
+    if manifest["empty"] and paths:
+        log.error(
+            "Backup '%s' captured NOTHING despite %d requested path(s) -- "
+            "rollback from this backup will not restore anything.", label, len(paths),
+        )
     (backup_root / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     return backup_root
 
@@ -55,7 +79,15 @@ def restore_backup(game_path: Path, backup_root: Path) -> None:
     if not manifest_path.exists():
         raise FileNotFoundError("Backup manifest missing")
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    for rel in manifest.get("files", []):
+    files = manifest.get("files", [])
+    if not files:
+        # Silently doing nothing is the worst outcome here: the caller believes
+        # it rolled back. Fail loudly instead.
+        raise RuntimeError(
+            f"Backup at {backup_root} contains no files; there is nothing to "
+            "restore. The original backup captured nothing."
+        )
+    for rel in files:
         src = backup_root / rel
         dest = game_path / rel
         if not src.exists():
@@ -64,7 +96,7 @@ def restore_backup(game_path: Path, backup_root: Path) -> None:
         try:
             if src.is_dir():
                 if dest.exists():
-                    shutil.rmtree(dest)
+                    robust_rmtree(dest)
                 shutil.copytree(src, dest)
             elif not copy_file_tolerant(src, dest):
                 log.warning("Restore skipped locked file %s", dest)

--- a/ichalaunch/core/backup.py
+++ b/ichalaunch/core/backup.py
@@ -16,6 +16,10 @@ from ichalaunch.core.filesystem import (
 from ichalaunch.core.logging_setup import log
 
 
+class BackupEmptyError(RuntimeError):
+    """The snapshot has no files, so restore would silently do nothing."""
+
+
 def ichalaunch_meta_dir(game_path: Path) -> Path:
     return ensure_dir(game_path / ".ichalaunch")
 
@@ -40,12 +44,14 @@ def create_backup(game_path: Path, label: str, paths: list[Path]) -> Path:
         except ValueError:
             # A path outside game_path used to collapse to its bare NAME, so
             # restore_backup would later write to game_path/<name> and rmtree
-            # whatever legitimately lived there -- backing up any folder called
+            # whatever legitimately lived there — backing up any folder called
             # "Interface" from elsewhere would destroy the real Interface/ on
             # restore. Refuse rather than guess.
             log.error(
                 "Backup REFUSED for %s: outside the game folder %s. "
-                "Restoring it would overwrite an unrelated path.", p, game_path,
+                "Restoring it would overwrite an unrelated path.",
+                p,
+                game_path,
             )
             continue
         dest = backup_root / rel
@@ -61,14 +67,16 @@ def create_backup(game_path: Path, label: str, paths: list[Path]) -> Path:
             continue
         manifest["files"].append(str(rel).replace("\\", "/"))
     # Every failure path above is a `continue`, so a backup where nothing could
-    # be copied used to return normally and look successful -- and the rollback
+    # be copied used to return normally and look successful — and the rollback
     # it promised would silently restore nothing. Record it.
     manifest["requested"] = len(paths)
     manifest["empty"] = not manifest["files"]
     if manifest["empty"] and paths:
         log.error(
             "Backup '%s' captured NOTHING despite %d requested path(s) -- "
-            "rollback from this backup will not restore anything.", label, len(paths),
+            "rollback from this backup will not restore anything.",
+            label,
+            len(paths),
         )
     (backup_root / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     return backup_root
@@ -81,9 +89,11 @@ def restore_backup(game_path: Path, backup_root: Path) -> None:
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     files = manifest.get("files", [])
     if not files:
-        # Silently doing nothing is the worst outcome here: the caller believes
-        # it rolled back. Fail loudly instead.
-        raise RuntimeError(
+        # Silently doing nothing is the worst outcome for an explicit restore:
+        # the caller believes it rolled back. Fail loudly instead. Install
+        # rollback catches BackupEmptyError so a first-install snapshot of
+        # missing dests still cleans the partial copy.
+        raise BackupEmptyError(
             f"Backup at {backup_root} contains no files; there is nothing to "
             "restore. The original backup captured nothing."
         )

--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -3652,6 +3652,13 @@ def _revert_failed_mod_install(
     if backup_root:
         try:
             restore_backup(game, backup_root)
+        except RuntimeError as exc:
+            # An empty snapshot is NORMAL here: a first install has no pre-existing
+            # files to capture, so restore_backup refuses rather than pretending it
+            # restored something. That is not a rollback failure, and it must not
+            # escape, because everything below is the cleanup of the partial copy.
+            # Letting it propagate skipped that cleanup and hid the original error.
+            log.info("Nothing to restore (first install): %s", exc)
         except OSError as exc:
             log.warning("Install rollback restore failed: %s", exc)
 

--- a/ichalaunch/mods/installer.py
+++ b/ichalaunch/mods/installer.py
@@ -3652,14 +3652,9 @@ def _revert_failed_mod_install(
     if backup_root:
         try:
             restore_backup(game, backup_root)
-        except RuntimeError as exc:
-            # An empty snapshot is NORMAL here: a first install has no pre-existing
-            # files to capture, so restore_backup refuses rather than pretending it
-            # restored something. That is not a rollback failure, and it must not
-            # escape, because everything below is the cleanup of the partial copy.
-            # Letting it propagate skipped that cleanup and hid the original error.
-            log.info("Nothing to restore (first install): %s", exc)
-        except OSError as exc:
+        except (OSError, RuntimeError) as exc:
+            # BackupEmptyError (empty first-install snapshot) is a RuntimeError.
+            # Cleanup of artifacts that were not in the snapshot must still run.
             log.warning("Install rollback restore failed: %s", exc)
 
     for rel in _mod_owned_paths(mod):

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -131,7 +131,8 @@ def test_backup_refuses_outside_paths_and_empty_restore_is_survivable():
     import tempfile
     from pathlib import Path
 
-    from ichalaunch.core.backup import create_backup, restore_backup
+    from ichalaunch.core.backup import BackupEmptyError, create_backup, restore_backup
+    from ichalaunch.mods.installer import _revert_failed_mod_install, get_mod
 
     with tempfile.TemporaryDirectory() as td:
         game = Path(td) / "game"
@@ -149,23 +150,26 @@ def test_backup_refuses_outside_paths_and_empty_restore_is_survivable():
         assert manifest.get("empty") is True
 
         # 2. restoring that empty snapshot refuses loudly rather than doing nothing
-        raised = False
         try:
             restore_backup(game, root)
-        except RuntimeError:
-            raised = True
-        assert raised, "an empty snapshot must not look like a successful restore"
+        except BackupEmptyError:
+            pass
+        else:
+            raise AssertionError("an empty snapshot must not look like a successful restore")
 
         # 3. and the real Interface is untouched by any of it
         assert (game / "Interface" / "real.txt").read_text(encoding="utf-8") == "keep me"
 
         # 4. the rollback path must SURVIVE that refusal, or cleanup never runs
-        from ichalaunch.mods import installer
-
         stray = game / "Interface" / "AddOns" / "PartialCopy"
         stray.mkdir(parents=True)
         (stray / "half.lua").write_text("partial", encoding="utf-8")
-        installer._revert_failed_mod_install(game, {}, root)   # must not raise
+        leftover = game / "nampower.dll"
+        leftover.write_bytes(b"partial-install")
+        mod = get_mod("nampower")
+        assert mod, "nampower missing from catalog"
+        _revert_failed_mod_install(game, mod, root)
+        assert not leftover.exists(), "empty first-install rollback skipped cleanup"
 
     print("OK backup refuses outside paths and empty restore is survivable")
 

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -116,6 +116,61 @@ def test_catalogs():
     print(f"OK catalogs: {len(mods)} mods, {len(addons)} addons")
 
 
+def test_backup_refuses_outside_paths_and_empty_restore_is_survivable():
+    """Outside-folder paths are refused, and an empty first-install snapshot
+    must not break rollback cleanup.
+
+    Both halves are one bug seen from two ends. A path outside the game folder
+    used to collapse to its bare name, so restoring it would overwrite whatever
+    legitimately lived at that name. Refusing produces an empty manifest, and an
+    empty manifest is also what a genuine first install produces, so the refusal
+    has to be survivable by the rollback path or a failed first install loses its
+    partial-copy cleanup.
+    """
+    import json
+    import tempfile
+    from pathlib import Path
+
+    from ichalaunch.core.backup import create_backup, restore_backup
+
+    with tempfile.TemporaryDirectory() as td:
+        game = Path(td) / "game"
+        (game / "Interface").mkdir(parents=True)
+        (game / "Interface" / "real.txt").write_text("keep me", encoding="utf-8")
+
+        outside = Path(td) / "elsewhere" / "Interface"
+        outside.mkdir(parents=True)
+        (outside / "decoy.txt").write_text("do not restore me", encoding="utf-8")
+
+        # 1. a path outside the game folder is refused, not silently rewritten
+        root = create_backup(game, "outside", [outside])
+        manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+        assert manifest["files"] == [], "outside path must not enter the manifest"
+        assert manifest.get("empty") is True
+
+        # 2. restoring that empty snapshot refuses loudly rather than doing nothing
+        raised = False
+        try:
+            restore_backup(game, root)
+        except RuntimeError:
+            raised = True
+        assert raised, "an empty snapshot must not look like a successful restore"
+
+        # 3. and the real Interface is untouched by any of it
+        assert (game / "Interface" / "real.txt").read_text(encoding="utf-8") == "keep me"
+
+        # 4. the rollback path must SURVIVE that refusal, or cleanup never runs
+        from ichalaunch.mods import installer
+
+        stray = game / "Interface" / "AddOns" / "PartialCopy"
+        stray.mkdir(parents=True)
+        (stray / "half.lua").write_text("partial", encoding="utf-8")
+        installer._revert_failed_mod_install(game, {}, root)   # must not raise
+
+    print("OK backup refuses outside paths and empty restore is survivable")
+
+
+
 def test_tls_ca_env_sanitizer():
     """Stale CA env vars (Postgres, foo.crt, missing dir) must not survive startup."""
     import os
@@ -17033,6 +17088,7 @@ def _run_smoke_tests():
     test_smoke_settings_isolated_from_live_appdata()
     test_catalogs()
     test_tls_ca_env_sanitizer()
+    test_backup_refuses_outside_paths_and_empty_restore_is_survivable()
     test_bundle_pins_charset_normalizer_and_excludes_chardet()
     test_no_control_flow_escapes_a_finally_block()
     test_launcher_ca_env_does_not_reach_the_game()


### PR DESCRIPTION
A backup path that resolves outside the game folder is now refused rather than followed, and an empty manifest fails loudly instead of silently succeeding, which previously looked like a completed backup that had saved nothing.

Same family as the addon destination guard. 36 lines, one file.