### PR TITLE
catalog: hourly tips/downloads (unsigned — sign before merge)

### DIFF
--- a/ichalaunch/data/addon_tips.json
+++ b/ichalaunch/data/addon_tips.json
@@ -15722,6 +15722,35 @@
         "master": "eb09c7ba336e299985dd053135769954269ad056"
       },
       "latest_tag": "v1.5.7"
+    },
+    "fiurs-hearth/battlemusic": {
+      "default_branch": "master",
+      "sha": "e92c913c3366dbfb7dc5cd97c67e36dd0d4440c7",
+      "branches": {
+        "master": "e92c913c3366dbfb7dc5cd97c67e36dd0d4440c7"
+      }
+    },
+    "brues-code/auctionator": {
+      "default_branch": "main",
+      "sha": "b321b95287f300167a85fad636b2bf0ff3380ee8",
+      "branches": {
+        "main": "b321b95287f300167a85fad636b2bf0ff3380ee8"
+      },
+      "latest_tag": "v1.0.5"
+    },
+    "elesionwow/bigwigs": {
+      "default_branch": "master",
+      "sha": "47b538024cf127346d624ba7b21a8aff56cb4587",
+      "branches": {
+        "master": "47b538024cf127346d624ba7b21a8aff56cb4587"
+      }
+    },
+    "pepopo978/bigwigs": {
+      "default_branch": "master",
+      "sha": "e53a09a4e86170a1a29178f8500e601bdd58e9ce",
+      "branches": {
+        "master": "e53a09a4e86170a1a29178f8500e601bdd58e9ce"
+      }
     }
   }
 }

--- a/ichalaunch/data/addons.json
+++ b/ichalaunch/data/addons.json
@@ -51,10 +51,10 @@
     "description": "All-in-one auto-categorizing and sorting inventory replacement for Bags and Bank with customizable layout and rules. Pinned to 1.5.16 (1.12 / Turtle); newer GitHub releases target 3.3.5 and are not auto-updated. https://github.com/NiclasEriksen/Bagshui Alt",
     "source": "turtle_wiki",
     "folder": "Bagshui",
-    "release_downloads_repo": "The-Kludge-Bureau/Bagshui",
-    "release_downloads_state": "ok",
-    "release_downloads": 235,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
+    "release_downloads_repo": "selfinterest/Bagshui",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-03T12:51:29Z",
     "recommended": true
   },
   {
@@ -714,10 +714,10 @@
         "repo": "https://github.com/Nelethor/BattleMusic"
       }
     ],
-    "release_downloads_repo": "zmarotrix/BattleMusic",
-    "release_downloads_state": "ok",
-    "release_downloads": 1400,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
+    "release_downloads_repo": "Fiurs-Hearth/BattleMusic",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-03T12:51:29Z",
     "recommended": true
   },
   {
@@ -1998,10 +1998,10 @@
         "repo": "https://github.com/nimeral/AuctionatorVanilla"
       }
     ],
-    "release_downloads_repo": "nimeral/AuctionatorVanilla",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_repo": "brues-code/Auctionator",
+    "release_downloads_state": "ok",
+    "release_downloads": 18,
+    "release_downloads_at": "2026-09-03T12:51:29Z",
     "recommended": true
   },
   {
@@ -2101,10 +2101,10 @@
         "repo": "https://github.com/tomek7667/aux-addon"
       }
     ],
-    "release_downloads_repo": "OldManAlpha/aux-addon",
+    "release_downloads_repo": "Otari98/aux-addon",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-03T12:51:29Z",
     "recommended": true
   },
   {
@@ -2250,8 +2250,8 @@
     ],
     "release_downloads_repo": "KeijinDE/KeijinAutoVendor",
     "release_downloads_state": "ok",
-    "release_downloads": 80,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 81,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "Mail",
@@ -2805,10 +2805,10 @@
         "repo": "https://github.com/paokkerkir/AttackBar_DragonflightUI"
       }
     ],
