### PR TITLE
Repin launcher update to 1.6.3 (deliberate rollback: 1.6.4 pulled)

### DIFF
--- a/ichalaunch/data/manifest.json
+++ b/ichalaunch/data/manifest.json
@@ -2,7 +2,7 @@
   "product": "RavenLaunch",
   "schema": 1,
   "generated_at": "2026-09-04T01:09:12Z",
-  "updated_at": "2026-09-04T01:09:12Z",
+  "updated_at": "2026-09-04T01:32:53Z",
   "catalogs": {
     "addons": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addons.json",
     "addon_tips": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addon_tips.json",
@@ -18,10 +18,10 @@
   },
   "launcher": {
     "id": "ichalaunch",
-    "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.4/IchaLaunch.exe",
-    "version": "1.6.4",
-    "sha256": "8f7c1865b01d7c0f223d76413ebcb313f608164ed1c005a114e6261fab626bd3",
-    "size": 277546556
+    "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.3/IchaLaunch.exe",
+    "version": "1.6.3",
+    "sha256": "822a0b0a12a3fc9014df7e9afd33f7f6cdba70518ed54305c6588e4dd107c665",
+    "size": 277522639
   },
   "news": {
     "url": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/news.json"

--- a/ichalaunch/data/manifest.json.sig
+++ b/ichalaunch/data/manifest.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "egvqPtMaEDNjuJ+NlK2jm7ZDML83rhAW4F5AGa5LGJfQ+Q7qoqiN9ZsVI5913WV/lG37+AG+RJUcDR7H4ZmhCA==",
+  "sig": "y7gCK1yz7WawJsbHFKJ9fEttafGjLj9UQFcsussMizTTnfZB9A4juJUMUI0asTIieuGpUFTnSjf2Kik4Tv9yAw==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "01bf1e2bc93ffd0be80f9a766cefdd152d9db58c382f97d66f19d22de145efd4"
+    "sha256": "9a80be89f812c369876eebf394f8ff3378bff9bd31080f41a782f2944350c7a5"
   },
-  "attestation_sig": "1L+Xxf50S8P0mMJj3x/TrOKsNzylPNechzniBhlKsu7LBYN13blzj4+sF7CYScdvk8JJBf6shS3NTw1lVM8KBA=="
+  "attestation_sig": "wy0nKDo6ww326NaKtbsvmt8oJ78lX6TDjzGQnn9gF2nq+4yau38GiaZqVY3afLLAJcix2lDJHkQ0+BfH8ZSYDw=="
 }

--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -1452,11 +1452,11 @@
     "name": "Raven Launcher",
     "source": {
       "type": "raw",
-      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.4/IchaLaunch.exe",
+      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.3/IchaLaunch.exe",
       "filename": "IchaLaunch.exe",
-      "sha256": "8f7c1865b01d7c0f223d76413ebcb313f608164ed1c005a114e6261fab626bd3",
-      "version": "1.6.4",
-      "size": 277546556
+      "sha256": "822a0b0a12a3fc9014df7e9afd33f7f6cdba70518ed54305c6588e4dd107c665",
+      "version": "1.6.3",
+      "size": 277522639
     }
   }
 ]

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "DtR+c+ij3fe6sCdKCqq9ICfDz646X+yo3yzmrmISL6H2n0QxOTmjxDNXpF7vZy7I3K0f7+JZK2GkSPuJGCMtDQ==",
+  "sig": "eqeHcg180GDBABjI40wfyBbE0yZjtVzqcbvd0HZlKoea78tBRy6brJt88xaJttDTBtOf+SBXiL9N+lE3C3uGBA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "820b16758ed09546178cd4909e49fe3b9b53a4c8efb0d4b63c0f433038c170a6"
+    "sha256": "b4e6f617dd3890ddb91ce0524c8b78ce71b6ab0be1db545d6457daf2647ac8a1"
   },
-  "attestation_sig": "tqWPlRiCQ1VW6Wk7/Hfd8VV2/kpHqqJYeA9/Z5wqZMxDMbcMRh3Pj3QRlwOiqUWy6r9Bo0M6Y00DdhIQAaReCg=="
+  "attestation_sig": "ST30JGFiU3e7myeB6Ml9TUWW4kCbTExKloJNYPvQngNwGgNytzHQqWE67AFpkkwfCZ/UOyjAUHMOLjtPwhx6Aw=="
 }


### PR DESCRIPTION
Deliberate rollback of the launcher update pin to **1.6.3** (`822a0b0a12a3…`, 277,522,639 bytes).

v1.6.4 was pulled tonight because the 1.6.3→1.6.4 self-update corrupts installs; its release .sig no longer exists, so clients offered 1.6.4 fail closed. mods.json + manifest.json are re-signed over LF bytes. The anti-rollback guards were consciously bypassed for this one run (guard code untouched).