### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/home_art.json
+++ b/ichalaunch/data/home_art.json
@@ -66,13 +66,7 @@
       "nudge_y": 0,
       "shrink_w": 0,
       "object_position": "100% 50%",
-      "vignette": 0.45,
-      "feather": {
-        "left": 0.2,
-        "right": 0.0,
-        "top": 0.0,
-        "bottom": 0.0
-      },
+      "vignette": 0.4,
       "news_id": "welcome-to-ravenlaunch-1-6",
       "news_fade": {
         "enabled": true,

--- a/ichalaunch/data/home_art.json.sig
+++ b/ichalaunch/data/home_art.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "oUO55gFBItQXl28cUUkkjUcgoKi+Xh1Dk+0461iKzPQq6soWRNoMX378Si4dteONitp7W1AP+bzA7+8kYMyaDg==",
+  "sig": "wVyS4oKFtIpGBF0mazPsoaIp8DZjeLfEXB8v1cUHwmdQJT5SsZckStJFCPIyla3RyZW3UKh+zgboLO86iVsBDQ==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "04f58dff042fa6014c250ae2ce7f25a566ec1c76228fd37e5cb2d5c3d89bbf55"
+    "sha256": "178fba16850b3f5c5b8525663586e540b7ced30e33e3eff02c28398ca2fbeccb"
   },
-  "attestation_sig": "8n4aaBRec6bc/BOrqQah24BofvbdExqB2asxxvntiXtjBODIHz09A02TEVxOfC6lQ5jsy+NMViCI3vUcNot3CQ=="
+  "attestation_sig": "7S1gFIBxepWWo4RErYIU+RcDl5qYJyudzdEmoFd7R608132jDiiwxkTo7HCSGyRWcdTeMShX9+7dceB8B5hhCg=="
 }

--- a/ichalaunch/data/news.json
+++ b/ichalaunch/data/news.json
@@ -1,7 +1,7 @@
 {
   "product": "RavenLaunch",
   "version": 2,
-  "updated_at": "2026-09-03T15:19:44Z",
+  "updated_at": "2026-09-03T17:10:10Z",
   "title": "LAUNCH EVENT EXTENSION",
   "body": "Given the latest developments and the influx of new members over the last 24 hours, we will be extending the launch event for an additional 7 days.\n\nThe event will remain active until September 5, 2026 at 2:00 PM, ending in 3 days.\n\nWe look forward to welcoming new players and continuing to build this community together.\n\nThank you to everyone who chooses to join us, and to those who have been here from the beginning, helping us carry this legacy forward.",
   "items": [
@@ -14,9 +14,11 @@
       "tag": "",
       "align": {
         "h": "left",
-        "v": "top"
+        "v": "center"
       },
-      "nudge_y": -1
+      "nudge_y": -1,
+      "title_size": 18,
+      "body_size": 14
     },
     {
       "id": "n_46bea399",
@@ -27,8 +29,10 @@
       "tag": "",
       "align": {
         "h": "left",
-        "v": "top"
-      }
+        "v": "center"
+      },
+      "title_size": 18,
+      "body_size": 14
     },
     {
       "id": "n_eb718cd5",
@@ -39,8 +43,10 @@
       "tag": "",
       "align": {
         "h": "left",
-        "v": "top"
-      }
+        "v": "center"
+      },
+      "title_size": 18,
+      "body_size": 14
     }
   ],
   "pairing": "art-bound",
@@ -112,13 +118,7 @@
       "nudge_y": 0,
       "shrink_w": 0,
       "object_position": "100% 50%",
-      "vignette": 0.45,
-      "feather": {
-        "left": 0.2,
-        "right": 0.0,
-        "top": 0.0,
-        "bottom": 0.0
-      },
+      "vignette": 0.4,
       "news_id": "welcome-to-ravenlaunch-1-6",
       "news_fade": {
         "enabled": true,

--- a/ichalaunch/data/news.json.sig
+++ b/ichalaunch/data/news.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "MOc7+RQ5uVJWufjgMFOLmy9GTJI4CTfyd0f0rXrOu/77qdgNeI5iUUhDdJdaY2oQaHlFWxOfnaDpUNU4Vs3MBA==",
+  "sig": "k5uBgUhRKn7iLZkPPORx703HYKT4ql7sGZzJzqhK2J6vOUJTSjUihN36l54NjW51nUWRltOLKxNT/jIyGZTKAQ==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "877d9e04bed3a85ea3f06d294041611bd862b8ed95fa911f20ba310752ac0264"
+    "sha256": "aee036704e6eb66d8c579450a0e0054397d19b6e5a35e157b87d674393d490fa"
   },
-  "attestation_sig": "AwRVmOdFGWfUS1dBoyysRksEXLweYd94vw5jV1dQzAzk/hs89ZMbaS3OqAKu5kMJIfRsuZDlBXyy3m1FQa8ODA=="
+  "attestation_sig": "eeSFTBxNM87xEANhkfZJL+JLYLdO5T7aOQq/z7rYRE24e5hLZlMdW1oZPU0yRKFDz16hB7Zx+sgdQhhq3lQPDg=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong at `ichalaunch/data/<name>.sig` beside the JSON.
- Merge JSON + `.sig` together.
- Signing keys stay on the maintainer machine and never enter CI.
- After merge, publish to the CDN / update server: `python tools/publish_cdn.py --catalogs`