-    "release_downloads_repo": "Siventt/AttackBar-TWoW",
+    "release_downloads_repo": "deceius/AttackBar",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-03T12:51:29Z",
     "recommended": true
   },
   {
@@ -2828,10 +2828,10 @@
         "repo": "https://github.com/KameleonUK/AuldLangSyne"
       }
     ],
-    "release_downloads_repo": "Road-block/AuldLangSyne",
-    "release_downloads_state": "ok",
-    "release_downloads": 304,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_repo": "refaim/AuldLangSyne",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-03T12:51:29Z",
     "recommended": true
   },
   {
@@ -3041,8 +3041,8 @@
     "folder": "BetterAlign",
     "release_downloads_repo": "DennisWG/BetterAlign",
     "release_downloads_state": "ok",
-    "release_downloads": 678,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 679,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "BetterBabelFish",
@@ -3631,8 +3631,8 @@
     ],
     "release_downloads_repo": "ScottHamper/chatsuey",
     "release_downloads_state": "ok",
-    "release_downloads": 5091,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 5092,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "ChatTimestamps",
@@ -3697,8 +3697,8 @@
     "folder": "ClassicSnowFall",
     "release_downloads_repo": "Road-block/ClassicSnowFall",
     "release_downloads_state": "ok",
-    "release_downloads": 565,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 566,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "ClassPortraits",
@@ -4932,8 +4932,8 @@
     "folder": "wow-vanilla-gearmenu",
     "release_downloads_repo": "RagedUnicorn/wow-vanilla-gearmenu",
     "release_downloads_state": "ok",
-    "release_downloads": 2669,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 2670,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "GFW HuntersHelper",
@@ -6500,8 +6500,8 @@
     ],
     "release_downloads_repo": "rgd87/NugComboBar",
     "release_downloads_state": "ok",
-    "release_downloads": 108,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 110,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "NugEnergy",
@@ -6534,8 +6534,8 @@
     ],
     "release_downloads_repo": "rgd87/NugEnergy",
     "release_downloads_state": "ok",
-    "release_downloads": 47,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 49,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "oCB",
@@ -7280,8 +7280,8 @@
     ],
     "release_downloads_repo": "Steelbash/RestBar",
     "release_downloads_state": "ok",
-    "release_downloads": 467,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 469,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "Rested",
@@ -7419,8 +7419,8 @@
     ],
     "release_downloads_repo": "jsb/RingMenu",
     "release_downloads_state": "ok",
-    "release_downloads": 836,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 838,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "ROAR-Guild",
@@ -8079,8 +8079,8 @@
     "folder": "ShaguTweaks-DruidManaBar",
     "release_downloads_repo": "gashole/ShaguTweaks-DruidManaBar",
     "release_downloads_state": "ok",
-    "release_downloads": 701,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 703,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "ShaguTweaks Mods",
@@ -8463,8 +8463,8 @@
     ],
     "release_downloads_repo": "EinBaum/SP_Overpower",
     "release_downloads_state": "ok",
-    "release_downloads": 1525,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 1526,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "SP_Revenge",
@@ -9809,8 +9809,8 @@
     ],
     "release_downloads_repo": "laytya/WowLuaVanilla",
     "release_downloads_state": "ok",
-    "release_downloads": 110,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 112,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "WowRadio",
@@ -10518,8 +10518,8 @@
     ],
     "release_downloads_repo": "laytya/MinimapButtonFrame-vanilla",
     "release_downloads_state": "ok",
-    "release_downloads": 2349,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 2353,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "PingoMatic",
@@ -11597,10 +11597,10 @@
         "repo": "https://github.com/laytya/AutoBar-for-Turtle-WoW"
       }
     ],
-    "release_downloads_repo": "laytya/AutoBar-for-Turtle-WoW",
+    "release_downloads_repo": "Bestoriop/AutoBar",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-03T12:51:29Z",
     "recommended": true
   },
   {
@@ -11654,8 +11654,8 @@
     "folder": "AutoQuest",
     "release_downloads_repo": "MickeyPickey/AutoQuest",
     "release_downloads_state": "ok",
-    "release_downloads": 291,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 292,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "AutoTurnIn",
@@ -11832,8 +11832,8 @@
     ],
     "release_downloads_repo": "JeromeM/GuidelimeVanilla",
     "release_downloads_state": "ok",
