### PR TITLE
catalog: hourly tips/downloads (unsigned — sign before merge)

### DIFF
--- a/ichalaunch/data/addon_tips.json
+++ b/ichalaunch/data/addon_tips.json
@@ -15460,6 +15460,297 @@
       "branches": {
         "master": "e53a09a4e86170a1a29178f8500e601bdd58e9ce"
       }
+    },
+    "bagaze/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "f43019aba2c7816d02a76265cfc827ddc566d064",
+      "branches": {
+        "master": "f43019aba2c7816d02a76265cfc827ddc566d064"
+      }
+    },
+    "wierdthing/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "fefde810f979bfbcbdccfbe30472de3a68701652",
+      "branches": {
+        "master": "fefde810f979bfbcbdccfbe30472de3a68701652"
+      }
+    },
+    "mnemozin/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "48562174a3a1fd861b10ca4c2668625b67ac4e22",
+      "branches": {
+        "master": "48562174a3a1fd861b10ca4c2668625b67ac4e22"
+      }
+    },
+    "hp-data/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "f43019aba2c7816d02a76265cfc827ddc566d064",
+      "branches": {
+        "master": "f43019aba2c7816d02a76265cfc827ddc566d064"
+      }
+    },
+    "airfinder/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "f43019aba2c7816d02a76265cfc827ddc566d064",
+      "branches": {
+        "master": "f43019aba2c7816d02a76265cfc827ddc566d064"
+      }
+    },
+    "0ninzya/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "ceae89b14544fd87a8449bd4a751802dd118809c",
+      "branches": {
+        "master": "ceae89b14544fd87a8449bd4a751802dd118809c"
+      }
+    },
+    "lxxie1988/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "ceae89b14544fd87a8449bd4a751802dd118809c",
+      "branches": {
+        "master": "ceae89b14544fd87a8449bd4a751802dd118809c"
+      }
+    },
+    "paokkerkir/pfquest": {
+      "default_branch": "main",
+      "sha": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9",
+      "branches": {
+        "main": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9"
+      }
+    },
+    "twapegg/pfquest": {
+      "default_branch": "main",
+      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
+      "branches": {
+        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
+      },
+      "latest_tag": "8.0.0"
+    },
+    "balakethelock/pfquest": {
+      "default_branch": "main",
+      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
+      "branches": {
+        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
+      }
+    },
+    "alandarev/pfquest": {
+      "default_branch": "main",
+      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
+      "branches": {
+        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
+      },
+      "latest_tag": "8.0.0"
+    },
+    "al3xc1985/pfquest": {
+      "default_branch": "main",
+      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
+      "branches": {
+        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
+      }
+    },
+    "hippoom/pfquest": {
+      "default_branch": "main",
+      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
+      "branches": {
+        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
+      }
+    },
+    "copypasteonly/pfquest": {
+      "default_branch": "main",
+      "sha": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9",
+      "branches": {
+        "main": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9"
+      },
+      "latest_tag": "8.0.0"
+    },
+    "ravenofseven/pfquest": {
+      "default_branch": "main",
+      "sha": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9",
+      "branches": {
+        "main": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9"
+      }
+    },
+    "paokkerkir/pfquest-octo": {
+      "default_branch": "main",
+      "sha": "dd3dc1fb80afe7a71e5c8ca8c31ca2a3ef57af67",
+      "branches": {
+        "main": "dd3dc1fb80afe7a71e5c8ca8c31ca2a3ef57af67"
+      }
+    },
+    "ravenofseven/pfui-bettertotems": {
+      "default_branch": "main",
+      "sha": "4bcb23338570476c97db89590a70d102b0438b09",
+      "branches": {
+        "main": "4bcb23338570476c97db89590a70d102b0438b09"
+      }
+    },
+    "whtmst/pfui-bettertotems": {
+      "default_branch": "main",
+      "sha": "4bcb23338570476c97db89590a70d102b0438b09",
+      "branches": {
+        "main": "4bcb23338570476c97db89590a70d102b0438b09"
+      }
+    },
+    "wow-br/blizzplates": {
+      "default_branch": "master",
+      "sha": "8aa50c0fe0d50aabeab39472abebb3f5f241672b",
+      "branches": {
+        "master": "8aa50c0fe0d50aabeab39472abebb3f5f241672b"
+      }
+    },
+    "alexpoatato/blizzplates": {
+      "default_branch": "master",
+      "sha": "8aa50c0fe0d50aabeab39472abebb3f5f241672b",
+      "branches": {
+        "master": "8aa50c0fe0d50aabeab39472abebb3f5f241672b"
+      }
+    },
+    "ravenofseven/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "f9873f69b656c9cb717febbb536beee51b7f910f",
+      "branches": {
+        "main": "f9873f69b656c9cb717febbb536beee51b7f910f"
+      }
+    },
+    "blehz-be/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "f9873f69b656c9cb717febbb536beee51b7f910f",
+      "branches": {
+        "main": "f9873f69b656c9cb717febbb536beee51b7f910f"
+      }
+    },
+    "mazdur/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "f9873f69b656c9cb717febbb536beee51b7f910f",
+      "branches": {
+        "main": "f9873f69b656c9cb717febbb536beee51b7f910f"
+      }
+    },
+    "zedris/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "86e8962b94af6bc057b3c697553ec67577569c4c",
+      "branches": {
+        "main": "86e8962b94af6bc057b3c697553ec67577569c4c"
+      }
+    },
+    "mr-rosh/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "2c9d3e84131dcc12c3f2844b8d369fbde048398f",
+      "branches": {
+        "main": "2c9d3e84131dcc12c3f2844b8d369fbde048398f"
+      }
+    },
+    "dirty-git/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "48cd30bff231add81b7d892b4fc1c9d40912c57e",
+      "branches": {
+        "main": "48cd30bff231add81b7d892b4fc1c9d40912c57e"
+      }
+    },
+    "jiangxt316/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "8cc036f32f67ace0baf749f2e67163460374c5a8",
+      "branches": {
+        "main": "8cc036f32f67ace0baf749f2e67163460374c5a8"
+      }
+    },
+    "shigemunekurogane/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "a499442783df407737a914e63718e26ec3b74a31",
+      "branches": {
+        "main": "a499442783df407737a914e63718e26ec3b74a31"
+      }
+    },
+    "commandersouza/pfui-autoinvite": {
+      "default_branch": "main",
+      "sha": "e67988f1f28478c2df1163e3b8a2a1b50656ad0a",
+      "branches": {
+        "main": "e67988f1f28478c2df1163e3b8a2a1b50656ad0a"
+      }
+    },
+    "ravenofseven/pfui-custommedia": {
+      "default_branch": "main",
+      "sha": "701bee8b249fbe91050e6e3645bf810841704696",
+      "branches": {
+        "main": "701bee8b249fbe91050e6e3645bf810841704696"
+      }
+    },
+    "macumbafeh/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
+      "branches": {
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
+      }
+    },
+    "amonra/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
+      "branches": {
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
+      }
+    },
+    "dwbclz/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
+      "branches": {
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
+      }
+    },
+    "jiangxt316/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
+      "branches": {
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
+      }
+    },
+    "ravenofseven/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
+      "branches": {
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
+      }
+    },
+    "spawnedc/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
+      "branches": {
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
+      }
+    },
+    "yani9o/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
+      "branches": {
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
+      }
+    },
+    "ravenofseven/pfui-locationplus": {
+      "default_branch": "master",
+      "sha": "e741cddc085dbefe955d9d128af016bbe697d657",
+      "branches": {
+        "master": "e741cddc085dbefe955d9d128af016bbe697d657"
+      }
+    },
+    "ravenofseven/pfui-moredatatexts": {
+      "default_branch": "master",
+      "sha": "5447b2a3e3ed9071a79240d52664884f0706903d",
+      "branches": {
+        "master": "5447b2a3e3ed9071a79240d52664884f0706903d"
+      }
+    },
+    "sica42/callofelements": {
+      "default_branch": "master",
+      "sha": "afc5398aef1f2f31ed34732ec89eaf77bce06d2f",
+      "branches": {
+        "master": "afc5398aef1f2f31ed34732ec89eaf77bce06d2f"
+      }
+    },
+    "roby-brok/pfquest-classicapi": {
+      "default_branch": "master",
+      "sha": "a71931538988b930ee51f115a7d5683fe914ec21",
+      "branches": {
+        "master": "a71931538988b930ee51f115a7d5683fe914ec21"
+      },
+      "latest_tag": "8.1.0"
     }
   }
 }

