### PR TITLE
Fill the Home brand rect with the featured slide instead of banking its remainder

### DIFF
--- a/ichalaunch/data/home_art.json
+++ b/ichalaunch/data/home_art.json
@@ -7,7 +7,7 @@
       "frame": "zaeya_first_60_frame.png",
       "frame_url": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/ui/theme/zaeya_first_60_frame.png",
       "hold": 2.0,
-      "fit": "width",
+      "fit": "cover",
       "nudge_x": -5,
       "nudge_y": -5,
       "shrink_w": 10


### PR DESCRIPTION
The featured slide was being fitted so that leftover space was banked rather than filled, leaving the brand rect short of the art. One line.