### PR TITLE
catalog: hourly tips/downloads (unsigned — sign before merge)

### DIFF
--- a/ichalaunch/data/addon_tips.json
+++ b/ichalaunch/data/addon_tips.json
@@ -16327,10 +16327,10 @@
       }
     },
     "roby-brok/pfui": {
-      "default_branch": "master",
+      "default_branch": "octo",
       "sha": "3df77210ad68543dcce39dff96e5d664677acd98",
       "branches": {
-        "master": "3df77210ad68543dcce39dff96e5d664677acd98"
+        "octo": "3df77210ad68543dcce39dff96e5d664677acd98"
       },
       "latest_tag": "v9.0.21"
     },
@@ -16529,10 +16529,10 @@
       "latest_tag": "7.0.1"
     },
     "roby-brok/pfquest-classicapi": {
-      "default_branch": "octo",
+      "default_branch": "master",
       "sha": "a71931538988b930ee51f115a7d5683fe914ec21",
       "branches": {
-        "octo": "a71931538988b930ee51f115a7d5683fe914ec21"
+        "master": "a71931538988b930ee51f115a7d5683fe914ec21"
       },
       "latest_tag": "8.1.0"
     },
@@ -16702,6 +16702,28 @@
         "master": "c4d29afe690193ad673bd84d1299fa56665a20a2"
       },
       "latest_tag": "1.3.1"
+    },
+    "greendam/theorycraft-turtle": {
+      "default_branch": "master",
+      "sha": "10d128aa3855c3fa10cb3609e121e272fba5b1a0",
+      "branches": {
+        "master": "10d128aa3855c3fa10cb3609e121e272fba5b1a0"
+      }
+    },
+    "roby-brok/mikscrollingbattletext": {
+      "default_branch": "octo",
+      "sha": "6169f104c873e3c90605339a4494b983892c5978",
+      "branches": {
+        "octo": "6169f104c873e3c90605339a4494b983892c5978"
+      }
+    },
+    "brutaliccus/ichalaunch": {
+      "default_branch": "master",
+      "sha": "a7483bfc7053bd6ef313c985d16f10ca75319d9b",
+      "branches": {
+        "master": "a7483bfc7053bd6ef313c985d16f10ca75319d9b"
+      },
+      "latest_tag": "v1.5.7"
     }
   }
 }

--- a/ichalaunch/data/addons.json
+++ b/ichalaunch/data/addons.json
@@ -123,8 +123,8 @@
     "folder": "Bagshui",
     "release_downloads_repo": "The-Kludge-Bureau/Bagshui",
     "release_downloads_state": "ok",
-    "release_downloads": 215,
-    "release_downloads_at": "2026-08-28T08:25:16Z"
+    "release_downloads": 235,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "BlizzMo",
@@ -135,8 +135,8 @@
     "folder": "BlizzMo_Vanilla",
     "release_downloads_repo": "Dyaxler/BlizzMo_Vanilla",
     "release_downloads_state": "ok",
-    "release_downloads": 1010,
-    "release_downloads_at": "2026-08-28T08:25:16Z"
+    "release_downloads": 1011,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "CooldownTimers",
@@ -815,8 +815,8 @@
     ],
     "release_downloads_repo": "zmarotrix/BattleMusic",
     "release_downloads_state": "ok",
-    "release_downloads": 1398,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 1400,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "BattleScribe",
@@ -2818,8 +2818,8 @@
     ],
     "release_downloads_repo": "The-Kludge-Bureau/Accountant",
     "release_downloads_state": "ok",
-    "release_downloads": 11,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 12,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "ActionButtonUtils",
@@ -3016,8 +3016,8 @@
     ],
     "release_downloads_repo": "Road-block/AttackBar",
     "release_downloads_state": "ok",
-    "release_downloads": 2628,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 2632,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "AttackBar Turtle",
@@ -3311,8 +3311,8 @@
     "folder": "BetterAlign",
     "release_downloads_repo": "DennisWG/BetterAlign",
     "release_downloads_state": "ok",
-    "release_downloads": 675,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 678,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "BetterBabelFish",
@@ -3930,8 +3930,8 @@
     ],
     "release_downloads_repo": "ScottHamper/chatsuey",
     "release_downloads_state": "ok",
-    "release_downloads": 5082,
-    "release_downloads_at": "2026-08-27T13:39:38Z"
+    "release_downloads": 5091,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "ChatTimestamps",
@@ -3996,8 +3996,8 @@
     "folder": "ClassicSnowFall",
     "release_downloads_repo": "Road-block/ClassicSnowFall",
     "release_downloads_state": "ok",
-    "release_downloads": 563,
-    "release_downloads_at": "2026-08-28T08:25:16Z"
+    "release_downloads": 565,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "ClassPortraits",
@@ -4137,8 +4137,8 @@
     ],
     "release_downloads_repo": "shagu/Clique",
     "release_downloads_state": "ok",
-    "release_downloads": 1654,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 1657,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "CLog",
@@ -5242,8 +5242,8 @@
     "folder": "wow-vanilla-gearmenu",
     "release_downloads_repo": "RagedUnicorn/wow-vanilla-gearmenu",
     "release_downloads_state": "ok",
-    "release_downloads": 2665,
-    "release_downloads_at": "2026-08-27T23:32:15Z"
+    "release_downloads": 2669,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "GFW HuntersHelper",
@@ -5884,8 +5884,8 @@
     "folder": "KeijinAchievementMonitor",
     "release_downloads_repo": "KeijinDE/KeijinAchievementMonitor",
     "release_downloads_state": "ok",
-    "release_downloads": 49,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 50,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "KethoDoc",
@@ -6224,8 +6224,8 @@
     ],
     "release_downloads_repo": "UndercityAddons-Vanilla/MacroTT-V",
     "release_downloads_state": "ok",
-    "release_downloads": 395,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 397,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "ManaMinder",
@@ -6810,8 +6810,8 @@
     ],
     "release_downloads_repo": "rgd87/NugComboBar",
     "release_downloads_state": "ok",
-    "release_downloads": 97,
-    "release_downloads_at": "2026-08-27T13:39:38Z"
+    "release_downloads": 108,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "NugEnergy",
@@ -6844,8 +6844,8 @@
     ],
     "release_downloads_repo": "rgd87/NugEnergy",
     "release_downloads_state": "ok",
-    "release_downloads": 44,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 47,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "oCB",
@@ -7589,8 +7589,8 @@
     ],
     "release_downloads_repo": "Steelbash/RestBar",
     "release_downloads_state": "ok",
-    "release_downloads": 462,
-    "release_downloads_at": "2026-08-27T13:39:38Z"
+    "release_downloads": 467,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "Rested",
@@ -7728,8 +7728,8 @@
     ],
     "release_downloads_repo": "jsb/RingMenu",
     "release_downloads_state": "ok",
-    "release_downloads": 833,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 836,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "ROAR-Guild",
@@ -7762,8 +7762,8 @@
     ],
     "release_downloads_repo": "Road-block/RogueFocus",
     "release_downloads_state": "ok",
-    "release_downloads": 1407,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 1408,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "RoguePack",
@@ -8388,8 +8388,8 @@
     "folder": "ShaguTweaks-DruidManaBar",
     "release_downloads_repo": "gashole/ShaguTweaks-DruidManaBar",
     "release_downloads_state": "ok",
-    "release_downloads": 700,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 701,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "ShaguTweaks Mods",
@@ -9148,10 +9148,10 @@
         "repo": "https://github.com/melbaa/TankHelper"
       }
     ],
-    "release_downloads_repo": "balakethelock/TankHelper",
+    "release_downloads_repo": "Otari98/TankHelper",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-02T01:10:54Z",
     "recommended": true
   },
   {
@@ -10118,8 +10118,8 @@
     ],
     "release_downloads_repo": "laytya/WowLuaVanilla",
     "release_downloads_state": "ok",
-    "release_downloads": 108,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 110,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "WowRadio",
@@ -10827,8 +10827,8 @@
     ],
     "release_downloads_repo": "laytya/MinimapButtonFrame-vanilla",
     "release_downloads_state": "ok",
-    "release_downloads": 2339,
-    "release_downloads_at": "2026-08-28T08:25:16Z"
+    "release_downloads": 2349,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "PingoMatic",
@@ -10991,8 +10991,8 @@
     ],
     "release_downloads_repo": "Shellyoung/AdvancedTradeSkillWindow2",
     "release_downloads_state": "ok",
-    "release_downloads": 153,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 159,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "Artisan",
@@ -11509,7 +11509,11 @@
         "repo": ""
       }
     ],
-    "recommended": true
+    "recommended": true,
+    "release_downloads_repo": "greendam/TheoryCraft-Turtle",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "TradeChat",
@@ -11785,8 +11789,8 @@
     ],
     "release_downloads_repo": "RagedUnicorn/wow-pvpwarn",
     "release_downloads_state": "ok",