--- a/ichalaunch/data/addons.json
+++ b/ichalaunch/data/addons.json
@@ -51,10 +51,10 @@
     "description": "All-in-one auto-categorizing and sorting inventory replacement for Bags and Bank with customizable layout and rules. Pinned to 1.5.16 (1.12 / Turtle); newer GitHub releases target 3.3.5 and are not auto-updated. https://github.com/NiclasEriksen/Bagshui Alt",
     "source": "turtle_wiki",
     "folder": "Bagshui",
-    "release_downloads_repo": "The-Kludge-Bureau/Bagshui",
-    "release_downloads_state": "ok",
-    "release_downloads": 235,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
+    "release_downloads_repo": "selfinterest/Bagshui",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-03T22:36:20Z",
     "recommended": true
   },
   {
@@ -84,8 +84,8 @@
     ],
     "release_downloads_repo": "Road-block/CooldownTimers",
     "release_downloads_state": "ok",
-    "release_downloads": 656,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 657,
+    "release_downloads_at": "2026-09-03T22:36:20Z"
   },
   {
     "name": "Destroy Cursor Item",
@@ -714,10 +714,10 @@
         "repo": "https://github.com/Nelethor/BattleMusic"
       }
     ],
-    "release_downloads_repo": "zmarotrix/BattleMusic",
-    "release_downloads_state": "ok",
-    "release_downloads": 1400,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
+    "release_downloads_repo": "Fiurs-Hearth/BattleMusic",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-03T22:36:20Z",
     "recommended": true
   },
   {
@@ -2101,10 +2101,10 @@
         "repo": "https://github.com/tomek7667/aux-addon"
       }
     ],