-    "release_downloads": 272,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 274,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "HardcoreAlarms",
@@ -11909,8 +11909,8 @@
     ],
     "release_downloads_repo": "Cliencer/pfExtend",
     "release_downloads_state": "ok",
-    "release_downloads": 9,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 13,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "pfQuest",
@@ -11967,8 +11967,8 @@
     ],
     "release_downloads_repo": "The-Kludge-Bureau/pfQuest",
     "release_downloads_state": "ok",
-    "release_downloads": 6986,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 7033,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "pfQuest-icons",
@@ -12426,10 +12426,10 @@
         "repo": "https://github.com/BahamutxD/AutoMasterLooter"
       }
     ],
-    "release_downloads_repo": "balakethelock/AutoMasterLooter",
+    "release_downloads_repo": "Otari98/AutoMasterLooter",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-03T12:51:29Z",
     "recommended": true
   },
   {
@@ -12453,10 +12453,10 @@
         "repo": "https://github.com/balakethelock/bananabar"
       }
     ],
-    "release_downloads_repo": "balakethelock/bananabar",
+    "release_downloads_repo": "Otari98/bananabar",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-03T12:51:29Z",
     "recommended": true
   },
   {
@@ -12486,7 +12486,11 @@
         "repo": "https://github.com/pepopo978/BigWigs"
       }
     ],
-    "recommended": true
+    "recommended": true,
+    "release_downloads_repo": "ElesionWoW/BigWigs",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "BMLoot",
@@ -13580,8 +13584,8 @@
     ],
     "release_downloads_repo": "obszczymucha/roll-for-vanilla",
     "release_downloads_state": "ok",
-    "release_downloads": 3754,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 3757,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "RoundRobinhood",
@@ -13799,8 +13803,8 @@
     ],
     "release_downloads_repo": "Sentilix/sota",
     "release_downloads_state": "ok",
-    "release_downloads": 45,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 46,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "SoundBoard",
@@ -14112,8 +14116,8 @@
     "folder": "XLoot_AddOns",
     "release_downloads_repo": "Road-block/XLoot_AddOns",
     "release_downloads_state": "ok",
-    "release_downloads": 1576,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 1577,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "XtraUnitFrame",
@@ -14729,8 +14733,8 @@
     "folder": "oCB",
     "release_downloads_repo": "Shellyoung/oCB-SuperWoW",
     "release_downloads_state": "ok",
-    "release_downloads": 138,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 139,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "Overhead",
@@ -14855,8 +14859,8 @@
     ],
     "release_downloads_repo": "OldManAlpha/Puppeteer",
     "release_downloads_state": "ok",
-    "release_downloads": 270,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 279,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "Quartz",
@@ -15648,8 +15652,8 @@
     ],
     "release_downloads_repo": "brues-code/SuperCleveRoidMacros",
     "release_downloads_state": "ok",
-    "release_downloads": 60,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
+    "release_downloads": 73,
+    "release_downloads_at": "2026-09-03T12:51:29Z",
     "recommended": true
   },
   {
@@ -16269,8 +16273,8 @@
     ],
     "release_downloads_repo": "i2ichardt/HealersMate",
     "release_downloads_state": "ok",
-    "release_downloads": 26,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 29,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "HideNamePlates",
@@ -16353,8 +16357,8 @@
     ],
     "release_downloads_repo": "Warlockbugs/impulse-booster",
     "release_downloads_state": "ok",
