### PR TITLE
catalog: signed news/home_art pairing and crop tweaks

### DIFF
--- a/ichalaunch/data/home_art.json
+++ b/ichalaunch/data/home_art.json
@@ -8,22 +8,16 @@
       "frame_url": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/ui/theme/zaeya_first_60_frame.png",
       "hold": 2.0,
       "fit": "width",
-      "nudge_x": 12,
-      "nudge_y": -5,
-      "shrink_w": 30,
+      "nudge_x": 0,
+      "nudge_y": 0,
+      "shrink_w": 0,
       "object_position": "100% 50%",
-      "crop": {
-        "x": 0.0,
-        "y": 0.0,
-        "w": 0.9,
-        "h": 1.0
-      },
-      "vignette": 0.1,
+      "vignette": 0.45,
       "feather": {
         "left": 0.0,
         "right": 0.0,
         "top": 0.1,
-        "bottom": 0.15
+        "bottom": 0.1
       },
       "news_id": null,
       "news": null,
@@ -41,22 +35,16 @@
       "frame_url": "",
       "hold": 1.0,
       "fit": "width",
-      "nudge_x": 9,
-      "nudge_y": -5,
-      "shrink_w": 30,
+      "nudge_x": 0,
+      "nudge_y": 0,
+      "shrink_w": 0,
       "object_position": "100% 50%",
-      "crop": {
-        "x": 0.0,
-        "y": 0.0,
-        "w": 0.9,
-        "h": 1.0
-      },
       "vignette": 0.45,
       "feather": {
         "left": 0.0,
         "right": 0.0,
         "top": 0.1,
-        "bottom": 0.15
+        "bottom": 0.1
       },
       "news_id": null,
       "news": null,

--- a/ichalaunch/data/home_art.json.sig
+++ b/ichalaunch/data/home_art.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "BpM1yWMa6M4j46iEqHHjgTACnZKa9AuQOgoIVkrzmukej4UNQt9XvuigePaHaEbrhA/GnhOuRvtX72xXQqO2Aw==",
+  "sig": "oUO55gFBItQXl28cUUkkjUcgoKi+Xh1Dk+0461iKzPQq6soWRNoMX378Si4dteONitp7W1AP+bzA7+8kYMyaDg==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "45d59a1852dd8ac3951e8b513b88c9f514062caa579c72e021ed90a6e15add18"
+    "sha256": "04f58dff042fa6014c250ae2ce7f25a566ec1c76228fd37e5cb2d5c3d89bbf55"
   },
-  "attestation_sig": "Bo2XGccci8o+q/lmCSfu39zzoBtmjF9/y+6U45WZgUuHMa074ZnPU46B4zK2QYCtRb23eFrEz/73N6SGTlzGAA=="
+  "attestation_sig": "8n4aaBRec6bc/BOrqQah24BofvbdExqB2asxxvntiXtjBODIHz09A02TEVxOfC6lQ5jsy+NMViCI3vUcNot3CQ=="
 }

--- a/ichalaunch/data/news.json
+++ b/ichalaunch/data/news.json
@@ -1,7 +1,7 @@
 {
   "product": "RavenLaunch",
   "version": 2,
-  "updated_at": "2026-09-03T10:00:20Z",
+  "updated_at": "2026-09-03T15:19:44Z",
   "title": "LAUNCH EVENT EXTENSION",
   "body": "Given the latest developments and the influx of new members over the last 24 hours, we will be extending the launch event for an additional 7 days.\n\nThe event will remain active until September 5, 2026 at 2:00 PM, ending in 3 days.\n\nWe look forward to welcoming new players and continuing to build this community together.\n\nThank you to everyone who chooses to join us, and to those who have been here from the beginning, helping us carry this legacy forward.",
   "items": [
@@ -11,7 +11,12 @@
       "body": "Given the latest developments and the influx of new members over the last 24 hours, we will be extending the launch event for an additional 7 days.\n\nThe event will remain active until September 5, 2026 at 2:00 PM, ending in 3 days.\n\nWe look forward to welcoming new players and continuing to build this community together.\n\nThank you to everyone who chooses to join us, and to those who have been here from the beginning, helping us carry this legacy forward.",
       "published_at": "2026-09-02T00:00:00Z",
       "link": "",
-      "tag": ""
+      "tag": "",
+      "align": {
+        "h": "left",
+        "v": "top"
+      },
+      "nudge_y": -1
     },
     {
       "id": "n_46bea399",
@@ -19,7 +24,11 @@
       "body": "The Bug Tracker is where confirmed and reproducible bugs should be reported so our team can investigate and address them.\n\nIf you're unsure whether an issue is a bug, or you're unable to reproduce it, contact a Game Master through /gm first so it can be investigated.\n\nBefore submitting a report, please check existing reports to avoid duplicates and include all relevant information needed to reproduce the issue.",
       "published_at": "2026-09-03T01:54:22Z",
       "link": "",
-      "tag": ""
+      "tag": "",
+      "align": {
+        "h": "left",
+        "v": "top"
+      }
     },
     {
       "id": "n_eb718cd5",
@@ -27,7 +36,11 @@
       "body": "The Database is your go-to place for information about our server.\n\nExplore items, creatures, locations, quests, and more, including all the latest content from Nightmare of Ursol — 1.18.1.\n\nWe'll continue expanding and updating it as new content is added and existing information is reviewed.",
       "published_at": "2026-09-03T01:54:50Z",
       "link": "",
-      "tag": ""
+      "tag": "",
+      "align": {
+        "h": "left",
+        "v": "top"
+      }
     }
   ],
   "pairing": "art-bound",
