### PR TITLE
Sign live catalog files.

### DIFF
--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -1440,5 +1440,19 @@
     "dependencies": [],
     "conflicts": [],
     "author": "IchaLaunch"
+  },
+  {
+    "id": "ichalaunch",
+    "kind": "launcher_update",
+    "hidden": true,
+    "name": "Raven Launcher",
+    "source": {
+      "type": "raw",
+      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.5.8/IchaLaunch.exe",
+      "filename": "IchaLaunch.exe",
+      "sha256": "8d5ef00e5d3bc9fb532c04f204071e784ee2d252403fb48f3075a6bf2c27ef42",
+      "version": "1.5.8",
+      "size": 277381061
+    }
   }
 ]

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "hoA+CnCooWXUAswTP7fSGZteDa/POO/m0M3vv/y/zesiKa4aQ9Xz//EIdd37NoBuY4dzRo7SRxLzCcyJtSKnDA==",
+  "sig": "zBAm77RZnDZDgVmVlYtbPTpIlhfV0F1m8CNbSvl912+f3bJVoK9VVyOdYKMnp/sKEpkNQRZxIVc+JHPQw5PLCA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "24fa910f2dab5b1c358c8ba676912184e16bd25e9c16daa3575fe66eb8cdfa56"
+    "sha256": "02578854a59dd2d707686e6b81539decab16b39441da4828bd0cd54e29f41b8e"
   },
-  "attestation_sig": "54hVuTf/GpM+k8g52h8AfixcY2H4HZyJMYKOex/mPdQxoBBM1272eEGzaY4/Aki8Jm61/9VpyoOlxtat7L5UCw=="
+  "attestation_sig": "LncZH9s1qlmhE0YYBR9mLrTrtMT+DQP67eQhvxB92nuXnt5zUQer2ehcSw7oukACZTHQhL4KpefLuRO9Zxq4Cw=="
 }


### PR DESCRIPTION
## Summary
- Add the hidden `ichalaunch` / `kind: launcher_update` pin for Raven Launcher 1.5.8
- Point `source.url` at the public GitHub Release EXE (not CDN, not Gitea)
- Re-sign `mods.json` with the local key so already-shipped clients can verify the catalog

## Test plan
- [x] Public Release v1.5.8 already has `IchaLaunch.exe` + `.sig`
- [ ] After merge, raw `mods.json` on public master contains the 1.5.8 pin and a valid sibling `.sig`