### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/news.json
+++ b/ichalaunch/data/news.json
@@ -1,7 +1,7 @@
 {
   "product": "RavenLaunch",
   "version": 2,
-  "updated_at": "2026-09-03T17:10:10Z",
+  "updated_at": "2026-09-03T18:08:29Z",
   "title": "LAUNCH EVENT EXTENSION",
   "body": "Given the latest developments and the influx of new members over the last 24 hours, we will be extending the launch event for an additional 7 days.\n\nThe event will remain active until September 5, 2026 at 2:00 PM, ending in 3 days.\n\nWe look forward to welcoming new players and continuing to build this community together.\n\nThank you to everyone who chooses to join us, and to those who have been here from the beginning, helping us carry this legacy forward.",
   "items": [
@@ -58,7 +58,7 @@
       "url": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/ui/theme/zaeya_first_60.jpg",
       "frame": "zaeya_first_60_frame.png",
       "frame_url": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/ui/theme/zaeya_first_60_frame.png",
-      "hold": 2.0,
+      "hold": 0.5,
       "fit": "width",
       "nudge_x": 0,
       "nudge_y": 0,
@@ -85,7 +85,7 @@
       "url": "https://download.ravencraft.io/ichalaunch/ui/theme/official_artworks/Flag_First-60-HC_Immortal.png",
       "frame": "",
       "frame_url": "",
-      "hold": 1.0,
+      "hold": 0.5,
       "fit": "width",
       "nudge_x": 0,
       "nudge_y": 0,

--- a/ichalaunch/data/news.json.sig
+++ b/ichalaunch/data/news.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "nC1RCCejm8OgW0dgZHfoiqtyrsPYzPHIw1PArbAZvK9pGKXwhqNYgRoZzRRQ/J/VF4dzpH3bwlfpLaq80dTHBA==",
+  "sig": "Z+cnUn8hUnxKs0LwlhKIjuGP4Re+8FAL0wyK0AWoyUujMvLIt9V4h5rXsMAf1tZeriwxMkkJE6kzwvn7UPC/Cw==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "18f09dad6afe43448e6462ccecd5a063b6ea666270956497d3378328b1036904"
+    "sha256": "8885b0f424e3d51551339c351283c3b2a47e1670f62ed3583447f75c46b2d112"
   },
-  "attestation_sig": "nNeH7TAJjNtkZwuxdH6/mndKq5idjAaUmSZfW335wmYfhPd3L+RPhtVK8GTD4b9qykBFYXF0RO1vXdifAgMYBA=="
+  "attestation_sig": "P89ASngVsr+yvF05H/vpN7UTKD2M7bRIn5EGDCmWGOr6fG/qW5o/R1LxafbrVkGMaxifKGWRtWqVzU1AGveBAA=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong at `ichalaunch/data/<name>.sig` beside the JSON.
- Merge JSON + `.sig` together.
- Signing keys stay on the maintainer machine and never enter CI.
- After merge, publish to the CDN / update server: `python tools/publish_cdn.py --catalogs`