-    "release_downloads_repo": "OldManAlpha/aux-addon",
+    "release_downloads_repo": "Otari98/aux-addon",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-03T22:36:20Z",
     "recommended": true
   },
   {
@@ -2805,10 +2805,10 @@
         "repo": "https://github.com/paokkerkir/AttackBar_DragonflightUI"
       }
     ],
-    "release_downloads_repo": "Siventt/AttackBar-TWoW",
+    "release_downloads_repo": "deceius/AttackBar",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-03T22:36:20Z",
     "recommended": true
   },
   {
@@ -2828,10 +2828,10 @@
         "repo": "https://github.com/KameleonUK/AuldLangSyne"
       }
     ],
-    "release_downloads_repo": "Road-block/AuldLangSyne",
-    "release_downloads_state": "ok",
-    "release_downloads": 304,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_repo": "refaim/AuldLangSyne",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-03T22:36:20Z",
     "recommended": true
   },
   {
@@ -3631,8 +3631,8 @@
     ],
     "release_downloads_repo": "ScottHamper/chatsuey",
     "release_downloads_state": "ok",
-    "release_downloads": 5092,
-    "release_downloads_at": "2026-09-03T12:51:29Z"
+    "release_downloads": 5093,
+    "release_downloads_at": "2026-09-03T22:36:20Z"
   },
   {
     "name": "ChatTimestamps",
@@ -4932,8 +4932,8 @@
     "folder": "wow-vanilla-gearmenu",
     "release_downloads_repo": "RagedUnicorn/wow-vanilla-gearmenu",
     "release_downloads_state": "ok",
-    "release_downloads": 2670,
-    "release_downloads_at": "2026-09-03T12:51:29Z"
+    "release_downloads": 2671,
+    "release_downloads_at": "2026-09-03T22:36:20Z"
   },
   {
     "name": "GFW HuntersHelper",
@@ -11597,10 +11597,10 @@
         "repo": "https://github.com/laytya/AutoBar-for-Turtle-WoW"
       }
     ],
-    "release_downloads_repo": "laytya/AutoBar-for-Turtle-WoW",
+    "release_downloads_repo": "Bestoriop/AutoBar",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-03T22:36:20Z",
     "recommended": true
   },
   {
@@ -11967,8 +11967,8 @@
     ],
     "release_downloads_repo": "The-Kludge-Bureau/pfQuest",
     "release_downloads_state": "ok",