-    "release_downloads": 5269,
-    "release_downloads_at": "2026-08-27T13:39:38Z"
+    "release_downloads": 5270,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "JIM toolbox",
@@ -17316,8 +17320,8 @@
     "description": "# For TurtleWoW launcher\nClick Addons - Add new addon - paste this url there: https://github.com/vaniron/TourGuide-Turtle.git\n\n# Contact & Donations\nYou can add me on discord: **vanironcz**\n\nIf you wanna support this fork, you can do so via https://www.paypal.com/donate/?hosted_button_id=FSQQQGRSBDA58\n\n# TourGuide-Turtle\nTekkub's TourGuide Addon backported for WoW 1.12 *with tweaks for TurtleWoW*\n\nRecommended Downloads: \n\n[**TomTom-TWOW**](https://github.com/laytya/TomTom-TWOW)\n* **Arrow to navigate you to next guide point**\n* you have to disable arrow from pfQuest as its showing closest quest, not optimal path - TomTom is integrated directly to TourGuide and shoudl be used instead\n\n[**pfQuest**](https://github.com/shagu/pfQuest) + [**pfQuest-turtle**](https://github.com/shagu/pfQuest-turtle)\n* pfQuest adds many features like tracking, map icons etc.\n\n[**pfUI**](https://github.com/shagu/pfUI)\n* pfUI provides so much more, overall UI overhaul but all features can be tweaked and disabled if you dont like them\n\nOptional addon: [TourGuide_Professions](https://github.com/Lorwik/TourGuide_Professions)\n\n\n**Features**\n* Automatic detection of objective completion\n  * Detect quest accept, completion and turnin\n  * Detect travel (by foot, flight, boat and stone)\n  * Detection of flight point discovery\n  * Detection of Hearth point change\n* Conditionals based on player’s class and item possession (only tell the player to accept the quest if they have the item that starts the quest)\n* Small “lego block” style frame shows current objective, detailed tooltips on hover\n* “Use item” frame, for those annoying quests where you have to use an item on a mob before you kill it, or you have to equip something, or you have to use an item to start a quest\n* Pop out frame for detailed view of quest sequence\n* Automatic mapping of coordinates with TomTom and questgiver locations from pfQuest if installed\n\nGuides list, plus few others didnt make it into the screenshot (Plaguelands, Silithus, Winterspring), too many for one screen xD\n![image](https://github.com/user-attachments/assets/7d655a07-d8b9-48ad-b514-b95fcefb81a8)\n\n\n**Contributors**\n* Tekkub\n* Cralor\n* Road-block\n* Rsheep\n* Azgaardian\n* Kyliexx\n* laytya\n* jb6357\n* Ez-mode\n* Gescht\n* Vaniron\n* Trus3683\n* Ravenhost",
     "release_downloads_repo": "vaniron/TourGuide-Turtle",
     "release_downloads_state": "ok",
