### PR TITLE
Sign live catalog files.

### DIFF
--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -1448,11 +1448,11 @@
     "name": "Raven Launcher",
     "source": {
       "type": "raw",
-      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.5.8/IchaLaunch.exe",
+      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.5.9/IchaLaunch.exe",
       "filename": "IchaLaunch.exe",
-      "sha256": "8d5ef00e5d3bc9fb532c04f204071e784ee2d252403fb48f3075a6bf2c27ef42",
-      "version": "1.5.8",
-      "size": 277381061
+      "sha256": "dc2d770a0a8798da1336e46a3236b381afc4ddf86b672faca06b1503710d276e",
+      "version": "1.5.9",
+      "size": 277383531
     }
   }
 ]

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "zBAm77RZnDZDgVmVlYtbPTpIlhfV0F1m8CNbSvl912+f3bJVoK9VVyOdYKMnp/sKEpkNQRZxIVc+JHPQw5PLCA==",
+  "sig": "LYdvhvqJnk86KUN6/Ai2EpiPif3hz6GjWh+kAYT1HNHCUUBcPC3RzSl679/ZuyusNFVmUVNQxMe/x4kpYAq6Ag==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "02578854a59dd2d707686e6b81539decab16b39441da4828bd0cd54e29f41b8e"
+    "sha256": "7f65d81922f7b6f04a1297cc1431b655ab94a797071ce45c9e44e3db856a0d55"
   },
-  "attestation_sig": "LncZH9s1qlmhE0YYBR9mLrTrtMT+DQP67eQhvxB92nuXnt5zUQer2ehcSw7oukACZTHQhL4KpefLuRO9Zxq4Cw=="
+  "attestation_sig": "yxb6XFjOXuCpbLg5Geq5ZMFx+0NXDx8t7AbZtf9YL2e/i61pCuU6qXPNryJsWhfqAxCIVgUyj9hqmAt6n9x7BQ=="
 }


### PR DESCRIPTION
## Summary
- Update the hidden `ichalaunch` launcher pin to Raven Launcher 1.5.9
- Point `source.url` at the public GitHub Release EXE
- Re-sign `mods.json` so already-shipped clients can verify the catalog

## Test plan
- [x] Public Release v1.5.9 has `IchaLaunch.exe` + `.sig`
- [ ] After merge, raw `mods.json` on public master pins 1.5.9 with a valid sibling `.sig`