### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -1452,11 +1452,11 @@
     "name": "Raven Launcher",
     "source": {
       "type": "raw",
-      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.2/IchaLaunch.exe",
+      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.3/IchaLaunch.exe",
       "filename": "IchaLaunch.exe",
-      "sha256": "ddfc8f19b01c9136cd4e6626d3025814ec12676abacf6740178183346bc854ae",
-      "version": "1.6.2",
-      "size": 277490033
+      "sha256": "822a0b0a12a3fc9014df7e9afd33f7f6cdba70518ed54305c6588e4dd107c665",
+      "version": "1.6.3",
+      "size": 277522639
     }
   }
 ]

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "1HMyXdE/vvXXPnP4nClxI1WJsyejNf/xoEcErMZ+Vb0tK9JZeJiiH8BcCBGafrsH/58Hl1G+GQiILazZCoA/DQ==",
+  "sig": "eqeHcg180GDBABjI40wfyBbE0yZjtVzqcbvd0HZlKoea78tBRy6brJt88xaJttDTBtOf+SBXiL9N+lE3C3uGBA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "9f6dde06ef3c583dce2b61eb81e53c715db2e41efe8c13284515499dd024bd4c"
+    "sha256": "b4e6f617dd3890ddb91ce0524c8b78ce71b6ab0be1db545d6457daf2647ac8a1"
   },
-  "attestation_sig": "K/9OWSWAicaHIj+wxW618tjUmSLq7a4RSuO0bToXL3IW3ILFKfhdM3hYxm1R7Rsg4aBzLHzZ8fqqFiGa2zFTBA=="
+  "attestation_sig": "ST30JGFiU3e7myeB6Ml9TUWW4kCbTExKloJNYPvQngNwGgNytzHQqWE67AFpkkwfCZ/UOyjAUHMOLjtPwhx6Aw=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong at `ichalaunch/data/<name>.sig` beside the JSON.
- Merge JSON + `.sig` together.
- Signing keys stay on the maintainer machine and never enter CI.
- After merge, publish to the CDN / update server: `python tools/publish_cdn.py --catalogs`