-    "release_downloads": 232,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 238,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "TourGuideVanilla",
@@ -17453,8 +17457,8 @@
     "description": "# pfUI - OctoWoW Edition\n\n> ### About this fork\n>\n> **This fork is maintained for [OctoWoW](https://octowow.st).** Everything here was found and\n> fixed while running on that server; the fixes are not OctoWoW-specific and should apply to any\n> 1.12 client, but OctoWoW is the only place it has actually been tested.\n>\n> pfUI is the work of **[Shagu](https://github.com/shagu/pfUI)** (Eric Mauser), released under the\n> MIT licence, and this branch descends from **me0wg4ming's** Turtle WoW edition — which is why\n> parts of the documentation below still refer to Turtle WoW. All the credit belongs to them; this\n> fork only adds the fixes listed here, on top of their work.\n>\n> Note that the upstream repository this was cloned from\n> (`github.com/me0wg4ming/pfUI`) is no longer reachable, which is part of why this copy exists.\n> The full original commit history is preserved here.\n>\n> Fork maintained by **Roby_Brok**. Version bumped to **9.0.8** to distinguish it.\n>\n> ---\n>\n> #### UI scale / resolution\n>\n> - **`GetPerfectPixel` guards an unparseable `gxResolution`** (previously `768 / nil`, which killed\n>   every border on the UI).\n>\n>   ~~It also measured against `UIParent:GetEffectiveScale()` rather than the `uiScale` cvar.~~\n>   **Reverted 2026-08-10 — that was wrong.** The cvar's 1.0 cap looks like a bug but is\n>   load-bearing: the \"Huge\"/\"Large\" presets push `UIParent` to 1.42 / 1.14 via `SetScale`, and\n>   measuring that true scale makes `768 / screenheight / scale` fall below half a pixel, so border\n>   `edgeSize` rounds to zero and the borders vanish. Caught by\n>   [brues-code](https://github.com/brues-code) after the same change was merged and then reverted\n>   upstream.\n> - **`pixelperfect` loaded 55th, but sets the scale everything else is measured against.** That\n>   value is cached on first use, so every module loaded before it baked in the *previous* scale —\n>   the classic \"reload twice before it looks right\". It now loads first.\n> - The module only re-applies the scale when it actually changes, and drops the cached pixel and\n>   border sizes when it does.\n> - \"Enable UI-Scale\" now asks for a reload instead of applying live, since existing frames keep\n>   border sizes computed for the old scale.\n>\n> #### Features that silently did nothing\n>\n> pfUI runs each module inside a sandboxed environment that has `__index` but no `__newindex`, so\n> a bare global assignment inside a module never reaches `_G`. These all looked registered and\n> were not:\n>\n> | Where | What was dead |\n> |---|---|\n> | `modules/nampower.lua` | `/disenchantall`, `/dea` |\n> | `modules/superwow.lua` | `/clickthrough`, `/ct` |\n> | `modules/unitxp.lua` | `/pfunitxp`, and the battleground-pop notification |\n> | `modules/hdgraphic.lua` | `OptionsFrame_OnShow` — the extended world-detail slider never installed |\n> | `modules/raid.lua` | `GROUP_REPLACE_PARTY` |\n>\n> #### Other\n>\n> - `modules/loot.lua` — restored `local autoLoot = arg1`; `CloseLoot(not autoLoot)` was reading a\n>   nil global and always suppressing the server-side close notification.\n> - `api/ui-widgets.lua` — removed a dead fourth value in `SetHighlight`'s colour assignment.\n> - `init/skins.xml` — removed a duplicated block that loaded five Turtle WoW skins twice.\n> - Plus an earlier batch of fixes across the stutter-prone hot paths (nameplate debuff scanning,\n>   unit-frame aggro checks, throttle allocations, cooldown updates), a number of silently broken\n>   features, and a class-colour accent option.\n> - `modules/thirdparty-vanilla.lua` — [OWThreat](https://github.com/roby-brok/OWThreat) now docks\n>   into the right chat panel and takes the pfUI skin, exactly like the TWThreat it was forked\n>   from; both are driven by the same *TW/OW Threatmeter* checkboxes under *Thirdparty*.\n>\n> ---\n\n[![Version](https://img.shields.io/badge/version-9.0.8-blue.svg)](https://github.com/roby-brok/pfUI)\n[![OctoWoW](https://img.shields.io/badge/OctoWoW-supported-brightgreen.svg)](https://octowo\n\n… (truncated)",
     "release_downloads_repo": "roby-brok/pfUI",
     "release_downloads_state": "ok",