-    "release_downloads": 226,
-    "release_downloads_at": "2026-08-27T23:32:15Z"
+    "release_downloads": 228,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "Quickcall",
@@ -12033,8 +12037,8 @@
     "folder": "AutoQuest",
     "release_downloads_repo": "MickeyPickey/AutoQuest",
     "release_downloads_state": "ok",
-    "release_downloads": 289,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 291,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "AutoTurnIn",
@@ -12211,8 +12215,8 @@
     ],
     "release_downloads_repo": "JeromeM/GuidelimeVanilla",
     "release_downloads_state": "ok",
-    "release_downloads": 264,
-    "release_downloads_at": "2026-08-27T23:32:15Z"
+    "release_downloads": 272,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "HardcoreAlarms",
@@ -12288,8 +12292,8 @@
     ],
     "release_downloads_repo": "Cliencer/pfExtend",
     "release_downloads_state": "ok",
-    "release_downloads": 170,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 8,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "pfQuest",
@@ -12346,8 +12350,8 @@
     ],
     "release_downloads_repo": "The-Kludge-Bureau/pfQuest",
     "release_downloads_state": "ok",
-    "release_downloads": 6695,
-    "release_downloads_at": "2026-08-28T08:25:16Z"
+    "release_downloads": 6975,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "pfQuest-icons",
@@ -12593,8 +12597,8 @@
     "folder": "QuestSoundBits",
     "release_downloads_repo": "Road-block/QuestSoundBits",
     "release_downloads_state": "ok",
-    "release_downloads": 132,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 133,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "QuestTracker",
@@ -12688,10 +12692,10 @@
         "repo": "https://github.com/cyaohiri/TriviaBot-TurtleWow"
       }
     ],
-    "release_downloads_repo": "cyaohiri/TriviaBot-TurtleWow",
+    "release_downloads_repo": "greendam/TriviaBot-TurtleWow",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-02T01:10:54Z",
     "recommended": true
   },
   {
@@ -13966,8 +13970,8 @@
     ],
     "release_downloads_repo": "obszczymucha/roll-for-vanilla",
     "release_downloads_state": "ok",
-    "release_downloads": 3736,
-    "release_downloads_at": "2026-08-27T23:32:15Z"
+    "release_downloads": 3754,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "RoundRobinhood",
@@ -14096,8 +14100,8 @@
     ],
     "release_downloads_repo": "Road-block/shootyepgp",
     "release_downloads_state": "ok",
-    "release_downloads": 676,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 678,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "SimpleRaidTargetIcons",
@@ -14234,10 +14238,10 @@
         "repo": "https://github.com/USS-Enterprise-Guild/StatCompare"
       }
     ],
-    "release_downloads_repo": "grimfiendish/StatCompare",
-    "release_downloads_state": "none",
+    "release_downloads_repo": "GrimWow/StatCompare",
+    "release_downloads_state": "ok",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-02T01:10:54Z",
     "recommended": true
   },
   {
@@ -14514,8 +14518,8 @@
     "folder": "XLoot_AddOns",
     "release_downloads_repo": "Road-block/XLoot_AddOns",
     "release_downloads_state": "ok",
-    "release_downloads": 1572,
-    "release_downloads_at": "2026-08-27T23:32:15Z"
+    "release_downloads": 1576,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "XtraUnitFrame",
@@ -14669,10 +14673,10 @@
         "repo": "https://github.com/CarnVanBeck/TurtleRP"
       }
     ],
-    "release_downloads_repo": "OldManAlpha/TurtleRP",
+    "release_downloads_repo": "bratmage/TurtleRP",
     "release_downloads_state": "ok",
-    "release_downloads": 265,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-02T01:10:54Z",
     "recommended": true
   },
   {
@@ -14990,8 +14994,8 @@
     ],
     "release_downloads_repo": "gashole/DruidManaBar",
     "release_downloads_state": "ok",
-    "release_downloads": 91,
-    "release_downloads_at": "2026-08-28T08:25:16Z"
+    "release_downloads": 94,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "FastTOT",
@@ -15008,8 +15012,8 @@
     ],
     "release_downloads_repo": "OldManAlpha/FastTOT",
     "release_downloads_state": "ok",
-    "release_downloads": 19,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 20,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "Friend-O-Tron",
@@ -15174,8 +15178,8 @@
     "folder": "oCB",
     "release_downloads_repo": "Shellyoung/oCB-SuperWoW",
     "release_downloads_state": "ok",
-    "release_downloads": 136,
-    "release_downloads_at": "2026-08-28T08:25:16Z"
+    "release_downloads": 138,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "Overhead",
@@ -15300,8 +15304,8 @@
     ],
     "release_downloads_repo": "OldManAlpha/Puppeteer",
     "release_downloads_state": "ok",
-    "release_downloads": 249,
-    "release_downloads_at": "2026-08-27T23:32:15Z"
+    "release_downloads": 268,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "Quartz",
@@ -16087,10 +16091,10 @@
         "repo": "https://github.com/balakethelock/SuperAPI_Castlib"
       }
     ],
-    "release_downloads_repo": "balakethelock/SuperAPI_Castlib",
+    "release_downloads_repo": "Gescht/SuperAPI_Castlib",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-02T01:10:54Z",
     "recommended": true
   },
   {
@@ -16118,10 +16122,10 @@
         "repo": "https://github.com/Hippoom/SuperCleveRoidMacros"
       }
     ],
-    "release_downloads_repo": "jrc13245/SuperCleveRoidMacros",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_repo": "brues-code/SuperCleveRoidMacros",
+    "release_downloads_state": "ok",
+    "release_downloads": 59,
+    "release_downloads_at": "2026-09-02T01:10:54Z",
     "recommended": true
   },
   {
@@ -16230,10 +16234,10 @@
         "repo": "https://github.com/MarcelineVQ/Tankalyze"
       }
     ],
-    "release_downloads_repo": "MarcelineVQ/Tankalyze",
+    "release_downloads_repo": "twapegg/Tankalyze",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-02T01:10:54Z",
     "recommended": true
   },
   {
@@ -16265,10 +16269,10 @@
         "repo": "https://github.com/shikulja/TankPlates"
       }
     ],
-    "release_downloads_repo": "MarcelineVQ/TankPlates",
-    "release_downloads_state": "none",
+    "release_downloads_repo": "daemonp/TankPlates",
+    "release_downloads_state": "ok",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-02T01:10:54Z",
     "recommended": true
   },
   {
@@ -16284,10 +16288,10 @@
         "repo": "https://github.com/MarcelineVQ/Tattler"
       }
     ],
-    "release_downloads_repo": "MarcelineVQ/Tattler",
+    "release_downloads_repo": "Bang1726528/Tattler",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-02T01:10:54Z",
     "recommended": true
   },
   {
@@ -16760,8 +16764,8 @@
     ],
     "release_downloads_repo": "i2ichardt/HealersMate",
     "release_downloads_state": "ok",
-    "release_downloads": 23,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 26,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "HideNamePlates",
@@ -17649,8 +17653,8 @@
     "description": "# pfQuest (turtle)\nThis AddOn is a [pfQuest](https://github.com/shagu/pfQuest) extension, which adds support for the [TurtleWoW](https://turtle-wow.org/) Private Server. In order to run this extension, the latest version of [pfQuest](https://github.com/shagu/pfQuest) is always required and only enUS-Gameclients are supported.\n\n*Notice: Issues and bugs like \"please add quest XYZ\" and all other content requests will be silently ignored. This is, because the data is not manually added, but depends on the Turtle-WoW team to release their database to a trusted person that can produce pfQuest-turtle builds.*\n\nIf you wish to contribute, please feel free to send a [Pull Requests](https://github.com/bennylava/pfQuest-turtle/pulls).\n\n## Install\n*The latest version of [pfQuest](https://shagu.org/pfQuest) is required for this module to work.*\n\n1. Download **[pfQuest-turtle](https://github.com/bennylava/pfQuest-turtle/archive/master.zip)**\n2. Unpack the Zip file\n3. Rename the folder \"pfQuest-turtle-master\" to \"pfQuest-turtle\"\n4. Copy \"pfQuest-turtle\" into Wow-Directory\\Interface\\AddOns\n5. Restart Wow",
     "release_downloads_repo": "Bennylavaa/pfQuest-turtle",
     "release_downloads_state": "ok",
