### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -345,8 +345,8 @@
       "type": "github_release_latest",
       "repo": "brues-code/ClassicAPI",
       "asset_contains": "ClassicAPI.dll",
-      "sha256": "3b20b690dbe35b013baf3c9d08e74e53c4ff8a93336fbf2e0ed8f3c3ef4cb59e",
-      "pinned_tag": "v1.13.2"
+      "sha256": "a3864f78fc90720a8143972f05d64caa0edfa572a94cc0149d7683ad4736b8ba",
+      "pinned_tag": "v1.13.3"
     },
     "files": [
       {
@@ -1452,11 +1452,11 @@
     "name": "Raven Launcher",
     "source": {
       "type": "raw",
-      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.3/IchaLaunch.exe",
+      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.2/IchaLaunch.exe",
       "filename": "IchaLaunch.exe",
-      "sha256": "822a0b0a12a3fc9014df7e9afd33f7f6cdba70518ed54305c6588e4dd107c665",
-      "version": "1.6.3",
-      "size": 277522639
+      "sha256": "ddfc8f19b01c9136cd4e6626d3025814ec12676abacf6740178183346bc854ae",
+      "version": "1.6.2",
+      "size": 277490033
     }
   }
 ]

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "cPxtQJ3m/xmeJeqd1tDwMl9CyV+qXmCVK47ntK15hk+3c6cV/JOiyp6EkfmoZj67jCWKX34qY1y5Rbs9buExDA==",
+  "sig": "1HMyXdE/vvXXPnP4nClxI1WJsyejNf/xoEcErMZ+Vb0tK9JZeJiiH8BcCBGafrsH/58Hl1G+GQiILazZCoA/DQ==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "85847082aaa6dcd61a221700451112a881fdd70c1c1a5a94117fcdc41470f9bf"
+    "sha256": "9f6dde06ef3c583dce2b61eb81e53c715db2e41efe8c13284515499dd024bd4c"
   },
-  "attestation_sig": "sORZyJDWJb2eiHJ9dLNzkKV7lWMnX7wL02osW/378NK8gTIyiOVeDPqEWK8Bu1iuwSujUcXbJezn78KSeDs1DQ=="
+  "attestation_sig": "K/9OWSWAicaHIj+wxW618tjUmSLq7a4RSuO0bToXL3IW3ILFKfhdM3hYxm1R7Rsg4aBzLHzZ8fqqFiGa2zFTBA=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong at `ichalaunch/data/<name>.sig` beside the JSON.
- Merge JSON + `.sig` together.
- Signing keys stay on the maintainer machine and never enter CI.
- After merge, publish to the CDN / update server: `python tools/publish_cdn.py --catalogs`
