### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/addon_tips.json.sig
+++ b/ichalaunch/data/addon_tips.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "ORgQDkSkApN/3zJoEI3D0t1LZVDFaCoF3wxaBjYcekHUK1eelK7HXR2o1cjZqYxr2W7bPAwjWfIA4hCNA+LMCA==",
+  "sig": "E6rjuZTxtA0Qewztm7ZM99+61lPu/ufoTpIMRDo8YeMDBPL58wipC5gxY34N47/xMGlHowLwaB4YzqjW5mt5AA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "98eab1321dfdf872368372f0b9563e85db40e803361dd99b56b5c0090f038248"
+    "sha256": "a9cab7d6fd300ff8d5377d82505e6a738b660fc61c95cf74c2c61eff025e36ac"
   },
-  "attestation_sig": "n1dhqumqECtm2ZXDIsvs2dKn6YTxxmk0YE7dsCGMzakBdvLGldPrdwV2c9VzneuLjqztXCkqEOx1eer5CNmXCg=="
+  "attestation_sig": "jXJU6xO7fygEFQKmxW4gOMfPetUOkwaeLZsg+qVtp6s9kiotoQW3qiPS/t0YpG1Noj59HRtlep2nGhAbFdoZDw=="
 }

--- a/ichalaunch/data/addons.json.sig
+++ b/ichalaunch/data/addons.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "UOAtdjR9w2tQYmJR3dLZ/S/lA1LONK2Mrxto9mfEdQBOaA3H1kremNE3qnPB/Qk/lswpAJ6WgWaYtY+5RIsKDg==",
+  "sig": "rc9xgHaET9ux1WAj/KBB58n5N47ize3CLUKeWleKMgj+b6YT4MaX6mUKVHknoGG7QryPGTQbCyaRrwjBVf9HBA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "04a0acf590ea56dbe332f4f9ac3f1c09eeacec91ddadd5edb00a0336b88a1bb3"
+    "sha256": "479e96677729ddef186c985466fb61e815ad20335b9b1e8573bcce80142f476c"
   },
-  "attestation_sig": "sTBYoNGsQaFuA4QYCabX1gl7bXfao0iWvWHKxVy15uVgrMeFgS03rbagiEsKeueu6CTAOicVwahPPy84442dBA=="
+  "attestation_sig": "dcrbApmllmgHyEJJVzf+iuo/rQDA0b+5KH4D3P8CWhTwmBOydJTq3z7qnemlVTxiPh41pbMQVcg4RTk5V//eAg=="
 }

--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -1405,8 +1405,7 @@
     "id": "ichalaunch_discord",
     "name": "Discord character status",
     "category": "Client Enhancements",
-    "hidden": true,
-    "description": "Behind-the-scenes helper that publishes character name, race, class, guild, zone, level, and faction for Discord Rich Presence. Loaded only when Show status on Discord and Show character details are both on. No in-game UI.",
+    "description": "Helper DLL that publishes character name, race, class, guild, zone, level, and faction for Discord Rich Presence. Enable it from Settings → Privacy (Show status on Discord and Show character details). No in-game UI.",
     "detect": {
       "any_files": [
         "ichalaunch_discord.dll"

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "k2vQ+4E/7+OZQbLG2e8cv8lOkh1k9yDzBp689Z6pVghAOyeinlxISZ9Bpo2yJLZO1F2/tu/60dQH2N2I2+qaBg==",
+  "sig": "Y/P9iqgzGx2B08Ea+9J8YBFHeDTVjZt7C+tPOQUlBNbXgUiv/u5O5CmEp3VRZLb1tNogaT9hA5ROksuCGp6nBw==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "0ef4e6d885a43a932d7d73e8488a31f31bee73a3cb1b36aff13c81b88eb995d9"
+    "sha256": "93bcea7ff5b57e6892df55e855e73a582006b75a83ebd4c1c3006159180ec933"
   },
-  "attestation_sig": "kDI8AXQHjzAxc1R/HP0teChP/IPhlb+4Bu4iOY6cVOzkxoI3O7Dnz1ZtcA2C/w6r5ympSkeeG7DQwUEBWNHZDA=="
+  "attestation_sig": "Gz8InTuvT8xHtWf9zTeC+VBMie2kzmDE12ymKK2MflluuGnZ4A5kEhTkGJUmJPCZz8ct0S1hPPtFngiuxu85Bg=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong on public `master` at `ichalaunch/data/<name>.sig`.
- Signing keys never enter CI. Merge JSON + `.sig` together.
