### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -302,8 +302,8 @@
       "type": "github_release_latest",
       "repo": "brues-code/ClassicAPI",
       "asset_contains": "ClassicAPI.dll",
-      "sha256": "2a823b141326383a56fba100d09f5a72f34798b08f38fa9340e5bdc2ee31dc65",
-      "pinned_tag": "v1.12.7"
+      "sha256": "1a23ce26d5611e035c7cc7d63d30d8584302998b599818cd9f31b2208c1a8260",
+      "pinned_tag": "v1.12.8"
     },
     "files": [
       {

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "NXAVBfyQuJjrmXBLrPuxNVdPM2uiL2jEzW8RGBGAvNL01To6hkznKRfCV0gvrP0xS2Lc11ieS4FaXt6BfKXGDw==",
+  "sig": "5/cZYEn+0Lp3CbtR5L2gY8ZExkw0mVGE1/qQsN3tR1XOj6mXcm7u/42yU6Wo+JuK04Po91H/IYXFF6/5b71nAA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "0d4915fa5721492f45da3ed6140e61c649107de9c4345c808c335bc870c4336d"
+    "sha256": "20c648e246aa48d21ef255a7490875795727a2f811b21f216e9304538af69d57"
   },
-  "attestation_sig": "3ItpEAX0bN3PSwCuFgh9LR9owHMxeakM8gD3ZK7WFbUgICU0lPit+b9OpBB5lVef1ghtvABbhMYiNFDxQpwQDg=="
+  "attestation_sig": "cOlUYd445cDLUGLMhzS/dTKTKAD+7/H6VrvGHlmkfyurb8ie7tYwtjDxwZrRpf4TBle0NmEdXp5N/K/x2VAbAw=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong on public `master` at `ichalaunch/data/<name>.sig`.
- Signing keys never enter CI. Merge JSON + `.sig` together.
