### PR TITLE
Use Qt's tiled blit instead of a Python draw loop

### DIFF
--- a/ichalaunch/ui/main_window.py
+++ b/ichalaunch/ui/main_window.py
@@ -349,16 +349,14 @@ def _paint_floor_fill(
         ox = tile_origin.x() if tile_origin is not None else rect.left()
         oy = tile_origin.y() if tile_origin is not None else rect.top()
         # Align tile phase to a shared origin so TopNav and ContentPanel match.
-        x0 = rect.left() - ((rect.left() - ox) % tw)
-        y0 = rect.top() - ((rect.top() - oy) % th)
         painter.setOpacity(_FLOOR_TILE_OPACITY)
-        y = y0
-        while y < rect.bottom():
-            x = x0
-            while x < rect.right():
-                painter.drawPixmap(x, y, floor)
-                x += tw
-            y += th
+        # drawTiledPixmap's offset is the starting point WITHIN the pixmap, so
+        # the shared tile phase above is preserved exactly. Qt's raster engine
+        # blits this in one pass; the Python double loop cost an interpreter
+        # iteration and a binding call per tile, which shows at 5120x2160.
+        painter.drawTiledPixmap(
+            rect, floor, QPoint((rect.left() - ox) % tw, (rect.top() - oy) % th)
+        )
         painter.setOpacity(1.0)
         painter.fillRect(rect, _FLOOR_WASH)
     painter.restore()

--- a/ichalaunch/ui/widgets/marble_bg.py
+++ b/ichalaunch/ui/widgets/marble_bg.py
@@ -83,15 +83,10 @@ def paint_marble_tiled(
         tw, th = tile.width(), tile.height()
         if tw > 0 and th > 0:
             painter.setOpacity(_TILE_OPACITY)
-            y = rect.top()
-            bottom = rect.top() + rect.height()
-            right = rect.left() + rect.width()
-            while y < bottom:
-                x = rect.left()
-                while x < right:
-                    painter.drawPixmap(x, y, tile)
-                    x += tw
-                y += th
+            # Qt's raster engine has a dedicated tiled-blit path. The Python
+            # double loop cost one interpreter iteration and one binding call
+            # per tile, which is measurable at 5120x2160.
+            painter.drawTiledPixmap(rect, tile)
             painter.setOpacity(1.0)
 
     painter.restore()


### PR DESCRIPTION
The repeated background was drawn by a Python loop placing each tile. Qt can do this in one call, so this hands it over. Fewer lines and less per repaint work.

11 added, 18 removed.