-    "release_downloads": 10,
-    "release_downloads_at": "2026-08-28T08:25:16Z"
+    "release_downloads": 13,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "pfQuest-turtle",
@@ -18217,8 +18221,8 @@
     "description": "# For TurtleWoW launcher\nClick Addons - Add new addon - paste this url there: https://github.com/vaniron/TourGuide-Turtle.git\n\n# Contact & Donations\nYou can add me on discord: **vanironcz**\n\nIf you wanna support this fork, you can do so via https://www.paypal.com/donate/?hosted_button_id=FSQQQGRSBDA58\n\n# TourGuide-Turtle\nTekkub's TourGuide Addon backported for WoW 1.12 *with tweaks for TurtleWoW*\n\nRecommended Downloads: \n\n[**TomTom-TWOW**](https://github.com/laytya/TomTom-TWOW)\n* **Arrow to navigate you to next guide point**\n* you have to disable arrow from pfQuest as its showing closest quest, not optimal path - TomTom is integrated directly to TourGuide and shoudl be used instead\n\n[**pfQuest**](https://github.com/shagu/pfQuest) + [**pfQuest-turtle**](https://github.com/shagu/pfQuest-turtle)\n* pfQuest adds many features like tracking, map icons etc.\n\n[**pfUI**](https://github.com/shagu/pfUI)\n* pfUI provides so much more, overall UI overhaul but all features can be tweaked and disabled if you dont like them\n\nOptional addon: [TourGuide_Professions](https://github.com/Lorwik/TourGuide_Professions)\n\n\n**Features**\n* Automatic detection of objective completion\n  * Detect quest accept, completion and turnin\n  * Detect travel (by foot, flight, boat and stone)\n  * Detection of flight point discovery\n  * Detection of Hearth point change\n* Conditionals based on player’s class and item possession (only tell the player to accept the quest if they have the item that starts the quest)\n* Small “lego block” style frame shows current objective, detailed tooltips on hover\n* “Use item” frame, for those annoying quests where you have to use an item on a mob before you kill it, or you have to equip something, or you have to use an item to start a quest\n* Pop out frame for detailed view of quest sequence\n* Automatic mapping of coordinates with TomTom and questgiver locations from pfQuest if installed\n\nGuides list, plus few others didnt make it into the screenshot (Plaguelands, Silithus, Winterspring), too many for one screen xD\n![image](https://github.com/user-attachments/assets/7d655a07-d8b9-48ad-b514-b95fcefb81a8)\n\n\n**Contributors**\n* Tekkub\n* Cralor\n* Road-block\n* Rsheep\n* Azgaardian\n* Kyliexx\n* laytya\n* jb6357\n* Ez-mode\n* Gescht\n* Vaniron\n* Trus3683\n* Ravenhost",
     "release_downloads_repo": "vaniron/TourGuide-Turtle",
     "release_downloads_state": "ok",
-    "release_downloads": 230,
-    "release_downloads_at": "2026-08-28T08:25:16Z"
+    "release_downloads": 232,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "TourGuideVanilla",
@@ -18353,9 +18357,9 @@
     "folder": "pfUI",
     "description": "# pfUI - OctoWoW Edition\n\n> ### About this fork\n>\n> **This fork is maintained for [OctoWoW](https://octowow.st).** Everything here was found and\n> fixed while running on that server; the fixes are not OctoWoW-specific and should apply to any\n> 1.12 client, but OctoWoW is the only place it has actually been tested.\n>\n> pfUI is the work of **[Shagu](https://github.com/shagu/pfUI)** (Eric Mauser), released under the\n> MIT licence, and this branch descends from **me0wg4ming's** Turtle WoW edition — which is why\n> parts of the documentation below still refer to Turtle WoW. All the credit belongs to them; this\n> fork only adds the fixes listed here, on top of their work.\n>\n> Note that the upstream repository this was cloned from\n> (`github.com/me0wg4ming/pfUI`) is no longer reachable, which is part of why this copy exists.\n> The full original commit history is preserved here.\n>\n> Fork maintained by **Roby_Brok**. Version bumped to **9.0.8** to distinguish it.\n>\n> ---\n>\n> #### UI scale / resolution\n>\n> - **`GetPerfectPixel` guards an unparseable `gxResolution`** (previously `768 / nil`, which killed\n>   every border on the UI).\n>\n>   ~~It also measured against `UIParent:GetEffectiveScale()` rather than the `uiScale` cvar.~~\n>   **Reverted 2026-08-10 — that was wrong.** The cvar's 1.0 cap looks like a bug but is\n>   load-bearing: the \"Huge\"/\"Large\" presets push `UIParent` to 1.42 / 1.14 via `SetScale`, and\n>   measuring that true scale makes `768 / screenheight / scale` fall below half a pixel, so border\n>   `edgeSize` rounds to zero and the borders vanish. Caught by\n>   [brues-code](https://github.com/brues-code) after the same change was merged and then reverted\n>   upstream.\n> - **`pixelperfect` loaded 55th, but sets the scale everything else is measured against.** That\n>   value is cached on first use, so every module loaded before it baked in the *previous* scale —\n>   the classic \"reload twice before it looks right\". It now loads first.\n> - The module only re-applies the scale when it actually changes, and drops the cached pixel and\n>   border sizes when it does.\n> - \"Enable UI-Scale\" now asks for a reload instead of applying live, since existing frames keep\n>   border sizes computed for the old scale.\n>\n> #### Features that silently did nothing\n>\n> pfUI runs each module inside a sandboxed environment that has `__index` but no `__newindex`, so\n> a bare global assignment inside a module never reaches `_G`. These all looked registered and\n> were not:\n>\n> | Where | What was dead |\n> |---|---|\n> | `modules/nampower.lua` | `/disenchantall`, `/dea` |\n> | `modules/superwow.lua` | `/clickthrough`, `/ct` |\n> | `modules/unitxp.lua` | `/pfunitxp`, and the battleground-pop notification |\n> | `modules/hdgraphic.lua` | `OptionsFrame_OnShow` — the extended world-detail slider never installed |\n> | `modules/raid.lua` | `GROUP_REPLACE_PARTY` |\n>\n> #### Other\n>\n> - `modules/loot.lua` — restored `local autoLoot = arg1`; `CloseLoot(not autoLoot)` was reading a\n>   nil global and always suppressing the server-side close notification.\n> - `api/ui-widgets.lua` — removed a dead fourth value in `SetHighlight`'s colour assignment.\n> - `init/skins.xml` — removed a duplicated block that loaded five Turtle WoW skins twice.\n> - Plus an earlier batch of fixes across the stutter-prone hot paths (nameplate debuff scanning,\n>   unit-frame aggro checks, throttle allocations, cooldown updates), a number of silently broken\n>   features, and a class-colour accent option.\n> - `modules/thirdparty-vanilla.lua` — [OWThreat](https://github.com/roby-brok/OWThreat) now docks\n>   into the right chat panel and takes the pfUI skin, exactly like the TWThreat it was forked\n>   from; both are driven by the same *TW/OW Threatmeter* checkboxes under *Thirdparty*.\n>\n> ---\n\n[![Version](https://img.shields.io/badge/version-9.0.8-blue.svg)](https://github.com/roby-brok/pfUI)\n[![OctoWoW](https://img.shields.io/badge/OctoWoW-supported-brightgreen.svg)](https://octowo\n\n… (truncated)",
     "release_downloads_repo": "roby-brok/pfUI",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_state": "ok",