-    "release_downloads": 8,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 14,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "pfUI",
@@ -17465,8 +17469,8 @@
     "description": "# pfUI - ClassicAPI Edition\n\n[![Octo WoW](https://img.shields.io/badge/Octo%20WoW-1.18.1-brightgreen.svg)](https://octowow.st/)\n[![ClassicAPI](https://img.shields.io/badge/ClassicAPI-Required-purple.svg)](https://github.com/brues-code/ClassicAPI)\n[![Nampower](https://img.shields.io/badge/Nampower-Required-purple.svg)](https://github.com/brues-code/nampower)\n[![SuperWoW](https://img.shields.io/badge/SuperWoW-Optional-yellow.svg)](https://github.com/balakethelock/SuperWoW)\n[![UnitXP](https://img.shields.io/badge/UnitXP__SP3-Optional-yellow.svg)](https://github.com/brues-code/UnitXP_SP3)\n\n**A pfUI fork specifically optimized for ClassicAPI on [Octo WoW](https://octowow.st/)**\n\nThis version includes significant performance improvements and DLL-enhanced features.\n\n## Installation\n1. Download **[Latest Version](https://github.com/brues-code/pfUI/releases/latest)**\n2. Unpack the Zip file\n4. Copy \"pfUI\" into Wow-Directory\\Interface\\AddOns\n5. Restart Wow\n\n## DLL Enhancements\n\nSince pfUI 6.0.0 includes integrations with client-side DLLs for enhanced functionality. These DLLs are permitted on Octo WoW:\n\n### [ClassicAPI](https://github.com/brues-code/ClassicAPI)\n\nProvides:\n- C_NamePlate - Event-driven nameplates (no more per-frame WorldFrame scanning) with real per-plate unit tokens and GUIDs\n- C_UnitAuras - Replaces over 3k lines of hand-rolled aura tracking\n- C_Spell - Replaces thousands of hardcoded spell names for each locale and powers castbar\n- Real cast bars - Actual cast/channel timing, spellID and interrupt state for any unit (C_Spell.UnitCastingInfo)\n- Focus - A genuine `focus` unit plus `/focus` and `/clearfocus` (FocusUnit / ClearFocus)\n- C_EquipmentSet - Full Equipment Manager with GUID-tracked gear sets (tells apart duplicate/enchanted items)\n- Instant Bag Sorting - C_Container.MoveItem / SwapItems instead of cursor pickup/drop\n- Sell junk in one call - C_MerchantFrame.GetNumJunkItems / SellAllJunkItems\n- Real item data - C_Item counts, quality, sell price and item info by ID\n- GUID-based targeting - Nameplates, mouseover and focus resolve by GUID, not by name text\n- Faster, safer profile sharing - Engine-side serialize/compress/base64 via C_EncodingUtil\n- C_Timer - After / NewTicker replacing hand-rolled OnUpdate throttles\n- Feign death, shapeshift and quest-item detection via real API calls\n- Mouseover Unit Frames\n- Click-casting\n- Loot Roll History (/loothistory)\n- New item highlighting\n- Plenty other functions\n\n### [Nampower](https://github.com/brues-code/nampower)\n\nProvides:\n- Spell queue indicator\n- GCD indicator\n\n### [SuperWoW](https://github.com/balakethelock/SuperWoW)\n\nProvides:\n- Tracks party/raid units on the minimap\n\n### [UnitXP_SP3](https://github.com/brues-code/UnitXP_SP3)\n\nProvides:\n- Line of Sight detection\n- Behind detection\n- Accurate distance calculations\n- OS notifications\n\nUse `/pfdll` in-game to check which DLLs are detected.\n\n## Commands\n\n    /pfui         Open the configuration GUI\n    /pfdll        Show DLL detection status (SuperWoW, Nampower, UnitXP)\n    /pfbehind     Test Behind/LOS detection on current target\n    /clickthrough Toggle clickthrough mode (or /ct)\n    /share        Open the configuration import/export dialog\n    /gm           Open the ticket Dialog\n    /rl           Reload the whole UI\n    /farm         Toggles the Farm-Mode\n    /pfcast       Same as /cast but for mouseover units\n    /focus        Creates a Focus-Frame for the current target\n    /castfocus    Same as /cast but for focus frame\n    /clearfocus   Clears the Focus-Frame\n    /swapfocus    Toggle Focus and Target-Frame\n    /pftest       Toggle pfUI Unitframe Test Mode\n    /abp          Addon Button Panel\n    /loothistory  Show Loot Roll History\n\n## Languages\npfUI supports and contains language specific code for the following gameclients.\n* English (enUS)\n* Korean (koKR)\n* French (frFR)\n* German (deDE)\n* Chinese (zhCN)\n* Spanish (esES)\n* Russian (ruRU)\n\n## Recommended Addons\n* [pfQuest](https://github.co\n\n… (truncated)",
     "release_downloads_repo": "brues-code/pfUI",
     "release_downloads_state": "ok",