-    "release_downloads": 7071,
-    "release_downloads_at": "2026-09-03T19:26:40Z"
+    "release_downloads": 7083,
+    "release_downloads_at": "2026-09-03T22:36:20Z"
   },
   {
     "name": "pfQuest-icons",
@@ -12426,10 +12426,10 @@
         "repo": "https://github.com/BahamutxD/AutoMasterLooter"
       }
     ],
-    "release_downloads_repo": "balakethelock/AutoMasterLooter",
+    "release_downloads_repo": "Otari98/AutoMasterLooter",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-03T22:36:20Z",
     "recommended": true
   },
   {
@@ -12453,10 +12453,10 @@
         "repo": "https://github.com/balakethelock/bananabar"
       }
     ],
-    "release_downloads_repo": "balakethelock/bananabar",
+    "release_downloads_repo": "Otari98/bananabar",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "release_downloads_at": "2026-09-03T22:36:20Z",
     "recommended": true
   },
   {
@@ -12486,7 +12486,11 @@
         "repo": "https://github.com/pepopo978/BigWigs"
       }
     ],
-    "recommended": true
+    "recommended": true,
+    "release_downloads_repo": "ElesionWoW/BigWigs",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-03T22:36:20Z"
   },
   {
     "name": "BMLoot",
@@ -13580,8 +13584,8 @@
     ],
     "release_downloads_repo": "obszczymucha/roll-for-vanilla",
     "release_downloads_state": "ok",