+    "release_downloads": 8,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "pfUI",
@@ -18366,8 +18370,8 @@
     "description": "# pfUI - ClassicAPI Edition\n\n[![Octo WoW](https://img.shields.io/badge/Octo%20WoW-1.18.1-brightgreen.svg)](https://octowow.st/)\n[![ClassicAPI](https://img.shields.io/badge/ClassicAPI-Required-purple.svg)](https://github.com/brues-code/ClassicAPI)\n[![Nampower](https://img.shields.io/badge/Nampower-Required-purple.svg)](https://github.com/brues-code/nampower)\n[![SuperWoW](https://img.shields.io/badge/SuperWoW-Optional-yellow.svg)](https://github.com/balakethelock/SuperWoW)\n[![UnitXP](https://img.shields.io/badge/UnitXP__SP3-Optional-yellow.svg)](https://github.com/brues-code/UnitXP_SP3)\n\n**A pfUI fork specifically optimized for ClassicAPI on [Octo WoW](https://octowow.st/)**\n\nThis version includes significant performance improvements and DLL-enhanced features.\n\n## Installation\n1. Download **[Latest Version](https://github.com/brues-code/pfUI/releases/latest)**\n2. Unpack the Zip file\n4. Copy \"pfUI\" into Wow-Directory\\Interface\\AddOns\n5. Restart Wow\n\n## DLL Enhancements\n\nSince pfUI 6.0.0 includes integrations with client-side DLLs for enhanced functionality. These DLLs are permitted on Octo WoW:\n\n### [ClassicAPI](https://github.com/brues-code/ClassicAPI)\n\nProvides:\n- C_NamePlate - Event-driven nameplates (no more per-frame WorldFrame scanning) with real per-plate unit tokens and GUIDs\n- C_UnitAuras - Replaces over 3k lines of hand-rolled aura tracking\n- C_Spell - Replaces thousands of hardcoded spell names for each locale and powers castbar\n- Real cast bars - Actual cast/channel timing, spellID and interrupt state for any unit (C_Spell.UnitCastingInfo)\n- Focus - A genuine `focus` unit plus `/focus` and `/clearfocus` (FocusUnit / ClearFocus)\n- C_EquipmentSet - Full Equipment Manager with GUID-tracked gear sets (tells apart duplicate/enchanted items)\n- Instant Bag Sorting - C_Container.MoveItem / SwapItems instead of cursor pickup/drop\n- Sell junk in one call - C_MerchantFrame.GetNumJunkItems / SellAllJunkItems\n- Real item data - C_Item counts, quality, sell price and item info by ID\n- GUID-based targeting - Nameplates, mouseover and focus resolve by GUID, not by name text\n- Faster, safer profile sharing - Engine-side serialize/compress/base64 via C_EncodingUtil\n- C_Timer - After / NewTicker replacing hand-rolled OnUpdate throttles\n- Feign death, shapeshift and quest-item detection via real API calls\n- Mouseover Unit Frames\n- Click-casting\n- Loot Roll History (/loothistory)\n- New item highlighting\n- Plenty other functions\n\n### [Nampower](https://github.com/brues-code/nampower)\n\nProvides:\n- Spell queue indicator\n- GCD indicator\n\n### [SuperWoW](https://github.com/balakethelock/SuperWoW)\n\nProvides:\n- Tracks party/raid units on the minimap\n\n### [UnitXP_SP3](https://github.com/brues-code/UnitXP_SP3)\n\nProvides:\n- Line of Sight detection\n- Behind detection\n- Accurate distance calculations\n- OS notifications\n\nUse `/pfdll` in-game to check which DLLs are detected.\n\n## Commands\n\n    /pfui         Open the configuration GUI\n    /pfdll        Show DLL detection status (SuperWoW, Nampower, UnitXP)\n    /pfbehind     Test Behind/LOS detection on current target\n    /clickthrough Toggle clickthrough mode (or /ct)\n    /share        Open the configuration import/export dialog\n    /gm           Open the ticket Dialog\n    /rl           Reload the whole UI\n    /farm         Toggles the Farm-Mode\n    /pfcast       Same as /cast but for mouseover units\n    /focus        Creates a Focus-Frame for the current target\n    /castfocus    Same as /cast but for focus frame\n    /clearfocus   Clears the Focus-Frame\n    /swapfocus    Toggle Focus and Target-Frame\n    /pftest       Toggle pfUI Unitframe Test Mode\n    /abp          Addon Button Panel\n    /loothistory  Show Loot Roll History\n\n## Languages\npfUI supports and contains language specific code for the following gameclients.\n* English (enUS)\n* Korean (koKR)\n* French (frFR)\n* German (deDE)\n* Chinese (zhCN)\n* Spanish (esES)\n* Russian (ruRU)\n\n## Recommended Addons\n* [pfQuest](https://github.co\n\n… (truncated)",
     "release_downloads_repo": "brues-code/pfUI",
     "release_downloads_state": "ok",
-    "release_downloads": 93,
-    "release_downloads_at": "2026-08-28T08:25:16Z"
+    "release_downloads": 39,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "NiceDamage-1.12",
@@ -18378,8 +18382,8 @@
     "description": "# NiceDamage for WoW Vanilla 1.12\n\n> ## 📥 Latest Release\n>\n> **Download the latest version here:**\n>\n> https://github.com/Wurmschwanz/NiceDamage-1.12/releases/latest\n\nA lightweight enhancement of the original **NiceDamage** addon for **World of Warcraft Vanilla 1.12**.\n\nNiceDamage replaces the default floating combat text font and introduces a lightweight minimap-based font selector with themed style categories while staying true to the original philosophy: **simple, lightweight and fast.**\n\n---\n\n# ✨ Features\n\n- Lightweight combat text font replacement\n- Minimap button for quick access\n- Hierarchical font selection menu\n- Style-based font organization\n- Automatic font saving\n- Lightweight implementation\n- No measurable FPS or CPU impact\n- Compatible with WoW Vanilla 1.12\n- Compatible with pfUI\n\n---\n\n# 🎨 Available Style Categories\n\n## Blizzard\n\n- Warcraft III Style\n- Diablo Style\n- StarCraft Style\n\n## FPS\n\n- Doom Style\n- Quake Style\n- Unreal Style\n- Half-Life Style\n\n## Sci-Fi\n\n- Halo Style\n- Alien Style\n\n---\n\n# 📦 Installation\n\n1. Remove any previous `NiceDamage` and `NiceDamage_Font_*` folders from:\n\n```text\nInterface/AddOns/\n```\n\n2. Extract the archive into:\n\n```text\nInterface/AddOns/\n```\n\n3. Start World of Warcraft.\n\n4. Left-click the minimap button to open the font menu.\n\n5. Select your preferred combat text style.\n\n> **Note**\n>\n> Some WoW Vanilla 1.12 clients cache combat fonts during startup.\n>\n> After changing the selected combat font, a **full game restart** is required.\n>\n> Using `/reload` is **not** sufficient on affected clients.\n\n---\n\n# ⚡ Performance\n\nNiceDamage was designed to remain lightweight.\n\n- No permanent `OnUpdate` loops\n- No continuous background processing\n- No measurable FPS impact\n- Font changes are only processed when requested by the player\n\n---\n\n# ✅ Compatibility\n\n- WoW Vanilla 1.12\n- pfUI compatible\n- Compatible with most Vanilla private servers using the original 1.12 client\n\n---\n\n# 🚀 Roadmap\n\nThe following style categories are planned for future updates.\n\n### Retro\n\n- Arcade\n- Terminal\n- Pixel\n\n### Fantasy\n\n- Medieval\n- Ancient\n\nMore style categories and additional combat font styles will be added over time.\n\n---\n\n# ❤️ Credits\n\nOriginal **NiceDamage** addon by its original author(s).\n\nEnhanced for **WoW Vanilla 1.12** by **Wurmschwanz**.\n\nSpecial thanks to everyone who helped testing fonts and improving compatibility.",
     "release_downloads_repo": "Wurmschwanz/NiceDamage-1.12",
     "release_downloads_state": "ok",
-    "release_downloads": 92,
-    "release_downloads_at": "2026-08-28T08:25:16Z"
+    "release_downloads": 110,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "Chronometer-Turtle",
@@ -18440,10 +18444,10 @@
     "source": "community",
     "folder": "MikScrollingBattleText",
     "description": "<html>\n\t<head>\n\t\t<title>Mik's Scrolling Battle Text Readme</title>\n\t\t<style type=\"text/css\">\n\t\t\tbody { font-size: 10pt; font-family: verdana, arial, helvetica, sans-serif; }\n\t\t\th1   { font-weight: bold; color: #004080; }\n\n\t\t\ta:link    { color: #000060; text-decoration: none; }\n\t\t\ta:visited { color: #000060; text-decoration: none; }\n\t\t\ta:hover   { text-decoration: underline; }\n\n\t\t\tdiv#HeaderBlock { background-color: #e0e0e0; border: 1px solid #000060; padding: 1ex; margin: 2em 0em 4em 0em; }\n\n\t\t\tdiv.TOCTitle      { font-weight: bold; font-size: 14pt; color: #004080; border-bottom: 1px solid #000060; }\n\t\t\tdiv.TOC           { margin: 2ex 1ex 4em 2ex; }\n\t\t\tdiv.TOCSection    { margin-bottom: 2ex; }\n\n\t\t\tdiv.SectionTitle    { margin-top: 6ex; font-weight: bold; font-size: 14pt; color: #004080; border-bottom: 1px solid #000060; }\n\t\t\tdiv.SectionBody     { margin: 2ex 0ex 2ex 2ex; }\n\t\t\tdiv.SectionBody ul  { margin-top: 1ex; }\n\n\t\t\tdiv.SectionBody a:link    { color: #002080; }\n\t\t\tdiv.SectionBody a:visited { color: #002080; }\n\t\t\tdiv.SectionBody a:hover   { text-decoration: underline; }\n\n\t\t\tdiv.SubsectionTitle { margin-top: 4ex; margin-bottom: 2ex; font-weight: bold; font-size: 110%; color: #004080; }\n\t\t\tdiv.SubsectionBody  { margin: 2ex 0ex 2ex 2ex; }\n\n\t\t\tdiv.TriggerParameter { margin-left: 2ex; }\n\n\t\t\ttd.ParameterName { font-size: 10pt; background-color: #e0e0e0; vertical-align: top; }\n\t\t\ttd.ParameterDesc { font-size: 10pt; background-color: #e0e0e0; text-align: left; }\n\n\t\t\tli.FAQListItem { margin-bottom: 6ex; }\n\t\t</style>\n\t</head>\n\t<body>\n\t\t<h1>Mik's Scrolling Battle Text</h1>\n\t\t<div id=\"HeaderBlock\">\n\t\t\tVersion: 5.7.148<br />\n\t\t\tAuthor: Mikord<br />\n\t\t\tUpdated: February 5, 2018<br />\n\t\t\tOfficial Site: <a href=\"https://wow.curseforge.com/projects/mik-scrolling-battle-text\">https://wow.curseforge.com/projects/mik-scrolling-battle-text</a><br /><br />\n\t\t\t<a href=\"#Credits\">See Credits</a>\n\t\t</div>\n\n\t\t<div class=\"SectionTitle\"><a name=\"TOC\"></a>Table of Contents:</div>\n\t\t<div class=\"TOC\">\n\t\t\t<ul>\n\t\t\t\t<li><a href=\"#WhatsNew\">What's new?</a></li>\n\t\t\t\t<li><a href=\"#Install\">Installation Instructions</a></li>\n\t\t\t\t<li><a href=\"#Description\">Description</a></li>\n\t\t\t\t<li><a href=\"#Commands\">Commands</a></li>\n\t\t\t\t<li>\n\t\t\t\t\t<a href=\"#TriggerGuide\">Trigger Guide</a>\n\t\t\t\t\t<div class=\"TOCSection\">\n\t\t\t\t\t\t<ul>\n\t\t\t\t\t\t\t<li><a href=\"#TriggerBasicConcepts\">Basic Concepts</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#TriggerMechanics\">Trigger Mechanics</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#TriggerAdvancedConcepts\">Advanced Concepts</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#ExampleTriggers\">Example Triggers</a></li>\n\t\t\t\t\t\t</ul>\n\t\t\t\t\t</div>\n\t\t\t\t</li>\n\t\t\t\t<li>\n\t\t\t\t\t<a href=\"#TriggerReference\">Trigger Reference</a>\n\t\t\t\t\t<div class=\"TOCSection\">\n\t\t\t\t\t\t<ul>\n\t\t\t\t\t\t\t<li><a href=\"#MainEvents\">Trigger Main Events</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#MainEventConditions\">Main Event Conditions</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#TriggerExceptions\">Trigger Exceptions</a></li>\n\t\t\t\t\t\t</ul>\n\t\t\t\t\t</div>\n\t\t\t\t</li>\n\t\t\t\t<li><a href=\"#SearchPatternReference\">Search Pattern Reference</a></li>\n\t\t\t\t<li>\n\t\t\t\t\t<a href=\"#FAQ\">Frequently Asked Questions</a></li>\n\t\t\t\t\t<div class=\"TOCSection\">\n\t\t\t\t\t\t<ul>\n\t\t\t\t\t\t\t<li><a href=\"#FAQFonts\">I don't like any of the fonts supplied with MSBT. How do I use my own fonts?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQFontSize\">How do I increase the font size to something larger than 38?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQSounds\">How do I add my own custom sounds?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQNewTrigger\">How do I create a new trigger?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQMutilate\">Is it possible to prevent Mutilate from being merged?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQXP\">Is is possible to disable the default Blizzard XP Text?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQVE\">How do I suppress Vampiric Embrace?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQExclusiveIcons\">I want to see skill names even when there is an icon. Is that possible?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQGameDamage\">Is there a way to show the damage ab\n\n… (truncated)",