-    "release_downloads": 44,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 29,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "NiceDamage-1.12",
@@ -17477,8 +17481,8 @@
     "description": "# NiceDamage for WoW Vanilla 1.12\n\n> ## 📥 Latest Release\n>\n> **Download the latest version here:**\n>\n> https://github.com/Wurmschwanz/NiceDamage-1.12/releases/latest\n\nA lightweight enhancement of the original **NiceDamage** addon for **World of Warcraft Vanilla 1.12**.\n\nNiceDamage replaces the default floating combat text font and introduces a lightweight minimap-based font selector with themed style categories while staying true to the original philosophy: **simple, lightweight and fast.**\n\n---\n\n# ✨ Features\n\n- Lightweight combat text font replacement\n- Minimap button for quick access\n- Hierarchical font selection menu\n- Style-based font organization\n- Automatic font saving\n- Lightweight implementation\n- No measurable FPS or CPU impact\n- Compatible with WoW Vanilla 1.12\n- Compatible with pfUI\n\n---\n\n# 🎨 Available Style Categories\n\n## Blizzard\n\n- Warcraft III Style\n- Diablo Style\n- StarCraft Style\n\n## FPS\n\n- Doom Style\n- Quake Style\n- Unreal Style\n- Half-Life Style\n\n## Sci-Fi\n\n- Halo Style\n- Alien Style\n\n---\n\n# 📦 Installation\n\n1. Remove any previous `NiceDamage` and `NiceDamage_Font_*` folders from:\n\n```text\nInterface/AddOns/\n```\n\n2. Extract the archive into:\n\n```text\nInterface/AddOns/\n```\n\n3. Start World of Warcraft.\n\n4. Left-click the minimap button to open the font menu.\n\n5. Select your preferred combat text style.\n\n> **Note**\n>\n> Some WoW Vanilla 1.12 clients cache combat fonts during startup.\n>\n> After changing the selected combat font, a **full game restart** is required.\n>\n> Using `/reload` is **not** sufficient on affected clients.\n\n---\n\n# ⚡ Performance\n\nNiceDamage was designed to remain lightweight.\n\n- No permanent `OnUpdate` loops\n- No continuous background processing\n- No measurable FPS impact\n- Font changes are only processed when requested by the player\n\n---\n\n# ✅ Compatibility\n\n- WoW Vanilla 1.12\n- pfUI compatible\n- Compatible with most Vanilla private servers using the original 1.12 client\n\n---\n\n# 🚀 Roadmap\n\nThe following style categories are planned for future updates.\n\n### Retro\n\n- Arcade\n- Terminal\n- Pixel\n\n### Fantasy\n\n- Medieval\n- Ancient\n\nMore style categories and additional combat font styles will be added over time.\n\n---\n\n# ❤️ Credits\n\nOriginal **NiceDamage** addon by its original author(s).\n\nEnhanced for **WoW Vanilla 1.12** by **Wurmschwanz**.\n\nSpecial thanks to everyone who helped testing fonts and improving compatibility.",
     "release_downloads_repo": "Wurmschwanz/NiceDamage-1.12",
     "release_downloads_state": "ok",
-    "release_downloads": 110,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 117,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "Chronometer-Turtle",
@@ -17786,8 +17790,8 @@
     "description": "A Questhelper and Database Addon for World of Warcraft: Vanilla & TBC",
     "release_downloads_repo": "shagu/pfQuest",
     "release_downloads_state": "ok",