@@ -41,22 +54,16 @@
       "frame_url": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/ui/theme/zaeya_first_60_frame.png",
       "hold": 2.0,
       "fit": "width",
-      "nudge_x": 12,
-      "nudge_y": -5,
-      "shrink_w": 30,
+      "nudge_x": 0,
+      "nudge_y": 0,
+      "shrink_w": 0,
       "object_position": "100% 50%",
-      "crop": {
-        "x": 0.0,
-        "y": 0.0,
-        "w": 0.9,
-        "h": 1.0
-      },
-      "vignette": 0.1,
+      "vignette": 0.45,
       "feather": {
         "left": 0.0,
         "right": 0.0,
         "top": 0.1,
-        "bottom": 0.15
+        "bottom": 0.1
       },
       "news_id": null,
       "news": null,
@@ -74,22 +81,16 @@
       "frame_url": "",
       "hold": 1.0,
       "fit": "width",
-      "nudge_x": 9,
-      "nudge_y": -5,
-      "shrink_w": 30,
+      "nudge_x": 0,
+      "nudge_y": 0,
+      "shrink_w": 0,
       "object_position": "100% 50%",
-      "crop": {
-        "x": 0.0,
-        "y": 0.0,
-        "w": 0.9,
-        "h": 1.0
-      },
       "vignette": 0.45,
       "feather": {
         "left": 0.0,
         "right": 0.0,
         "top": 0.1,
-        "bottom": 0.15
+        "bottom": 0.1
       },
       "news_id": null,
       "news": null,

--- a/ichalaunch/data/news.json.sig
+++ b/ichalaunch/data/news.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "FVgR9b9X4rxxl1jdRugBQJRKGDOjiuiutZ9FLjVKRDfex/WZRjwT55SKd1sXR2UQCBx9EMUlRiKiRIjn+9xcBg==",
+  "sig": "MOc7+RQ5uVJWufjgMFOLmy9GTJI4CTfyd0f0rXrOu/77qdgNeI5iUUhDdJdaY2oQaHlFWxOfnaDpUNU4Vs3MBA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "77952db3c0d215f0c1acd4aa68c5145ca35579b670cef1c4c3a2ad426dd93a39"
+    "sha256": "877d9e04bed3a85ea3f06d294041611bd862b8ed95fa911f20ba310752ac0264"
   },
-  "attestation_sig": "GSgy3UAXaGZxmmTb4NdSVHlcAmyGiAQn94i/POGQAI0oBOHWQIzcRhIFb4YHcdgiPI/FCFE5qmt6XCRGJESXDA=="
+  "attestation_sig": "AwRVmOdFGWfUS1dBoyysRksEXLweYd94vw5jV1dQzAzk/hs89ZMbaS3OqAKu5kMJIfRsuZDlBXyy3m1FQa8ODA=="
 }


### PR DESCRIPTION
## Summary
- Publishes the signed news.json + home_art.json pairing/align/crop tweaks from the admin news-media editor.
- JSON + `.sig` together. Does **not** touch `mods.json` or `manifest.json`.
- Keeps the live 1.6.2 EXE pin (GitHub Release / `ddfc8f19…` / 277490033).
- **Do not merge #560** — that PR regresses bootstrap catalogs to CDN and the launcher pin to 1.6.0 / `update.ravencraft.io`.

## Test plan
- [x] Sidecar attestation sha256 matches LF payloads
- [ ] After merge, raw `mods.json` pin is still 1.6.2
- [ ] After merge, raw `manifest.json` launcher is still GitHub v1.6.2

Made with [Cursor](https://cursor.com)