### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/manifest.json
+++ b/ichalaunch/data/manifest.json
@@ -1,8 +1,8 @@
 {
   "product": "RavenLaunch",
   "schema": 1,
-  "generated_at": "2026-09-04T00:25:44Z",
-  "updated_at": "2026-09-04T00:25:44Z",
+  "generated_at": "2026-09-04T01:09:12Z",
+  "updated_at": "2026-09-04T01:09:12Z",
   "catalogs": {
     "addons": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addons.json",
     "addon_tips": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addon_tips.json",
@@ -20,8 +20,8 @@
     "id": "ichalaunch",
     "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.4/IchaLaunch.exe",
     "version": "1.6.4",
-    "sha256": "289cc91f258fead2e47e4a4c26e1740eb33eb3e5473d56e5562d4702b9bf2643",
-    "size": 277533337
+    "sha256": "8f7c1865b01d7c0f223d76413ebcb313f608164ed1c005a114e6261fab626bd3",
+    "size": 277546556
   },
   "news": {
     "url": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/news.json"

--- a/ichalaunch/data/manifest.json.sig
+++ b/ichalaunch/data/manifest.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "RXCC3XsplEwQa60VmUSMzSlqbSeXgEwWClLdXlR7AVwiM3F2Pwxndx/wF1mBQ3L3BYrydwWBqmIHrdajqNxaAA==",
+  "sig": "egvqPtMaEDNjuJ+NlK2jm7ZDML83rhAW4F5AGa5LGJfQ+Q7qoqiN9ZsVI5913WV/lG37+AG+RJUcDR7H4ZmhCA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "0a03d289fa109d63c0c334b8905db878340ca31164e2b7367bc9afaca1e7770d"
+    "sha256": "01bf1e2bc93ffd0be80f9a766cefdd152d9db58c382f97d66f19d22de145efd4"
   },
-  "attestation_sig": "7ZZ5HCJFJ8H7Uo/Joom6dtMbON02DjhizxT14C15Gc06A6tjmCKwyLTffYA5MVO7BR7SOasL/QdakShqrkNMAA=="
+  "attestation_sig": "1L+Xxf50S8P0mMJj3x/TrOKsNzylPNechzniBhlKsu7LBYN13blzj4+sF7CYScdvk8JJBf6shS3NTw1lVM8KBA=="
 }

--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -1454,9 +1454,9 @@
       "type": "raw",
       "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.4/IchaLaunch.exe",
       "filename": "IchaLaunch.exe",
-      "sha256": "289cc91f258fead2e47e4a4c26e1740eb33eb3e5473d56e5562d4702b9bf2643",
+      "sha256": "8f7c1865b01d7c0f223d76413ebcb313f608164ed1c005a114e6261fab626bd3",
       "version": "1.6.4",
-      "size": 277533337
+      "size": 277546556
     }
   }
 ]

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "fU0iiC5PFx0QBNyquelyWoQwsIMXa2nF+Asz4zm71GMXTReGBv1Uzoqx2FskJkVdtM+Y0O58MOzOlZTnVSi/Bw==",
+  "sig": "DtR+c+ij3fe6sCdKCqq9ICfDz646X+yo3yzmrmISL6H2n0QxOTmjxDNXpF7vZy7I3K0f7+JZK2GkSPuJGCMtDQ==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "4d40331687b1ea268b92d2b42b20f268ece9e143e8e8df4f66f8dab8e6daa3ff"
+    "sha256": "820b16758ed09546178cd4909e49fe3b9b53a4c8efb0d4b63c0f433038c170a6"
   },
-  "attestation_sig": "liozKI7XmUhCBewCeFqNQI2wjgp0I9wvmmqNaSpCXd9TSGxAJl6TN2IuKAXq91mbl6hLcvdN4QzGeMjpUtxxAg=="
+  "attestation_sig": "tqWPlRiCQ1VW6Wk7/Hfd8VV2/kpHqqJYeA9/Z5wqZMxDMbcMRh3Pj3QRlwOiqUWy6r9Bo0M6Y00DdhIQAaReCg=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong at `ichalaunch/data/<name>.sig` beside the JSON.
- Merge JSON + `.sig` together.
- Signing keys stay on the maintainer machine and never enter CI.
- After merge, publish to the CDN / update server: `python tools/publish_cdn.py --catalogs`