-    "release_downloads": 227828,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 228023,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "pfQuest-classicAPI",
@@ -17798,8 +17802,8 @@
     "description": "> ### Attribution\n>\n> **This is a downstream fork. Almost none of the work here is mine.**\n>\n> | | |\n> |---|---|\n> | **[Shagu](https://github.com/shagu/pfQuest)** | created pfQuest, with **txtsd** maintaining. |\n> | **[brues-code / Railgun](https://github.com/brues-code/pfQuest)** | modernised it onto ClassicAPI — reading through the API instead of shipped tables (`C_QuestLog`, `C_Item`, `C_TaxiMap`, DBC-derived race/class bitmasks). **Also the author of [ClassicAPI](https://github.com/brues-code/ClassicAPI)** itself. |\n> | **[The Kludge Bureau](https://github.com/The-Kludge-Bureau/pfQuest)** | the build this fork's data lineage came from. |\n> | **[VMaNGOS](https://github.com/vmangos)** | the underlying quest database. |\n> | **Roby_Brok** | this repo: four local patches for OctoWoW on top of Railgun's tree. |\n>\n> Upstream is **https://github.com/brues-code/pfQuest** — go there for the real project.\n>\n> 📋 **[CHANGES-octo.md](CHANGES-octo.md) — full changelog of the changes on top of upstream.**\n> Local changes live on the `octo` branch. GPLv3, same as upstream; see `LICENSE`.\n\n# pfQuest\n\n<img src=\"https://raw.githubusercontent.com/The-Kludge-Bureau/pfQuest/main/_img/mode.png\" float=\"right\" align=\"right\" width=\"25%\">\n\npfQuest is a quest helper and database browser for World of Warcraft Vanilla (1.12), The Burning Crusade (2.4.3), and Wrath of the Lich King (3.3.5a). Accept a quest and the relevant NPCs, monsters, and objects are automatically pinned on your world map and minimap. Open the database browser to look up any unit, item, or game object in the game — or use the chat commands to build macros for tracking gathering nodes.\n\nThe goal is to provide an accurate in-game equivalent of [AoWoW](http://db.vanillagaming.org/) or [Wowhead](http://www.wowhead.com/), not a quest guide or turn-by-turn assistant. The Vanilla database is powered by [VMaNGOS](https://github.com/vmangos). The Burning Crusade version uses data from [CMaNGOS](https://github.com/cmangos) with translations from [MaNGOS Extras](https://github.com/MangosExtras).\n\npfQuest is the successor of [ShaguQuest](https://shagu.org/ShaguQuest/), written from scratch with no dependency on any specific map or questlog addon. It is designed to work alongside the default UI and any other addon. If you run into a conflict, please open an issue on the bugtracker.\n\nYou can check the [Latest Changes](https://github.com/The-Kludge-Bureau/pfQuest/commits/main) page to see what has changed recently.\n\n## What this fork changes, briefly\n\n*(as of 2026-08-10 — details and reasoning in [CHANGES-octo.md](CHANGES-octo.md))*\n\n- **The `[Translate]` button works** — it was inert on every install; a new *Quest Text\n  Translations* option (default on) keeps the quest locale data it reads, and turning it\n  off frees the memory and hides the button. Offered upstream as\n  [PR #2](https://github.com/brues-code/pfQuest/pull/2).\n- **Tracker defaults to Current Zone** instead of every active quest at once\n- **Configurable quest-database website** (defaults to OctoWoW's DB) and\n  **world map / minimap node scale** options\n- **Seven quests with missing objective data restored** (`corrections.lua`, each verified\n  by hand); **`/db checkdb`** lists quests in your log that draw no pins\n- `/db` shows a build identity instead of the raw packager placeholder\n- The changelog's claims are **audited against upstream** — the ones that turned out wrong\n  stay visible, struck through, rather than quietly deleted.\n\n## Before You Install\n\npfQuest ships a complete database of all spawns, objects, items, and quests. The full package is approximately 80 MB and is loaded into memory once at login — memory usage is stable after that and does not grow during play.\n\nOn Vanilla clients, WoW will show a warning if an addon exceeds the default memory limit. **Before installing, set Script Memory to `0` (no limit)** in the AddOns panel of the character selection screen. This is a one-time step. A [screenshot\n\n… (truncated)",
     "release_downloads_repo": "roby-brok/pfQuest-classicAPI",
     "release_downloads_state": "ok",
-    "release_downloads": 11,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 25,
+    "release_downloads_at": "2026-09-03T12:51:29Z"
   },
   {
     "name": "AddOnOrganizer",


### PR DESCRIPTION
## Summary
- Standing PR for unsigned `addon_tips.json` / stamped `addons.json`.
- Version bumps of existing addons are **held back** and listed on the standing **Catalog Update** issue — they are not live until that issue is approved and signed.
- **Do not merge JSON alone.** Sign locally (purpose `ichalaunch-catalog`) and commit the `.sig` files, then merge JSON+`.sig` together.
- Signing keys must not enter CI. Fail-closed clients ignore unsigned live catalogs.