### PR TITLE
catalog: add dabblez/MatrixMaps

### DIFF
--- a/ichalaunch/data/addons.json
+++ b/ichalaunch/data/addons.json
@@ -19185,5 +19185,13 @@
     "source": "community",
     "folder": "X-Perl-UnitFrames",
     "description": "X-Perl UnitFrames for Vanilla WoW 1.12.1"
+  },
+  {
+    "name": "MatrixMaps",
+    "repo": "https://github.com/dabblez/MatrixMaps",
+    "category": "General",
+    "source": "community",
+    "folder": "MatrixMaps",
+    "description": "Mtxgrower33: SexyMaps Rework⚡MatrixMaps (V1.1) - TurtleWoW"
   }
 ]


### PR DESCRIPTION
## Summary
- Adds [dabblez/MatrixMaps](https://github.com/dabblez/MatrixMaps) to `ichalaunch/data/addons.json` (`source: community`).
- Opened from catalog suggestion issue #451 (label `catalog-approved`).
- This Action squash-merges automatically after creation.

Closes #451