-    "release_downloads_repo": "HOYS/MikScrollingBattleText",
+    "release_downloads_repo": "roby-brok/MikScrollingBattleText",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-02T01:10:54Z",
     "forks": [
       {
         "label": "HOYS",
@@ -18700,8 +18704,8 @@
     "description": "A Questhelper and Database Addon for World of Warcraft: Vanilla & TBC",
     "release_downloads_repo": "shagu/pfQuest",
     "release_downloads_state": "ok",
-    "release_downloads": 226967,
-    "release_downloads_at": "2026-08-28T08:25:16Z"
+    "release_downloads": 227813,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "pfQuest-classicAPI",
@@ -18711,9 +18715,9 @@
     "folder": "pfQuest-classicAPI",
     "description": "> ### Attribution\n>\n> **This is a downstream fork. Almost none of the work here is mine.**\n>\n> | | |\n> |---|---|\n> | **[Shagu](https://github.com/shagu/pfQuest)** | created pfQuest, with **txtsd** maintaining. |\n> | **[brues-code / Railgun](https://github.com/brues-code/pfQuest)** | modernised it onto ClassicAPI — reading through the API instead of shipped tables (`C_QuestLog`, `C_Item`, `C_TaxiMap`, DBC-derived race/class bitmasks). **Also the author of [ClassicAPI](https://github.com/brues-code/ClassicAPI)** itself. |\n> | **[The Kludge Bureau](https://github.com/The-Kludge-Bureau/pfQuest)** | the build this fork's data lineage came from. |\n> | **[VMaNGOS](https://github.com/vmangos)** | the underlying quest database. |\n> | **Roby_Brok** | this repo: four local patches for OctoWoW on top of Railgun's tree. |\n>\n> Upstream is **https://github.com/brues-code/pfQuest** — go there for the real project.\n>\n> 📋 **[CHANGES-octo.md](CHANGES-octo.md) — full changelog of the changes on top of upstream.**\n> Local changes live on the `octo` branch. GPLv3, same as upstream; see `LICENSE`.\n\n# pfQuest\n\n<img src=\"https://raw.githubusercontent.com/The-Kludge-Bureau/pfQuest/main/_img/mode.png\" float=\"right\" align=\"right\" width=\"25%\">\n\npfQuest is a quest helper and database browser for World of Warcraft Vanilla (1.12), The Burning Crusade (2.4.3), and Wrath of the Lich King (3.3.5a). Accept a quest and the relevant NPCs, monsters, and objects are automatically pinned on your world map and minimap. Open the database browser to look up any unit, item, or game object in the game — or use the chat commands to build macros for tracking gathering nodes.\n\nThe goal is to provide an accurate in-game equivalent of [AoWoW](http://db.vanillagaming.org/) or [Wowhead](http://www.wowhead.com/), not a quest guide or turn-by-turn assistant. The Vanilla database is powered by [VMaNGOS](https://github.com/vmangos). The Burning Crusade version uses data from [CMaNGOS](https://github.com/cmangos) with translations from [MaNGOS Extras](https://github.com/MangosExtras).\n\npfQuest is the successor of [ShaguQuest](https://shagu.org/ShaguQuest/), written from scratch with no dependency on any specific map or questlog addon. It is designed to work alongside the default UI and any other addon. If you run into a conflict, please open an issue on the bugtracker.\n\nYou can check the [Latest Changes](https://github.com/The-Kludge-Bureau/pfQuest/commits/main) page to see what has changed recently.\n\n## What this fork changes, briefly\n\n*(as of 2026-08-10 — details and reasoning in [CHANGES-octo.md](CHANGES-octo.md))*\n\n- **The `[Translate]` button works** — it was inert on every install; a new *Quest Text\n  Translations* option (default on) keeps the quest locale data it reads, and turning it\n  off frees the memory and hides the button. Offered upstream as\n  [PR #2](https://github.com/brues-code/pfQuest/pull/2).\n- **Tracker defaults to Current Zone** instead of every active quest at once\n- **Configurable quest-database website** (defaults to OctoWoW's DB) and\n  **world map / minimap node scale** options\n- **Seven quests with missing objective data restored** (`corrections.lua`, each verified\n  by hand); **`/db checkdb`** lists quests in your log that draw no pins\n- `/db` shows a build identity instead of the raw packager placeholder\n- The changelog's claims are **audited against upstream** — the ones that turned out wrong\n  stay visible, struck through, rather than quietly deleted.\n\n## Before You Install\n\npfQuest ships a complete database of all spawns, objects, items, and quests. The full package is approximately 80 MB and is loaded into memory once at login — memory usage is stable after that and does not grow during play.\n\nOn Vanilla clients, WoW will show a warning if an addon exceeds the default memory limit. **Before installing, set Script Memory to `0` (no limit)** in the AddOns panel of the character selection screen. This is a one-time step. A [screenshot\n\n… (truncated)",
     "release_downloads_repo": "roby-brok/pfQuest-classicAPI",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-27T23:32:15Z"
+    "release_downloads_state": "ok",
+    "release_downloads": 10,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "AddOnOrganizer",
@@ -18732,7 +18736,11 @@
     "category": "General",
     "source": "community",
     "folder": "FlightMap",
-    "description": "# FlightMap\nDhask's FlightMap v1.12-1 with support for [LevelRange-Turtle](https://github.com/Tenyar97/LevelRange-Turtle).\n\nCommands:\n/flightmap /fmap\n\nSummary:\n- Show all flight line available from a zone when hovering over it in world map, as well as their cost.    \n- Shows flight duration with a progress bar.    \n- Shows flight master locations on the world map.\n\n## OctoWoW Fork\n\nFlightMap was created by **Dhask** — all credit for the addon goes to them, thank you!\n\nChanges in this version, fixed by **Roby_Brok**:\n- Flights on routes without a recorded duration (the server's new flight paths) now show a **live elapsed timer** counting up instead of a static label, while the real duration is recorded for the next flight\n- The take-off confirmation no longer advertises a flight time of **\"0s\"** on a route it has never flown. An unknown duration is stored as zero, which the dialog printed verbatim; it now says the duration is unknown until the first flight records one"
+    "description": "# FlightMap\nDhask's FlightMap v1.12-1 with support for [LevelRange-Turtle](https://github.com/Tenyar97/LevelRange-Turtle).\n\nCommands:\n/flightmap /fmap\n\nSummary:\n- Show all flight line available from a zone when hovering over it in world map, as well as their cost.    \n- Shows flight duration with a progress bar.    \n- Shows flight master locations on the world map.\n\n## OctoWoW Fork\n\nFlightMap was created by **Dhask** — all credit for the addon goes to them, thank you!\n\nChanges in this version, fixed by **Roby_Brok**:\n- Flights on routes without a recorded duration (the server's new flight paths) now show a **live elapsed timer** counting up instead of a static label, while the real duration is recorded for the next flight\n- The take-off confirmation no longer advertises a flight time of **\"0s\"** on a route it has never flown. An unknown duration is stored as zero, which the dialog printed verbatim; it now says the duration is unknown until the first flight records one",
+    "release_downloads_repo": "roby-brok/FlightMap",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "OWThreat",
@@ -18740,14 +18748,22 @@
     "category": "General",
     "source": "community",
     "folder": "OWThreat",
-    "description": "# OWThreat v1.4.0\n\nThreat meter for [OctoWoW](https://octowow.st) (WoW 1.12.1). Fork of\n[TWThreat](https://github.com/MarcelineVQ/TWThreat) by Xerron/Er, renamed and\nbug-fixed. Based on upstream v1.3.0.\n\nRequirements: in `party` or `raid`, attacking `elite` creatures or `bosses`.\n\n## Install\n\nClone into your `Interface\\AddOns` folder so it can be updated with `git pull`:\n\n```\ncd \"<your wow folder>\\Interface\\AddOns\"\ngit clone https://github.com/roby-brok/OWThreat.git\n```\n\nRemove `TWThreat` if you have it — see below.\n\n## Relationship to TWThreat\n\nOnly the *addon* is renamed. Every on-the-wire string is unchanged, so OWThreat\ntalks to the server's threat API and to other raiders running stock TWThreat\nexactly as before:\n\n| | value |\n|---|---|\n| addon message prefix | `TWT` |\n| threat api | `TWTv4=` |\n| tank mode api | `TMTv1=` |\n| threat query | `TWT_UDTSv4` / `TWT_UDTSv4_TM` |\n| roster messages | `TWTVersion:` `TWT_WHO` `TWT_ME:` `TWTRoleTexture:` |\n\nDo not run OWThreat and TWThreat at the same time — they would both answer the\nsame roster queries and both poll for threat.\n\nOne deliberate exception: OWThreat broadcasts `TWTVersion:1.3.0`, not its own\n`1.4.0`. A stock TWThreat client turns any higher version it hears into a \"new\nversion available\" notice pointing at *upstream*, so advertising 1.4.0 would\nsend every TWThreat user in your guild chasing a release that does not exist.\nThe fork version is still what you see locally and what the launcher reads.\n\n## Slash commands\n\n`/owt` and `/twt` are both accepted.\n\n- `/owt show` (also `/owtshow`, `/twtshow`)\n- `/owt hide`\n- `/owt toggle`\n- `/owt tankmode`\n- `/owt who` — list who in the raid has the addon\n- `/owt debug` (also `/owtdebug`)\n\n## Fixes in this fork\n\n**Correctness**\n\n- Your own bar no longer freezes at its last width when your threat reads 0%\n  (`animateTo` was passed an undefined global, which meant \"stop animating\").\n- The \"not listed by the server yet\" placeholder used `0` for `tank`/`melee`.\n  `0` is truthy in Lua, so it faked a tank at zero threat — which could zero the\n  *Pull Aggro at* bar — and rendered your own bar full-width. Now `false`.\n- That same placeholder took the localized class name from `UnitClass` instead\n  of the class token, which broke the class icon/colour lookup on non-enUS\n  clients. Uses the token now.\n- `OWT_CONFIG.tankmode` typo (should be `tankMode`) in the threat-query gate.\n- The first TPS sample for each player was discarded instead of recorded.\n- `version()` no longer throws on malformed input off the addon channel;\n  `queryWho`/`updateWithAddon`/`getClasses` no longer throw on a nil class from\n  an offline raid member.\n- Class colour/coord lookups fall back instead of indexing nil.\n- The talent scan in `combatStart` no longer assumes three populated spell tabs\n  (it can run before talents load on `PLAYER_ENTERING_WORLD`).\n- Tank mode shows for a single tanked mob, not just two or more.\n- Tank mode click-to-target rebuilt: the guid was being pushed through\n  `SetID`, which only accepts numbers, and looked up as `tostring(GetID())`.\n  Button rows now carry a real index and the guid lives in a side table, so the\n  settings preview works too. Guid→unit resolution accepts either a decimal or\n  hex encoding of the low id before falling back to `AssistByName`.\n- Window position survives a scale change. Previously only the drag handler\n  wrote a position, as a `CENTER` offset, while the scale handler re-anchored\n  via `TOPLEFT` and never saved — so the window jumped on next login.\n- Bar alpha no longer multiplies the combat/OOC alpha a second time.\n- `visibleBars` is clamped to the actual resize limits.\n- Window lock reads the config instead of comparing a texture path string.\n- `RAID_ROSTER_UPDATE` is handled, so classes and the raid/party channel stay\n  current when the raid changes.\n\n**Performance**\n\n- The `__explode` scratch tables were declared *below* every use site, so they\n  resolved as nil globals and a fresh table\n\n… (truncated)"
+    "description": "# OWThreat v1.4.0\n\nThreat meter for [OctoWoW](https://octowow.st) (WoW 1.12.1). Fork of\n[TWThreat](https://github.com/MarcelineVQ/TWThreat) by Xerron/Er, renamed and\nbug-fixed. Based on upstream v1.3.0.\n\nRequirements: in `party` or `raid`, attacking `elite` creatures or `bosses`.\n\n## Install\n\nClone into your `Interface\\AddOns` folder so it can be updated with `git pull`:\n\n```\ncd \"<your wow folder>\\Interface\\AddOns\"\ngit clone https://github.com/roby-brok/OWThreat.git\n```\n\nRemove `TWThreat` if you have it — see below.\n\n## Relationship to TWThreat\n\nOnly the *addon* is renamed. Every on-the-wire string is unchanged, so OWThreat\ntalks to the server's threat API and to other raiders running stock TWThreat\nexactly as before:\n\n| | value |\n|---|---|\n| addon message prefix | `TWT` |\n| threat api | `TWTv4=` |\n| tank mode api | `TMTv1=` |\n| threat query | `TWT_UDTSv4` / `TWT_UDTSv4_TM` |\n| roster messages | `TWTVersion:` `TWT_WHO` `TWT_ME:` `TWTRoleTexture:` |\n\nDo not run OWThreat and TWThreat at the same time — they would both answer the\nsame roster queries and both poll for threat.\n\nOne deliberate exception: OWThreat broadcasts `TWTVersion:1.3.0`, not its own\n`1.4.0`. A stock TWThreat client turns any higher version it hears into a \"new\nversion available\" notice pointing at *upstream*, so advertising 1.4.0 would\nsend every TWThreat user in your guild chasing a release that does not exist.\nThe fork version is still what you see locally and what the launcher reads.\n\n## Slash commands\n\n`/owt` and `/twt` are both accepted.\n\n- `/owt show` (also `/owtshow`, `/twtshow`)\n- `/owt hide`\n- `/owt toggle`\n- `/owt tankmode`\n- `/owt who` — list who in the raid has the addon\n- `/owt debug` (also `/owtdebug`)\n\n## Fixes in this fork\n\n**Correctness**\n\n- Your own bar no longer freezes at its last width when your threat reads 0%\n  (`animateTo` was passed an undefined global, which meant \"stop animating\").\n- The \"not listed by the server yet\" placeholder used `0` for `tank`/`melee`.\n  `0` is truthy in Lua, so it faked a tank at zero threat — which could zero the\n  *Pull Aggro at* bar — and rendered your own bar full-width. Now `false`.\n- That same placeholder took the localized class name from `UnitClass` instead\n  of the class token, which broke the class icon/colour lookup on non-enUS\n  clients. Uses the token now.\n- `OWT_CONFIG.tankmode` typo (should be `tankMode`) in the threat-query gate.\n- The first TPS sample for each player was discarded instead of recorded.\n- `version()` no longer throws on malformed input off the addon channel;\n  `queryWho`/`updateWithAddon`/`getClasses` no longer throw on a nil class from\n  an offline raid member.\n- Class colour/coord lookups fall back instead of indexing nil.\n- The talent scan in `combatStart` no longer assumes three populated spell tabs\n  (it can run before talents load on `PLAYER_ENTERING_WORLD`).\n- Tank mode shows for a single tanked mob, not just two or more.\n- Tank mode click-to-target rebuilt: the guid was being pushed through\n  `SetID`, which only accepts numbers, and looked up as `tostring(GetID())`.\n  Button rows now carry a real index and the guid lives in a side table, so the\n  settings preview works too. Guid→unit resolution accepts either a decimal or\n  hex encoding of the low id before falling back to `AssistByName`.\n- Window position survives a scale change. Previously only the drag handler\n  wrote a position, as a `CENTER` offset, while the scale handler re-anchored\n  via `TOPLEFT` and never saved — so the window jumped on next login.\n- Bar alpha no longer multiplies the combat/OOC alpha a second time.\n- `visibleBars` is clamped to the actual resize limits.\n- Window lock reads the config instead of comparing a texture path string.\n- `RAID_ROSTER_UPDATE` is handled, so classes and the raid/party channel stay\n  current when the raid changes.\n\n**Performance**\n\n- The `__explode` scratch tables were declared *below* every use site, so they\n  resolved as nil globals and a fresh table\n\n… (truncated)",
+    "release_downloads_repo": "roby-brok/OWThreat",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "FuBar",
     "repo": "https://github.com/laytya/FuBar",
     "category": "General",
     "source": "community",
-    "folder": "FuBar"
+    "folder": "FuBar",
+    "release_downloads_repo": "laytya/FuBar",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "_LazyPig",
@@ -18756,7 +18772,11 @@
     "source": "community",
     "folder": "_LazyPig",
     "description": "Updated for Turtle WoW Expansion mounts and Riding Turtle - autodismount\n\n\nThis mod is mostly for lazy people:\n\n\nPASSIVE ENHANCEMENTS:\nAUTO DISMOUNT \t\t\t\t- when casting spell or interacting with flightmaster(aq40 mounts included)\nAUTO ZG ROLL \t\t\t\t- on bijou, coins(avaliable 4 modes: off, pass, greed, need)\nLOOT WINDOW AUTO POSITION\t\t- under the cursor when looting\nGOSSIP AUTO PROCESSING\t\t\t- when talking to NPC(taxi, battlemaster, innkeeper, vendors)\nWORLD CHAT MUTE\t\t\t\t- mute /world channel in raid/dungeon/bg zone also filter repeated messages(30s default ban time)\nIMPROVED RIGHT CLICK\t\t\t- if trade/auction/mail window is active, right click on container item will drag and drop it into trade/auction_create/send_mail window\n\n\nACTIVE ENHANCEMENTS(require shift modifier key press):\nSHIFT SPLIT/MERGE\t\t\t- shift + right will split stacked items\nAUTO GREY SELL/REPAIR\t\t\t- press shift when merchant frame is open\nREPEATABLE QUESTS AUTOCOMPLETE \t\t- token quests like: AD(scourge stones,insignias), ZG(coins), BG(marks), Thorium Shells (v1.7changelog)\n\nMINOR ENHANCEMENTS:\nGROUP AUTO ACCEPT \t\t\t- 3 modes (GUILDMATES, GUILDMATES>FRIENDS, EVERYONE)\nSUMMON AUTO ACCEPT \t  \t\t- accept 2 seconds before confirm time expire\nINSTANCE RESURECTION ACCEPT OOC\t\t- instant accept OOC(ouf of combat)\nEXTENDED CAMERA DISTANCE\t\t- increase max camera distance up to 50y\n\n\nSPECIAL KEY COMBINATIONS\nalt+ctrl+shift\t\t\t\t- logout\n\nctrl+shift\t\t\t\t- follow\n\nalt+shift \t\t\t\t- inspect, click button: bid_auction\n\nalt+ctrl\t\t\t\t- initiate/accept trade with other player, \n\t\t\t\t\t  confirm popups: group_invite/bg_entry/release_spirit/recover_corpse/summon etc etc,\n\t\t\t\t\t  click button: send_mail/create_auction/buyout_auction/accept quest etc etc,\n\t\t\t\t\t  roll: on greenies other clolors are ignored, 3 modes (NEED,GREEN,PASS)\n\n\n\n\n\ntyping /lp    - customize addon functionality(most of the functions can be toggled)\n\nSome of the addon's functions may not work if you're using not en/us localized client also bongos and oskin may cause some small issues. \n\n\nAddons with similar functionality you don't need anymore\n- Auto Profit\n- Ez Dismount\n- Automaton\n- Quick Loot\n- Block Salation\n- MailTo -> If you gonna use it anyways be sure to disable _LazyPig features(Improved Right Click and Shift Split/Merge) to avoid override.\n\nNew in v1.7 \nAdded new feature record/replay for repeatable quests that allows you to complete them extremely fast.\nTo record just hold down the Shift key and complete the repeatable quest, after that talk to the NPC again and all\nthe previous actions will be auto replayed, remember not to release the Shift key.\nNew in v1.8\nAdded split feature\n- shift + right click will split stack\nNew in v1.9\nAdded auto roll option for zg rep items: bijous, coins \nNew in 2.3\n- added easy to use grey sell feature, just press shift key when merchant frame is open\n- thorium shells exchange quest now can be automated(v1.7 changelog)\n- added auto queue bg feature\nNew in 2.5\n- resolved problem with dismounting when more than 16 buffs is active(tooltip instead of texture scanning)\n- fixed all issues with the auto completing of repeatable quests (bg marks)\n- fixed bg auto leave feature (did not trigger sometimes)\nNew in 2.7\n- added new key combinations\n- improved right click on container items\n- added auto repair function(performed when merchant frame is visible and Shift key pressed)\n- improved quest/gossip auto processing\nNew in 2.8\n- improved Shift Split(see v1.8 changelog)\nNew in 2.83\n- removed /lps command replaced by easy to use intuitive split mechanism(to enable split feature you need to type /lp 6 - if disabled)\nNew in 2.88\n- added Alt+Ctrl green roll key combinations\nNew in 3.0\n- added \"Mute World\" chat functionality, available 3 modes (RAID>DUNGEON>BG, RAID>DUNGEON, RAID) after leaving specified zone /world chat will be unmuted, function disabled as default type /lp for details\nNew in 3.50\n- greatly improved split mechanism, check video\nNew in 4.00\n- added GUI to acces type /\n\n… (truncated)",
-    "turtle_custom": true
+    "turtle_custom": true,
+    "release_downloads_repo": "Otari98/_LazyPig",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "GetSpellInfoVanilla",
@@ -18764,7 +18784,11 @@
     "category": "General",
     "source": "community",
     "folder": "GetSpellInfoVanilla",
-    "description": "# GetSpellInfoVanilla\nAn addon to help developers access information about spells, for example to create buffs for addons\n\n\nThere are essentially 4 global methods you can call from other addons:\n\n> Name is always the spellname as returned by GetSpellInfo(id) in World of Warcraft 2.0+\n>\n> Icon is the client's path to the used icon e.g. \"\\\\Interface\\\\...\" as returbed by GetSpellInfo(id) in World of Warcraft 2.0+\n\n### function GetSpellInfoById(id) \n\nreturns [name, rank, icon, cost, isFunnel, powerType]\n\n### function GetSpellInfoByIcon(Icon) \n\nreturns a table of [name, rank, icon, cost, isFunnel, powerType] with the spellID as keys\n\n### function GetSpellInfoByName(Name) \n\nreturns a table of [name, rank, icon, cost, isFunnel, powerType] with the spellID as keys\n\n### function GetSpellInfoByIconAndName(Icon, Name)\n\nreturns a table of [name, rank, icon, cost, isFunnel, powerType] with the spellID as key"
+    "description": "# GetSpellInfoVanilla\nAn addon to help developers access information about spells, for example to create buffs for addons\n\n\nThere are essentially 4 global methods you can call from other addons:\n\n> Name is always the spellname as returned by GetSpellInfo(id) in World of Warcraft 2.0+\n>\n> Icon is the client's path to the used icon e.g. \"\\\\Interface\\\\...\" as returbed by GetSpellInfo(id) in World of Warcraft 2.0+\n\n### function GetSpellInfoById(id) \n\nreturns [name, rank, icon, cost, isFunnel, powerType]\n\n### function GetSpellInfoByIcon(Icon) \n\nreturns a table of [name, rank, icon, cost, isFunnel, powerType] with the spellID as keys\n\n### function GetSpellInfoByName(Name) \n\nreturns a table of [name, rank, icon, cost, isFunnel, powerType] with the spellID as keys\n\n### function GetSpellInfoByIconAndName(Icon, Name)\n\nreturns a table of [name, rank, icon, cost, isFunnel, powerType] with the spellID as key",
+    "release_downloads_repo": "Schaka/GetSpellInfoVanilla",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "SpecialTalentUI",
@@ -18772,7 +18796,11 @@
     "category": "General",
     "source": "community",
     "folder": "SpecialTalentUI",
-    "description": "# SpecialTalentUI\nA WoW 1.12 Vanilla+ addon that allows the in-game planning of talents, originaly made by Aquendyn.\n\n![image](https://user-images.githubusercontent.com/1638449/146279318-14c5b0d5-3352-486c-881d-99dfcabcb03e.png)\n\n![image](https://user-images.githubusercontent.com/1638449/146279454-10b8874a-c93f-4d4b-a8b8-51d227194f1a.png)\n\n![image](https://user-images.githubusercontent.com/1638449/146279561-3be71a39-4835-4fc7-a1e6-bc67dc3fc467.png)\n\n## Changes from the original version\n- Fixed an issue where the addon would not work with certain custom-made talents on private servers such as [Vanilla+](https://vanillaplus.org/)\n- Added the option to change between twenty plans you can name per character\n- Added a reset talent plan feature (the screenshots above are outdated)\n\n## Installation instructions\n1. Install the `SpecialTalent` dependency from [here](https://github.com/KrekoG/SpecialTalent/tree/main)\n2. Press the green \"code\" button -> Download ZIP\n3. Extract the `SpecialTalentUI-main.zip` file and rename the extracted folder to `SpecialTalentUI`, then move it to your client's `\\Interface\\AddOns\\` folder.\n4. Start/Restart your game"
+    "description": "# SpecialTalentUI\nA WoW 1.12 Vanilla+ addon that allows the in-game planning of talents, originaly made by Aquendyn.\n\n![image](https://user-images.githubusercontent.com/1638449/146279318-14c5b0d5-3352-486c-881d-99dfcabcb03e.png)\n\n![image](https://user-images.githubusercontent.com/1638449/146279454-10b8874a-c93f-4d4b-a8b8-51d227194f1a.png)\n\n![image](https://user-images.githubusercontent.com/1638449/146279561-3be71a39-4835-4fc7-a1e6-bc67dc3fc467.png)\n\n## Changes from the original version\n- Fixed an issue where the addon would not work with certain custom-made talents on private servers such as [Vanilla+](https://vanillaplus.org/)\n- Added the option to change between twenty plans you can name per character\n- Added a reset talent plan feature (the screenshots above are outdated)\n\n## Installation instructions\n1. Install the `SpecialTalent` dependency from [here](https://github.com/KrekoG/SpecialTalent/tree/main)\n2. Press the green \"code\" button -> Download ZIP\n3. Extract the `SpecialTalentUI-main.zip` file and rename the extracted folder to `SpecialTalentUI`, then move it to your client's `\\Interface\\AddOns\\` folder.\n4. Start/Restart your game",
+    "release_downloads_repo": "KrekoG/SpecialTalentUI",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "TomTom-TWOW",
@@ -18781,7 +18809,11 @@
     "source": "community",
     "folder": "TomTom-TWOW",
     "description": "# TomTom for Turtle-WoW\n\n*Cladhaire's TomTom AddOn backported for 1.12*\n\n## Updated:\n## 28/08/2025\n\n+ Updated to TWOW 1.18\n\n## 04.06.2025\n\n+ Fixed maps coordinates\n+ Added new TWOW's maps\n+ **Working in instances**\n+ TWOW 1.17.2 compatible.\n+ Added Waterfall gui for options (/tomtom to show, /ttcli for chat commands)\n\n\nContinuation of work from Alphaeast. https://forum.elysium-project.org/topic/29180-addon-tomtom/",
-    "turtle_custom": true
+    "turtle_custom": true,
+    "release_downloads_repo": "laytya/TomTom-TWOW",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "Auctionator (ClassicAPI)",
@@ -18789,7 +18821,11 @@
     "category": "General",
     "source": "community",
     "folder": "Auctionator",
-    "description": "1.12.1 backport. Requires ClassicAPI"
+    "description": "1.12.1 backport. Requires ClassicAPI",
+    "release_downloads_repo": "brues-code/Auctionator",
+    "release_downloads_state": "ok",
+    "release_downloads": 17,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   },
   {
     "name": "pfQuest-octo",
@@ -18798,6 +18834,10 @@
     "source": "community",
     "folder": "pfQuest-octo",
     "description": "# pfQuest (Octo DB)\n\nA [pfQuest](https://github.com/The-Kludge-Bureau/pfQuest) database pack for the\n[OctoWoW](https://octowow.st) server (WoW 1.12.1), maintained by **Roby_Brok**.\nPart of my [OctoWoW addon setup](https://github.com/roby-brok/octowow-addons).\n\n**None of the data here is mine.** This pack is two existing packs combined, nothing more —\nsee [Credits](#credits). It exists because running both of them at once does not work.\n\n---\n\n## Why this exists\n\npfQuest database packs assign their tables outright rather than merging into them:\n\n```lua\npfDB[\"quests\"][\"data-turtle\"] = { ... }\n```\n\nSo with `pfQuest-octo` and `pfQuest-turtle` both installed, the one whose folder sorts last\nsimply replaces the other. `pfQuest-turtle` wins on the letter *t*, and `pfQuest-octo` is parsed\nat every login and thrown away — roughly 15 MB of work for data that never gets used, and the\nquest links point at the wrong server's website.\n\nPicking one meant giving something up: the turtle pack has far more quest data, the octo pack has\nthe OctoWoW corrections and links. This pack is both, so there is nothing to choose between.\n\n## What is in it\n\nThe TurtleWoW database as the base, with the Octo pack folded in on top:\n\n| | octo pack alone | this pack |\n|---|---|---|\n| quests | 5,175 | **6,842** |\n| units | 9,928 | **11,095** |\n| objects | 15,163 | **15,857** |\n| items | 9,301 | **12,672** |\n| locales | 5 | **6** (deDE regained) |\n| corrections | 137 | **162** |\n\n`overwrites.lua` carries three things in order — the 23 records the Octo DB has that the\nTurtleWoW build lacks, then the Octo pack's 137 corrections, then the TurtleWoW pack's own 2.\nRecords come first so anything indexing into them finds them present. The generated files under\n`db/` are byte-identical to the TurtleWoW build; nothing there was hand-edited, so a future\ndatabase refresh will not silently drop any of it.\n\nQuest links point at [octowow.st/db](https://octowow.st/db).\n\nThe pack's own code changes and fixes are listed in **[CHANGES-octo.md](CHANGES-octo.md)**.\n\n## Install\n\n**Requires [pfQuest](https://github.com/The-Kludge-Bureau/pfQuest).** This is a database pack, not\na standalone addon.\n\n1. **[Download the latest release](https://github.com/roby-brok/pfQuest-octo/releases/latest)** —\n   take *Source code (zip)* at the bottom of the release page\n2. Unpack it and open the `pfQuest-octo-<version>` folder inside\n3. Copy **`pfQuest-octo`** into `Wow-Directory\\Interface\\AddOns`\n4. *Non-English clients only:* also copy the one folder matching your language —\n   `pfQuest-octo-deDE`, `-esES`, `-ptBR`, `-ruRU` or `-zhCN`\n5. Restart WoW\n\n**Copy the folders from inside the wrapper, not the wrapper itself.** The zip unpacks to a\nfolder carrying the version or branch on the end — `pfQuest-octo-1.1.0`, or\n`pfQuest-octo-master` if you grabbed it straight off the branch. Copying *that* into `AddOns`\nis the one thing that goes wrong: WoW skips a folder whose name does not match the `.toc`\ninside it, in silence, with no error and no entry in the addon list. The folders one level\ndown are already named correctly, so there is nothing to rename.\n\n**English clients need only `pfQuest-octo`.** The language folders are load-on-demand: the pack\npulls in the single one matching your client and never touches the others, so copying all of them\ncosts nothing but disk. Copying none of them is fine too — quest text simply stays English.\n\n**Remove `pfQuest-turtle` if you have it.** Its data is already included here, and leaving both\ninstalled puts you right back in the situation this pack was built to avoid.\n\n## Credits\n\nEverything here is other people's work, combined and nothing else. All of it is MIT licensed,\ncopyright Eric Mauser (Shagu), and that licence is retained in full.\n\n* **[Shagu](https://github.com/shagu)** — wrote pfQuest and the original database packs.\n* **[The Kludge Bureau](https://github.com/The-Kludge-Bureau/pfQuest-turtle)** — the TurtleWoW\n  build this pack's databa\n\n… (truncated)",
-    "turtle_custom": true
+    "turtle_custom": true,
+    "release_downloads_repo": "roby-brok/pfQuest-octo",
+    "release_downloads_state": "ok",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-02T01:10:54Z"
   }
 ]


### PR DESCRIPTION
## Summary
- Standing PR for unsigned `addon_tips.json` / stamped `addons.json`.
- Version bumps of existing addons are **held back** and listed on the standing **Catalog Update** issue — they are not live until that issue is approved and signed.
- **Do not merge JSON alone.** Sign locally (purpose `ichalaunch-catalog`) and commit the `.sig` files, then merge JSON+`.sig` together.
- Signing keys must not enter CI. Fail-closed clients ignore unsigned live catalogs.