### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -130,6 +130,7 @@
       ]
     },
     "kind": "dll_bundle",
+    "has_config": true,
     "dependencies": [],
     "conflicts": [],
     "author": "balakethelock"
@@ -210,6 +211,7 @@
       ]
     },
     "kind": "dll_file",
+    "has_config": true,
     "dependencies": [],
     "conflicts": [],
     "author": "brues-code"
@@ -251,6 +253,7 @@
       ]
     },
     "kind": "dll_bundle",
+    "has_config": true,
     "dependencies": [],
     "conflicts": [],
     "author": "brues-code"
@@ -349,6 +352,7 @@
       ]
     },
     "kind": "dll_file",
+    "has_config": true,
     "dependencies": [],
     "conflicts": [],
     "author": "RetroCro"

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "Y+lj/oB+Wdqymbhcp+MV591F+7tuHvuEyADILap/UEoFwcYq1A4jNCOsiX+2EtYRUFF6DspjlSCzRMOIVw2vBQ==",
+  "sig": "00+/7/U2To+ZdRaJ5KV3L14JvqCxH9A6DwtQ6XFRIdRiMQddks/smmK2oXHi8JmWjrJTeQ+YoLkXAUshgqS5AQ==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "3cf40f950c30805a67dda0c25bd0cedf5b6587087f4d8a29b5a269d165c0cee5"
+    "sha256": "70f3ba09917329d78661e1282bfdcb92cd9202fd11d998c6eabfe95a18d99fef"
   },
-  "attestation_sig": "hojVizHyKFcYQdXEf5kp7q63719fdfCDvX8FXXBaExUnJYiGnDbr6eo2uReN/F2GZpprEs1IU/lgCH5BXiRCAg=="
+  "attestation_sig": "ftvTm00q9usypaVSm7G9VbloEtV9EcrZMJLTOl/UZJAQTkCMOT8CnsMzr7+Eaaedmb7PzhUibtgcymmzODVKAA=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong on public `master` at `ichalaunch/data/<name>.sig`.
- Signing keys never enter CI. Merge JSON + `.sig` together.