-    "release_downloads": 3757,
-    "release_downloads_at": "2026-09-03T12:51:29Z"
+    "release_downloads": 3759,
+    "release_downloads_at": "2026-09-03T22:36:20Z"
   },
   {
     "name": "RoundRobinhood",
@@ -17465,8 +17469,8 @@
     "description": "# pfUI - ClassicAPI Edition\n\n[![Octo WoW](https://img.shields.io/badge/Octo%20WoW-1.18.1-brightgreen.svg)](https://octowow.st/)\n[![ClassicAPI](https://img.shields.io/badge/ClassicAPI-Required-purple.svg)](https://github.com/brues-code/ClassicAPI)\n[![Nampower](https://img.shields.io/badge/Nampower-Required-purple.svg)](https://github.com/brues-code/nampower)\n[![SuperWoW](https://img.shields.io/badge/SuperWoW-Optional-yellow.svg)](https://github.com/balakethelock/SuperWoW)\n[![UnitXP](https://img.shields.io/badge/UnitXP__SP3-Optional-yellow.svg)](https://github.com/brues-code/UnitXP_SP3)\n\n**A pfUI fork specifically optimized for ClassicAPI on [Octo WoW](https://octowow.st/)**\n\nThis version includes significant performance improvements and DLL-enhanced features.\n\n## Installation\n1. Download **[Latest Version](https://github.com/brues-code/pfUI/releases/latest)**\n2. Unpack the Zip file\n4. Copy \"pfUI\" into Wow-Directory\\Interface\\AddOns\n5. Restart Wow\n\n## DLL Enhancements\n\nSince pfUI 6.0.0 includes integrations with client-side DLLs for enhanced functionality. These DLLs are permitted on Octo WoW:\n\n### [ClassicAPI](https://github.com/brues-code/ClassicAPI)\n\nProvides:\n- C_NamePlate - Event-driven nameplates (no more per-frame WorldFrame scanning) with real per-plate unit tokens and GUIDs\n- C_UnitAuras - Replaces over 3k lines of hand-rolled aura tracking\n- C_Spell - Replaces thousands of hardcoded spell names for each locale and powers castbar\n- Real cast bars - Actual cast/channel timing, spellID and interrupt state for any unit (C_Spell.UnitCastingInfo)\n- Focus - A genuine `focus` unit plus `/focus` and `/clearfocus` (FocusUnit / ClearFocus)\n- C_EquipmentSet - Full Equipment Manager with GUID-tracked gear sets (tells apart duplicate/enchanted items)\n- Instant Bag Sorting - C_Container.MoveItem / SwapItems instead of cursor pickup/drop\n- Sell junk in one call - C_MerchantFrame.GetNumJunkItems / SellAllJunkItems\n- Real item data - C_Item counts, quality, sell price and item info by ID\n- GUID-based targeting - Nameplates, mouseover and focus resolve by GUID, not by name text\n- Faster, safer profile sharing - Engine-side serialize/compress/base64 via C_EncodingUtil\n- C_Timer - After / NewTicker replacing hand-rolled OnUpdate throttles\n- Feign death, shapeshift and quest-item detection via real API calls\n- Mouseover Unit Frames\n- Click-casting\n- Loot Roll History (/loothistory)\n- New item highlighting\n- Plenty other functions\n\n### [Nampower](https://github.com/brues-code/nampower)\n\nProvides:\n- Spell queue indicator\n- GCD indicator\n\n### [SuperWoW](https://github.com/balakethelock/SuperWoW)\n\nProvides:\n- Tracks party/raid units on the minimap\n\n### [UnitXP_SP3](https://github.com/brues-code/UnitXP_SP3)\n\nProvides:\n- Line of Sight detection\n- Behind detection\n- Accurate distance calculations\n- OS notifications\n\nUse `/pfdll` in-game to check which DLLs are detected.\n\n## Commands\n\n    /pfui         Open the configuration GUI\n    /pfdll        Show DLL detection status (SuperWoW, Nampower, UnitXP)\n    /pfbehind     Test Behind/LOS detection on current target\n    /clickthrough Toggle clickthrough mode (or /ct)\n    /share        Open the configuration import/export dialog\n    /gm           Open the ticket Dialog\n    /rl           Reload the whole UI\n    /farm         Toggles the Farm-Mode\n    /pfcast       Same as /cast but for mouseover units\n    /focus        Creates a Focus-Frame for the current target\n    /castfocus    Same as /cast but for focus frame\n    /clearfocus   Clears the Focus-Frame\n    /swapfocus    Toggle Focus and Target-Frame\n    /pftest       Toggle pfUI Unitframe Test Mode\n    /abp          Addon Button Panel\n    /loothistory  Show Loot Roll History\n\n## Languages\npfUI supports and contains language specific code for the following gameclients.\n* English (enUS)\n* Korean (koKR)\n* French (frFR)\n* German (deDE)\n* Chinese (zhCN)\n* Spanish (esES)\n* Russian (ruRU)\n\n## Recommended Addons\n* [pfQuest](https://github.co\n\n… (truncated)",
     "release_downloads_repo": "brues-code/pfUI",
     "release_downloads_state": "ok",
-    "release_downloads": 46,
-    "release_downloads_at": "2026-09-03T19:26:40Z"
+    "release_downloads": 48,
+    "release_downloads_at": "2026-09-03T22:36:20Z"
   },
   {
     "name": "NiceDamage-1.12",
@@ -17786,8 +17790,8 @@
     "description": "A Questhelper and Database Addon for World of Warcraft: Vanilla & TBC",
     "release_downloads_repo": "shagu/pfQuest",
     "release_downloads_state": "ok",
-    "release_downloads": 228095,
-    "release_downloads_at": "2026-09-03T19:26:40Z"
+    "release_downloads": 228142,
+    "release_downloads_at": "2026-09-03T22:36:20Z"
   },
   {
     "name": "pfQuest-classicAPI",
@@ -17798,8 +17802,8 @@
     "description": "> ### Attribution\n>\n> **This is a downstream fork. Almost none of the work here is mine.**\n>\n> | | |\n> |---|---|\n> | **[Shagu](https://github.com/shagu/pfQuest)** | created pfQuest, with **txtsd** maintaining. |\n> | **[brues-code / Railgun](https://github.com/brues-code/pfQuest)** | modernised it onto ClassicAPI — reading through the API instead of shipped tables (`C_QuestLog`, `C_Item`, `C_TaxiMap`, DBC-derived race/class bitmasks). **Also the author of [ClassicAPI](https://github.com/brues-code/ClassicAPI)** itself. |\n> | **[The Kludge Bureau](https://github.com/The-Kludge-Bureau/pfQuest)** | the build this fork's data lineage came from. |\n> | **[VMaNGOS](https://github.com/vmangos)** | the underlying quest database. |\n> | **Roby_Brok** | this repo: four local patches for OctoWoW on top of Railgun's tree. |\n>\n> Upstream is **https://github.com/brues-code/pfQuest** — go there for the real project.\n>\n> 📋 **[CHANGES-octo.md](CHANGES-octo.md) — full changelog of the changes on top of upstream.**\n> Local changes live on the `octo` branch. GPLv3, same as upstream; see `LICENSE`.\n\n# pfQuest\n\n<img src=\"https://raw.githubusercontent.com/The-Kludge-Bureau/pfQuest/main/_img/mode.png\" float=\"right\" align=\"right\" width=\"25%\">\n\npfQuest is a quest helper and database browser for World of Warcraft Vanilla (1.12), The Burning Crusade (2.4.3), and Wrath of the Lich King (3.3.5a). Accept a quest and the relevant NPCs, monsters, and objects are automatically pinned on your world map and minimap. Open the database browser to look up any unit, item, or game object in the game — or use the chat commands to build macros for tracking gathering nodes.\n\nThe goal is to provide an accurate in-game equivalent of [AoWoW](http://db.vanillagaming.org/) or [Wowhead](http://www.wowhead.com/), not a quest guide or turn-by-turn assistant. The Vanilla database is powered by [VMaNGOS](https://github.com/vmangos). The Burning Crusade version uses data from [CMaNGOS](https://github.com/cmangos) with translations from [MaNGOS Extras](https://github.com/MangosExtras).\n\npfQuest is the successor of [ShaguQuest](https://shagu.org/ShaguQuest/), written from scratch with no dependency on any specific map or questlog addon. It is designed to work alongside the default UI and any other addon. If you run into a conflict, please open an issue on the bugtracker.\n\nYou can check the [Latest Changes](https://github.com/The-Kludge-Bureau/pfQuest/commits/main) page to see what has changed recently.\n\n## What this fork changes, briefly\n\n*(as of 2026-08-10 — details and reasoning in [CHANGES-octo.md](CHANGES-octo.md))*\n\n- **The `[Translate]` button works** — it was inert on every install; a new *Quest Text\n  Translations* option (default on) keeps the quest locale data it reads, and turning it\n  off frees the memory and hides the button. Offered upstream as\n  [PR #2](https://github.com/brues-code/pfQuest/pull/2).\n- **Tracker defaults to Current Zone** instead of every active quest at once\n- **Configurable quest-database website** (defaults to OctoWoW's DB) and\n  **world map / minimap node scale** options\n- **Seven quests with missing objective data restored** (`corrections.lua`, each verified\n  by hand); **`/db checkdb`** lists quests in your log that draw no pins\n- `/db` shows a build identity instead of the raw packager placeholder\n- The changelog's claims are **audited against upstream** — the ones that turned out wrong\n  stay visible, struck through, rather than quietly deleted.\n\n## Before You Install\n\npfQuest ships a complete database of all spawns, objects, items, and quests. The full package is approximately 80 MB and is loaded into memory once at login — memory usage is stable after that and does not grow during play.\n\nOn Vanilla clients, WoW will show a warning if an addon exceeds the default memory limit. **Before installing, set Script Memory to `0` (no limit)** in the AddOns panel of the character selection screen. This is a one-time step. A [screenshot\n\n… (truncated)",
     "release_downloads_repo": "roby-brok/pfQuest-classicAPI",
     "release_downloads_state": "ok",
-    "release_downloads": 27,
-    "release_downloads_at": "2026-09-03T19:26:40Z"
+    "release_downloads": 28,
+    "release_downloads_at": "2026-09-03T22:36:20Z"
   },
   {
     "name": "AddOnOrganizer",


### PR DESCRIPTION
## Summary
- Standing PR for unsigned `addon_tips.json` / stamped `addons.json`.
- Version bumps of existing addons are **held back** and listed on the standing **Catalog Update** issue — they are not live until that issue is approved and signed.
- **Do not merge JSON alone.** Sign locally (purpose `ichalaunch-catalog`) and commit the `.sig` files, then merge JSON+`.sig` together.
- Signing keys must not enter CI. Fail-closed clients ignore unsigned live catalogs.