### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/addon_tips.json
+++ b/ichalaunch/data/addon_tips.json
@@ -14784,9 +14784,9 @@
     },
     "torchlite-bit/aegis_rallypower": {
       "default_branch": "main",
-      "sha": "f1fe55346937aca8642a49383a567f1e53556100",
+      "sha": "8f1ba229ce018c23811dbeaa3e93f0b6368fb563",
       "branches": {
-        "main": "f1fe55346937aca8642a49383a567f1e53556100"
+        "main": "8f1ba229ce018c23811dbeaa3e93f0b6368fb563"
       }
     },
     "cinos03/bijoucounter": {
@@ -15076,9 +15076,9 @@
     },
     "igreed1993/greedmeter": {
       "default_branch": "main",
-      "sha": "0c0b0236315ae70407a70eba8c5db8caaa4f6995",
+      "sha": "899d7a28f0b4c35e41d6e4b11f4c02668395a22b",
       "branches": {
-        "main": "0c0b0236315ae70407a70eba8c5db8caaa4f6995"
+        "main": "899d7a28f0b4c35e41d6e4b11f4c02668395a22b"
       }
     },
     "kobeniiiiii/combatledger": {
@@ -15426,11 +15426,11 @@
     },
     "brutaliccus/ichalaunch": {
       "default_branch": "master",
-      "sha": "f36ad144594747323f1e1641c861a79bb253a6e9",
+      "sha": "5c502023d0ecd077c868f1cde7118e1001601178",
       "branches": {
-        "master": "f36ad144594747323f1e1641c861a79bb253a6e9"
+        "master": "5c502023d0ecd077c868f1cde7118e1001601178"
       },
-      "latest_tag": "v1.6.3"
+      "latest_tag": "v1.6.4"
     },
     "fiurs-hearth/battlemusic": {
       "default_branch": "master",

--- a/ichalaunch/data/addon_tips.json.sig
+++ b/ichalaunch/data/addon_tips.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "PxYGhnViIkeDxo6k1lWTCCNLYmyBub6mG0X7viCrXQNQ+9NtJYcSkFAeChXJZbo46Saldc7a/j47LXU5NP7TCA==",
+  "sig": "wtedTUhGRs9Vqih/pBNqu++IbPsppoX8qBQiKy91C7JChQXQ9tc4dmGLeB4RX964d83WsNkGsajarRM/RWhdDg==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "25fb4eed18549c315804a3615c67da31a3003c3903fdcf3c3a7469de074107ae"
+    "sha256": "cfdbe2d8c3ca42d26af24227e049195542d9fcfbf8483b324ab5a7fa92664ba0"
   },
-  "attestation_sig": "TqOv/XlsESCqhJIDIsOJJGIWElCqKsIVxAbOhfIrEd+iN6ppFB3/UB+WewojfYSCKisRdBrd9daIvKyRqjgMDg=="
+  "attestation_sig": "vp7Jd5Ul8RuVj0muCtVhx+yw1Pcj2ZcQWz+KskQSyM4Jx2/pjVv92MfqqqPJ7KigrGMwdQNs00Xp8V/GH1BFBQ=="
 }

--- a/ichalaunch/data/manifest.json
+++ b/ichalaunch/data/manifest.json
@@ -1,8 +1,8 @@
 {
   "product": "RavenLaunch",
   "schema": 1,
-  "generated_at": "2026-09-04T01:09:12Z",
-  "updated_at": "2026-09-04T01:32:53Z",
+  "generated_at": "2026-09-04T02:06:38Z",
+  "updated_at": "2026-09-04T02:06:38Z",
   "catalogs": {
     "addons": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addons.json",
     "addon_tips": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addon_tips.json",
@@ -18,10 +18,10 @@
   },
   "launcher": {
     "id": "ichalaunch",
-    "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.3/IchaLaunch.exe",
-    "version": "1.6.3",
-    "sha256": "822a0b0a12a3fc9014df7e9afd33f7f6cdba70518ed54305c6588e4dd107c665",
-    "size": 277522639
+    "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.4/IchaLaunch.exe",
+    "version": "1.6.4",
+    "sha256": "84e4282372fdc7cceb4818b3a69498f5a15ffba46342f23b5fc40b6dc72e38d8",
+    "size": 277550961
   },
   "news": {
     "url": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/news.json"

--- a/ichalaunch/data/manifest.json.sig
+++ b/ichalaunch/data/manifest.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "y7gCK1yz7WawJsbHFKJ9fEttafGjLj9UQFcsussMizTTnfZB9A4juJUMUI0asTIieuGpUFTnSjf2Kik4Tv9yAw==",
+  "sig": "im1TNYDWrui8qhF0NcGqaC2AQ0OsuyFjigj/EwogK0oyQXAsu5FTOwVVCANY0df67pBzYAcw+5y4kh084MAMBQ==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "9a80be89f812c369876eebf394f8ff3378bff9bd31080f41a782f2944350c7a5"
+    "sha256": "cee7dca9e499830dab24ed946d6853a238e404eb7789be17a4fa5a900b6027e4"
   },
-  "attestation_sig": "wy0nKDo6ww326NaKtbsvmt8oJ78lX6TDjzGQnn9gF2nq+4yau38GiaZqVY3afLLAJcix2lDJHkQ0+BfH8ZSYDw=="
+  "attestation_sig": "jxSE9JcPmqWQ7iwW/j/MRQjCMz0qM3makkPQLd5WdzgFE6e5ubCaHMfDze5FanZdSa8qHCKkEJl7Og1F8MDDBw=="
 }

--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -1452,11 +1452,11 @@
     "name": "Raven Launcher",
     "source": {
       "type": "raw",
-      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.3/IchaLaunch.exe",
+      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.4/IchaLaunch.exe",
       "filename": "IchaLaunch.exe",
-      "sha256": "822a0b0a12a3fc9014df7e9afd33f7f6cdba70518ed54305c6588e4dd107c665",
-      "version": "1.6.3",
-      "size": 277522639
+      "sha256": "84e4282372fdc7cceb4818b3a69498f5a15ffba46342f23b5fc40b6dc72e38d8",
+      "version": "1.6.4",
+      "size": 277550961
     }
   }
 ]

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "eqeHcg180GDBABjI40wfyBbE0yZjtVzqcbvd0HZlKoea78tBRy6brJt88xaJttDTBtOf+SBXiL9N+lE3C3uGBA==",
+  "sig": "JSfmVzJImyBU0o5pn9QhWv3FBf33H1GZ+RqAnocnxgT+ZVCjNJqBOdFlRCF60IWVQzBWayBz+il3ANOpUm7BAA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "b4e6f617dd3890ddb91ce0524c8b78ce71b6ab0be1db545d6457daf2647ac8a1"
+    "sha256": "3ffacc847acf9ec36457e12bc88dd775c018d3efbd6d2db5ef0e72cf167b0d70"
   },
-  "attestation_sig": "ST30JGFiU3e7myeB6Ml9TUWW4kCbTExKloJNYPvQngNwGgNytzHQqWE67AFpkkwfCZ/UOyjAUHMOLjtPwhx6Aw=="
+  "attestation_sig": "V0A3kLlk5vUyzAkjfDXM66YUIQA58fQHTMDVXxO1kKhRoJNXFT4+AQPtrC5ZFz6/ntquHKhaU0bjeZICOPMhAA=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong at `ichalaunch/data/<name>.sig` beside the JSON.
- Merge JSON + `.sig` together.
- Signing keys stay on the maintainer machine and never enter CI.
- After merge, publish to the CDN / update server: `python tools/publish_cdn.py --catalogs`
