### PR TITLE
Cache ETags and reuse one connection for GitHub update scans

### DIFF
--- a/ichalaunch/addons/github.py
+++ b/ichalaunch/addons/github.py
@@ -33,10 +33,8 @@ from ichalaunch.game.launcher import detect_game, ensure_addons_dir, resolve_add
 ProgressCb = Callable[[str], None]
 UA = {"User-Agent": "IchaLaunch/0.1", "Accept": "application/vnd.github+json"}
 
-# PERF: a bare ``requests.get`` opens a fresh TCP connection and completes a full
-# TLS handshake every call. A catalog scan makes hundreds of them and the
-# handshakes dominate the wall clock. One module-level Session keeps the
-# connection to api.github.com alive and reuses it for the whole scan.
+# A catalog scan makes hundreds of GETs. One Session keeps the TLS connection
+# to api.github.com alive instead of handshaking per call.
 _SESSION = requests.Session()
 _SESSION.headers.update({"User-Agent": UA["User-Agent"]})
 
@@ -666,6 +664,7 @@ def list_repo_forks(owner: str, repo: str, *, use_cache: bool = True) -> list[di
     try:
         r = _github_api_get(
             f"https://api.github.com/repos/{owner}/{repo}",
+            use_etag=True,
             timeout=30,
         )
         _note_rate_headers(r)
@@ -701,6 +700,7 @@ def list_repo_forks(owner: str, repo: str, *, use_cache: bool = True) -> list[di
         for page in range(1, _FORK_LIST_MAX_PAGES + 1):
             r = _github_api_get(
                 f"https://api.github.com/repos/{owner}/{repo}/forks",
+                use_etag=True,
                 timeout=30,
                 params={
                     "per_page": _FORK_LIST_PER_PAGE,
@@ -773,6 +773,7 @@ def list_repo_versions(
     try:
         r = _github_api_get(
             f"https://api.github.com/repos/{owner}/{repo}/releases",
+            use_etag=True,
             timeout=30,
             params={"per_page": cap},
         )
@@ -797,6 +798,7 @@ def list_repo_versions(
     try:
         r = _github_api_get(
             f"https://api.github.com/repos/{owner}/{repo}/tags",
+            use_etag=True,
             timeout=30,
             params={"per_page": cap},
         )
@@ -978,20 +980,17 @@ def _http_get(url: str, **kwargs: Any) -> requests.Response:
     return _SESSION.get(url, **kwargs)
 
 
-# ---------------------------------------------------------------- ETag cache
 # GitHub does not charge a conditional request against the rate limit when it
-# answers 304 Not Modified, and between two scans almost nothing has changed.
-# Replaying a cached body on a 304 therefore turns the 60-requests/hour
-# unauthenticated ceiling into an effectively unlimited scan.
-# https://docs.github.com/rest/overview/resources-in-the-rest-api#conditional-requests
+# answers 304 Not Modified. Replaying a cached body on a 304 turns the
+# 60-requests/hour unauthenticated ceiling into an effectively unlimited scan.
+# Archive / stream downloads must never use this path (see github_open).
 _ETAG_MAX_ENTRIES = 1500
+_ETAG_MAX_BODY_BYTES = 512 * 1024
 _etag_cache: dict[str, dict[str, Any]] | None = None
 _etag_dirty = False
 
 
 def _etag_cache_path() -> Path:
-    from ichalaunch.config.settings import appdata_root
-
     return appdata_root() / "etag-cache.json"
 
 
@@ -1019,13 +1018,14 @@ def _load_etag_cache() -> dict[str, dict[str, Any]]:
 
 def save_etag_cache() -> None:
     """Persist the cache. A cheap no-op when nothing changed."""
-    global _etag_dirty
+    global _etag_dirty, _etag_cache
     if not _etag_dirty or _etag_cache is None:
         return
     cache = _etag_cache
     if len(cache) > _ETAG_MAX_ENTRIES:
         newest = sorted(cache.items(), key=lambda kv: kv[1].get("ts", 0), reverse=True)
         cache = dict(newest[:_ETAG_MAX_ENTRIES])
+        _etag_cache = cache
     try:
         _etag_cache_path().write_text(json.dumps(cache), encoding="utf-8")
         _etag_dirty = False
@@ -1033,9 +1033,6 @@ def save_etag_cache() -> None:
         log.warning("Could not save ETag cache: %s", exc)
 
 
-# Flushed at exit rather than per write: the scan that matters is the FIRST one
-# after a restart, so a cache that only lived for one session would be the wrong
-# half of the benefit.
 atexit.register(save_etag_cache)
 
 
@@ -1045,10 +1042,16 @@ def _etag_store(key: str, response: requests.Response) -> None:
     if not etag:
         return
     try:
-        body = response.content.decode("utf-8")
-    except (UnicodeDecodeError, AttributeError):
+        body = response.content
+    except (OSError, AttributeError):
         return
-    _load_etag_cache()[key] = {"etag": etag, "body": body, "ts": time.time()}
+    if not body or len(body) > _ETAG_MAX_BODY_BYTES:
+        return
+    try:
+        text = body.decode("utf-8")
+    except UnicodeDecodeError:
+        return
+    _load_etag_cache()[key] = {"etag": etag, "body": text, "ts": time.time()}
     _etag_dirty = True
 
 
@@ -1501,9 +1504,7 @@ def github_latest_version_tag(owner: str, repo: str) -> str | None:
 
     try:
         tags_url = f"https://api.github.com/repos/{full}/tags"
-        r = _github_api_get(
-            tags_url, use_etag=True, timeout=30, params={"per_page": 10}
-        )
+        r = _github_api_get(tags_url, use_etag=True, timeout=30, params={"per_page": 10})
         _note_rate_headers(r)
         if _looks_like_rate_limit(r):
             raise GitHubRateLimitError(RATE_LIMIT_STATUS)

--- a/ichalaunch/addons/github.py
+++ b/ichalaunch/addons/github.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import atexit
 import json
 import re
 import shutil
@@ -31,6 +32,13 @@ from ichalaunch.game.launcher import detect_game, ensure_addons_dir, resolve_add
 
 ProgressCb = Callable[[str], None]
 UA = {"User-Agent": "IchaLaunch/0.1", "Accept": "application/vnd.github+json"}
+
+# PERF: a bare ``requests.get`` opens a fresh TCP connection and completes a full
+# TLS handshake every call. A catalog scan makes hundreds of them and the
+# handshakes dominate the wall clock. One module-level Session keeps the
+# connection to api.github.com alive and reuses it for the whole scan.
+_SESSION = requests.Session()
+_SESSION.headers.update({"User-Agent": UA["User-Agent"]})
 
 RATE_LIMIT_STATUS = "GitHub rate limit hit — add a token in Settings or try later"
 WAITING_RATE_LIMIT_STATUS = "Waiting for GitHub rate limit…"
@@ -908,6 +916,12 @@ def _consume_api_budget() -> None:
     _budget_window_used += 1
 
 
+def _refund_api_budget() -> None:
+    """Give a reserved slot back. A 304 costs no quota, so it must not be charged."""
+    global _budget_window_used
+    _budget_window_used = max(0, _budget_window_used - 1)
+
+
 def _looks_like_rate_limit(response: requests.Response) -> bool:
     if response.status_code == 429:
         return True
@@ -955,31 +969,166 @@ def _unauth_headers() -> dict[str, str]:
     return dict(UA)
 
 
-def _github_api_get(url: str, **kwargs: Any) -> requests.Response:
-    """GET a GitHub API URL; retry without token when a stored token is rejected."""
+def _http_get(url: str, **kwargs: Any) -> requests.Response:
+    """Every GitHub API GET goes through here, over the shared Session.
+
+    Named rather than inlined so the transport has a single seam -- for the
+    connection pool, and for tests that need to stand in for the network.
+    """
+    return _SESSION.get(url, **kwargs)
+
+
+# ---------------------------------------------------------------- ETag cache
+# GitHub does not charge a conditional request against the rate limit when it
+# answers 304 Not Modified, and between two scans almost nothing has changed.
+# Replaying a cached body on a 304 therefore turns the 60-requests/hour
+# unauthenticated ceiling into an effectively unlimited scan.
+# https://docs.github.com/rest/overview/resources-in-the-rest-api#conditional-requests
+_ETAG_MAX_ENTRIES = 1500
+_etag_cache: dict[str, dict[str, Any]] | None = None
+_etag_dirty = False
+
+
+def _etag_cache_path() -> Path:
+    from ichalaunch.config.settings import appdata_root
+
+    return appdata_root() / "etag-cache.json"
+
+
+def _etag_key(url: str, params: Any = None) -> str:
+    """Cache key. Params are part of the identity: /tags?per_page=1 is not /tags."""
+    if not params:
+        return url
+    try:
+        tail = "&".join(f"{k}={params[k]}" for k in sorted(params))
+    except (TypeError, KeyError):
+        return url
+    return f"{url}?{tail}"
+
+
+def _load_etag_cache() -> dict[str, dict[str, Any]]:
+    global _etag_cache
+    if _etag_cache is None:
+        try:
+            loaded = json.loads(_etag_cache_path().read_text(encoding="utf-8"))
+            _etag_cache = loaded if isinstance(loaded, dict) else {}
+        except (OSError, ValueError):
+            _etag_cache = {}
+    return _etag_cache
+
+
+def save_etag_cache() -> None:
+    """Persist the cache. A cheap no-op when nothing changed."""
+    global _etag_dirty
+    if not _etag_dirty or _etag_cache is None:
+        return
+    cache = _etag_cache
+    if len(cache) > _ETAG_MAX_ENTRIES:
+        newest = sorted(cache.items(), key=lambda kv: kv[1].get("ts", 0), reverse=True)
+        cache = dict(newest[:_ETAG_MAX_ENTRIES])
+    try:
+        _etag_cache_path().write_text(json.dumps(cache), encoding="utf-8")
+        _etag_dirty = False
+    except OSError as exc:
+        log.warning("Could not save ETag cache: %s", exc)
+
+
+# Flushed at exit rather than per write: the scan that matters is the FIRST one
+# after a restart, so a cache that only lived for one session would be the wrong
+# half of the benefit.
+atexit.register(save_etag_cache)
+
+
+def _etag_store(key: str, response: requests.Response) -> None:
+    global _etag_dirty
+    etag = response.headers.get("ETag")
+    if not etag:
+        return
+    try:
+        body = response.content.decode("utf-8")
+    except (UnicodeDecodeError, AttributeError):
+        return
+    _load_etag_cache()[key] = {"etag": etag, "body": body, "ts": time.time()}
+    _etag_dirty = True
+
+
+def _etag_replay(key: str) -> requests.Response | None:
+    """Rebuild a 200 response from the cached body, to answer a 304."""
+    entry = _load_etag_cache().get(key)
+    if not entry:
+        return None
+    entry["ts"] = time.time()
+    r = requests.Response()
+    r.status_code = 200
+    r._content = entry["body"].encode("utf-8")  # noqa: SLF001 - no public setter
+    r.url = key
+    r.headers["Content-Type"] = "application/json"
+    r.headers["X-IchaLaunch-FromCache"] = "1"
+    return r
+
+
+def _github_api_get(
+    url: str, *, use_etag: bool = False, **kwargs: Any
+) -> requests.Response:
+    """GET a GitHub API URL; retry without token when a stored token is rejected.
+
+    With *use_etag* the request is made conditional: a stored ETag is sent as
+    ``If-None-Match``, a 304 is answered from cache, and the reserved rate-limit
+    slot is refunded. JSON endpoints only -- ``github_open`` streams archives,
+    and their bodies must never go through the cache.
+    """
     headers = dict(github_headers(url))
     extra_headers = kwargs.pop("headers", None)
     if extra_headers:
         headers.update(extra_headers)
+
+    key = _etag_key(url, kwargs.get("params")) if use_etag else None
+    cached = _load_etag_cache().get(key) if key else None
+    if cached and cached.get("etag"):
+        headers["If-None-Match"] = cached["etag"]
+
     had_token = "Authorization" in headers
+    consumed = 0
     if not had_token:
         _consume_api_budget()
-    r = requests.get(url, headers=headers, **kwargs)
+        consumed += 1
+    r = _http_get(url, headers=headers, **kwargs)
     _note_rate_headers(r)
     if had_token and r.status_code == 401:
         note_github_token_rejected()
         _consume_api_budget()
+        consumed += 1
         retry_headers = _unauth_headers()
+        if cached and cached.get("etag"):
+            retry_headers["If-None-Match"] = cached["etag"]
         if extra_headers:
             retry_headers.update(extra_headers)
-        r = requests.get(url, headers=retry_headers, **kwargs)
+        r = _http_get(url, headers=retry_headers, **kwargs)
         _note_rate_headers(r)
+
+    if not key:
+        return r
+    if r.status_code == 304:
+        replay = _etag_replay(key)
+        if replay is not None:
+            for _ in range(consumed):
+                _refund_api_budget()
+            return replay
+        # The entry was evicted underneath us. Refetch unconditionally rather
+        # than hand the caller a 304 it has no body for.
+        headers.pop("If-None-Match", None)
+        if "Authorization" not in headers:
+            _consume_api_budget()
+        r = _http_get(url, headers=headers, **kwargs)
+        _note_rate_headers(r)
+    if r.status_code == 200:
+        _etag_store(key, r)
     return r
 
 
 def github_get(url: str, *, timeout: int = 30) -> requests.Response:
     """GET a GitHub API URL with auth headers; raise on rate limit."""
-    r = _github_api_get(url, timeout=timeout)
+    r = _github_api_get(url, use_etag=True, timeout=timeout)
     if _looks_like_rate_limit(r):
         raise GitHubRateLimitError(RATE_LIMIT_STATUS)
     if r.status_code == 401:
@@ -1334,7 +1483,7 @@ def github_latest_version_tag(owner: str, repo: str) -> str | None:
     full = f"{owner}/{repo}"
     try:
         latest_url = f"https://api.github.com/repos/{full}/releases/latest"
-        r = _github_api_get(latest_url, timeout=30)
+        r = _github_api_get(latest_url, use_etag=True, timeout=30)
         _note_rate_headers(r)
         if _looks_like_rate_limit(r):
             raise GitHubRateLimitError(RATE_LIMIT_STATUS)
@@ -1352,7 +1501,9 @@ def github_latest_version_tag(owner: str, repo: str) -> str | None:
 
     try:
         tags_url = f"https://api.github.com/repos/{full}/tags"
-        r = _github_api_get(tags_url, timeout=30, params={"per_page": 10})
+        r = _github_api_get(
+            tags_url, use_etag=True, timeout=30, params={"per_page": 10}
+        )
         _note_rate_headers(r)
         if _looks_like_rate_limit(r):
             raise GitHubRateLimitError(RATE_LIMIT_STATUS)
@@ -1472,6 +1623,7 @@ def fetch_repo_readme(owner: str, repo: str, branch: str | None = None) -> dict[
     try:
         r = _github_api_get(
             url,
+            use_etag=True,
             timeout=30,
             params={"ref": branch} if branch else None,
         )

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -7669,7 +7669,7 @@ def test_github_bad_token_retries_without_auth():
     from ichalaunch.addons import github as G
 
     prev_token = G.settings.get("github_token")
-    orig_get = G.requests.get
+    orig_get = G._http_get
     calls: list[tuple[str, str | None]] = []
 
     class _Resp:
@@ -7702,7 +7702,7 @@ def test_github_bad_token_retries_without_auth():
     try:
         G.settings.set("github_token", "ghp_invalid_token")
         G._token_rejected_pending = False
-        G.requests.get = _fake_get
+        G._http_get = _fake_get
         r = G.github_get("https://api.github.com/repos/hannesmann/vanillafixes/releases/latest")
         assert r.status_code == 200
         assert len(calls) == 2
@@ -7710,7 +7710,7 @@ def test_github_bad_token_retries_without_auth():
         assert calls[1][1] is None
         assert G.take_github_token_warning() == G.GITHUB_TOKEN_REJECTED_MSG
     finally:
-        G.requests.get = orig_get
+        G._http_get = orig_get
         G.settings.set("github_token", prev_token or "")
         G._token_rejected_pending = False
 

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -7678,6 +7678,7 @@ def test_github_bad_token_retries_without_auth():
             self.headers = {"Content-Type": "application/json"}
             self.text = body
             self._body = body
+            self.content = body.encode("utf-8")
 
         def json(self):
             return json.loads(self._body)
@@ -7702,6 +7703,8 @@ def test_github_bad_token_retries_without_auth():
     try:
         G.settings.set("github_token", "ghp_invalid_token")
         G._token_rejected_pending = False
+        G._etag_cache = {}
+        G._etag_dirty = False
         G._http_get = _fake_get
         r = G.github_get("https://api.github.com/repos/hannesmann/vanillafixes/releases/latest")
         assert r.status_code == 200
@@ -7713,8 +7716,79 @@ def test_github_bad_token_retries_without_auth():
         G._http_get = orig_get
         G.settings.set("github_token", prev_token or "")
         G._token_rejected_pending = False
+        G._etag_cache = {}
+        G._etag_dirty = False
 
     print("OK github bad token retries without auth")
+
+
+def test_github_etag_cache_replays_304():
+    """A second scan with If-None-Match must reuse the body and refund the slot."""
+    import requests
+
+    from ichalaunch.addons import github as G
+
+    orig_get = G._http_get
+    orig_cache = G._etag_cache
+    orig_dirty = G._etag_dirty
+    orig_used = G._budget_window_used
+    orig_start = G._budget_window_start
+    calls: list[dict] = []
+
+    class _Resp:
+        def __init__(self, status_code: int, body: str = "{}", etag: str | None = None):
+            self.status_code = status_code
+            self.headers = {"Content-Type": "application/json"}
+            if etag:
+                self.headers["ETag"] = etag
+            self.text = body
+            self._body = body
+            self.content = body.encode("utf-8")
+            self.url = "https://api.github.com/repos/o/r/releases/latest"
+
+        def json(self):
+            return json.loads(self._body)
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise requests.HTTPError(f"{self.status_code}", response=self)
+
+        def close(self):
+            pass
+
+    def _fake_get(url, headers=None, **kw):
+        headers = headers or {}
+        calls.append({"url": url, "inm": headers.get("If-None-Match")})
+        if headers.get("If-None-Match") == '"v1"':
+            return _Resp(304)
+        return _Resp(200, '{"tag_name":"1.0.0"}', etag='"v1"')
+
+    try:
+        G._etag_cache = {}
+        G._etag_dirty = False
+        G._budget_window_start = None
+        G._budget_window_used = 0
+        G._http_get = _fake_get
+        first = G.github_get("https://api.github.com/repos/o/r/releases/latest")
+        assert first.status_code == 200
+        assert first.json()["tag_name"] == "1.0.0"
+        used_after_first = G._budget_window_used
+        second = G.github_get("https://api.github.com/repos/o/r/releases/latest")
+        assert second.status_code == 200
+        assert second.headers.get("X-IchaLaunch-FromCache") == "1"
+        assert second.json()["tag_name"] == "1.0.0"
+        assert calls[1]["inm"] == '"v1"'
+        assert G._budget_window_used == used_after_first, (
+            "304 was charged against the unauthenticated budget"
+        )
+    finally:
+        G._http_get = orig_get
+        G._etag_cache = orig_cache
+        G._etag_dirty = orig_dirty
+        G._budget_window_used = orig_used
+        G._budget_window_start = orig_start
+
+    print("OK github etag cache replays 304")
 
 
 def test_auto_scan_cooldown_setting():
@@ -17317,6 +17391,7 @@ def _run_smoke_tests():
     test_preview_addon_repo_soft_fails_fake_tags()
     test_github_token_not_sent_to_third_party_readme_hosts()
     test_github_bad_token_retries_without_auth()
+    test_github_etag_cache_replays_304()
     test_auto_scan_cooldown_setting()
     test_auto_scan_cooldown_persists_to_disk()
     test_addon_startup_token_gating()


### PR DESCRIPTION
Update scans re-fetched catalog data that had not changed and opened a fresh connection per request. This caches ETags so unchanged responses come back as 304, and reuses a single session across the scan.

This branches from an older master and will need a rebase before it can merge. Say the word and I will refresh it.