### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -302,8 +302,8 @@
       "type": "github_release_latest",
       "repo": "brues-code/ClassicAPI",
       "asset_contains": "ClassicAPI.dll",
-      "sha256": "1a23ce26d5611e035c7cc7d63d30d8584302998b599818cd9f31b2208c1a8260",
-      "pinned_tag": "v1.12.8"
+      "sha256": "2a823b141326383a56fba100d09f5a72f34798b08f38fa9340e5bdc2ee31dc65",
+      "pinned_tag": "v1.12.7"
     },
     "files": [
       {
@@ -1120,79 +1120,6 @@
     "author": "MarcelineVQ"
   },
   {
-    "id": "wu_outline",
-    "name": "Outlines",
-    "category": "Advanced",
-    "description": "Glowing colored outlines around units. Toggle with /outlines or /ol.",
-    "info_url": "https://codeberg.org/MarcelineVQ/WeirdUtils",
-    "repo_url": "https://codeberg.org/MarcelineVQ/WeirdUtils",
-    "detect": {
-      "any_files": [
-        "outline.dll"
-      ]
-    },
-    "source": {
-      "type": "local",
-      "path": "tools/_weirdutils/out/outline.dll",
-      "filename": "outline.dll",
-      "bundle": "weirdutils",
-      "version": "1.0",
-      "build_hint": "Run: python tools/build_weirdutils.py --build-only"
-    },
-    "files": [
-      {
-        "match": "outline.dll",
-        "destination": "outline.dll"
-      }
-    ],
-    "dlls_txt": {
-      "add": [
-        "outline.dll"
-      ]
-    },
-    "kind": "dll_file",
-    "dependencies": [],
-    "conflicts": [],
-    "author": "MarcelineVQ"
-  },
-  {
-    "id": "wu_interact",
-    "name": "Interact",
-    "category": "Advanced",
-    "hidden": true,
-    "description": "Interact Nearest and Loot All Corpses helpers. Changes client hit-testing — follow your server's rules. Built from WeirdUtils source.",
-    "info_url": "https://codeberg.org/MarcelineVQ/WeirdUtils",
-    "repo_url": "https://codeberg.org/MarcelineVQ/WeirdUtils",
-    "detect": {
-      "any_files": [
-        "interact.dll"
-      ]
-    },
-    "source": {
-      "type": "local",
-      "path": "tools/_weirdutils/out/interact.dll",
-      "filename": "interact.dll",
-      "bundle": "weirdutils",
-      "version": "1.1.0",
-      "build_hint": "Run: python tools/build_weirdutils.py --build-only"
-    },
-    "files": [
-      {
-        "match": "interact.dll",
-        "destination": "interact.dll"
-      }
-    ],
-    "dlls_txt": {
-      "add": [
-        "interact.dll"
-      ]
-    },
-    "kind": "dll_file",
-    "dependencies": [],
-    "conflicts": [],
-    "author": "MarcelineVQ"
-  },
-  {
     "id": "wu_pngscreenshots",
     "name": "PNG Screenshots",
     "category": "Advanced",
@@ -1220,43 +1147,6 @@
     "dlls_txt": {
       "add": [
         "pngscreenshots.dll"
-      ]
-    },
-    "kind": "dll_file",
-    "dependencies": [],
-    "conflicts": [],
-    "author": "MarcelineVQ"
-  },
-  {
-    "id": "wu_framecrash",
-    "name": "Crash Fix",
-    "category": "Advanced",
-    "hidden": true,
-    "description": "Guards stale UI frame anchors on stock 1.12.1 (5875). Hidden — official Codeberg releases do not ship a PE, and the SuperWoW 2.2 source build still #132s on enter-world. Optional; not part of any preset. Built from patched WeirdUtils source.",
-    "info_url": "https://codeberg.org/MarcelineVQ/WeirdUtils",
-    "repo_url": "https://codeberg.org/MarcelineVQ/WeirdUtils",
-    "detect": {
-      "any_files": [
-        "framecrash.dll"
-      ]
-    },
-    "source": {
-      "type": "local",
-      "path": "tools/_weirdutils/out/framecrash.dll",
-      "filename": "framecrash.dll",
-      "bundle": "weirdutils",
-      "version": "1.0.2",
-      "build_hint": "Run: python tools/build_weirdutils.py --build-only"
-    },
-    "files": [
-      {
-        "match": "framecrash.dll",
-        "destination": "framecrash.dll"
-      }
-    ],
-    "dlls_txt": {
-      "add": [
-        "framecrash.dll"
       ]
     },
     "kind": "dll_file",
@@ -1523,17 +1413,19 @@
       ]
     },
     "source": {
-      "type": "local",
-      "path": "tools/_discord_presence/out/ichalaunch_discord.dll",
+      "type": "github_release",
+      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/ichalaunch-discord-1.2/ichalaunch_discord.dll",
       "filename": "ichalaunch_discord.dll",
-      "bundle": "discord_wow",
-      "version": "1.0",
-      "build_hint": "Run: python tools/build_discord_presence.py"
+      "sha256": "222617a87a7931e3c4b6ee27151ed75c0679072122859d3cb3de823a24e1e872",
+      "dest_sha256": "222617a87a7931e3c4b6ee27151ed75c0679072122859d3cb3de823a24e1e872",
+      "version": "1.2",
+      "path": "tools/_discord_presence/out/ichalaunch_discord.dll"
     },
     "files": [
       {
         "match": "ichalaunch_discord.dll",
-        "destination": "ichalaunch_discord.dll"
+        "destination": "ichalaunch_discord.dll",
+        "sha256": "222617a87a7931e3c4b6ee27151ed75c0679072122859d3cb3de823a24e1e872"
       }
     ],
     "dlls_txt": {

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "5/cZYEn+0Lp3CbtR5L2gY8ZExkw0mVGE1/qQsN3tR1XOj6mXcm7u/42yU6Wo+JuK04Po91H/IYXFF6/5b71nAA==",
+  "sig": "k2vQ+4E/7+OZQbLG2e8cv8lOkh1k9yDzBp689Z6pVghAOyeinlxISZ9Bpo2yJLZO1F2/tu/60dQH2N2I2+qaBg==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "20c648e246aa48d21ef255a7490875795727a2f811b21f216e9304538af69d57"
+    "sha256": "0ef4e6d885a43a932d7d73e8488a31f31bee73a3cb1b36aff13c81b88eb995d9"
   },
-  "attestation_sig": "cOlUYd445cDLUGLMhzS/dTKTKAD+7/H6VrvGHlmkfyurb8ie7tYwtjDxwZrRpf4TBle0NmEdXp5N/K/x2VAbAw=="
+  "attestation_sig": "kDI8AXQHjzAxc1R/HP0teChP/IPhlb+4Bu4iOY6cVOzkxoI3O7Dnz1ZtcA2C/w6r5ympSkeeG7DQwUEBWNHZDA=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong on public `master` at `ichalaunch/data/<name>.sig`.
- Signing keys never enter CI. Merge JSON + `.sig` together.
