### PR TITLE
Repin launcher update to 1.6.3 (deliberate rollback: 1.6.4 pulled)

### DIFF
--- a/ichalaunch/data/manifest.json
+++ b/ichalaunch/data/manifest.json
@@ -2,7 +2,7 @@
   "product": "RavenLaunch",
   "schema": 1,
   "generated_at": "2026-09-04T02:06:38Z",
-  "updated_at": "2026-09-04T02:06:38Z",
+  "updated_at": "2026-09-04T02:17:55Z",
   "catalogs": {
     "addons": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addons.json",
     "addon_tips": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addon_tips.json",
@@ -18,10 +18,10 @@
   },
   "launcher": {
     "id": "ichalaunch",
-    "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.4/IchaLaunch.exe",
-    "version": "1.6.4",
-    "sha256": "84e4282372fdc7cceb4818b3a69498f5a15ffba46342f23b5fc40b6dc72e38d8",
-    "size": 277550961
+    "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.3/IchaLaunch.exe",
+    "version": "1.6.3",
+    "sha256": "822a0b0a12a3fc9014df7e9afd33f7f6cdba70518ed54305c6588e4dd107c665",
+    "size": 277522639
   },
   "news": {
     "url": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/news.json"

--- a/ichalaunch/data/manifest.json.sig
+++ b/ichalaunch/data/manifest.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "im1TNYDWrui8qhF0NcGqaC2AQ0OsuyFjigj/EwogK0oyQXAsu5FTOwVVCANY0df67pBzYAcw+5y4kh084MAMBQ==",
+  "sig": "nh0Sb7Ud4vgHE6ld7GC4kYYFgJBevaRxzqX4O37gid6w+bpMU5n/g0KCVE34/OP4z+xN7nvkiFM/7nbbmCeNDw==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "cee7dca9e499830dab24ed946d6853a238e404eb7789be17a4fa5a900b6027e4"
+    "sha256": "bab2c8d77913424475a19fdeff46d0f26f4937041df5afd84ee7cef5f983c86a"
   },
-  "attestation_sig": "jxSE9JcPmqWQ7iwW/j/MRQjCMz0qM3makkPQLd5WdzgFE6e5ubCaHMfDze5FanZdSa8qHCKkEJl7Og1F8MDDBw=="
+  "attestation_sig": "Vk2amfRjwk/YzLwESo5I9yvEpU3yILUKvYsbgl3vS9jUmWZKjcNId+yCMFyG4T1+ymqA9mo/0AZlp5dp1tCPCw=="
 }

--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -1452,11 +1452,11 @@
     "name": "Raven Launcher",
     "source": {
       "type": "raw",
-      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.4/IchaLaunch.exe",
+      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.3/IchaLaunch.exe",
       "filename": "IchaLaunch.exe",
-      "sha256": "84e4282372fdc7cceb4818b3a69498f5a15ffba46342f23b5fc40b6dc72e38d8",
-      "version": "1.6.4",
-      "size": 277550961
+      "sha256": "822a0b0a12a3fc9014df7e9afd33f7f6cdba70518ed54305c6588e4dd107c665",
+      "version": "1.6.3",
+      "size": 277522639
     }
   }
 ]

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "JSfmVzJImyBU0o5pn9QhWv3FBf33H1GZ+RqAnocnxgT+ZVCjNJqBOdFlRCF60IWVQzBWayBz+il3ANOpUm7BAA==",
+  "sig": "eqeHcg180GDBABjI40wfyBbE0yZjtVzqcbvd0HZlKoea78tBRy6brJt88xaJttDTBtOf+SBXiL9N+lE3C3uGBA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "3ffacc847acf9ec36457e12bc88dd775c018d3efbd6d2db5ef0e72cf167b0d70"
+    "sha256": "b4e6f617dd3890ddb91ce0524c8b78ce71b6ab0be1db545d6457daf2647ac8a1"
   },
-  "attestation_sig": "V0A3kLlk5vUyzAkjfDXM66YUIQA58fQHTMDVXxO1kKhRoJNXFT4+AQPtrC5ZFz6/ntquHKhaU0bjeZICOPMhAA=="
+  "attestation_sig": "ST30JGFiU3e7myeB6Ml9TUWW4kCbTExKloJNYPvQngNwGgNytzHQqWE67AFpkkwfCZ/UOyjAUHMOLjtPwhx6Aw=="
 }


### PR DESCRIPTION
Deliberate rollback of the launcher update pin to **1.6.3** (`822a0b0a12a3…`, 277,522,639 bytes).

v1.6.4 was pulled tonight because the 1.6.3→1.6.4 self-update corrupts installs; its release .sig no longer exists, so clients offered 1.6.4 fail closed. mods.json + manifest.json are re-signed over LF bytes. The anti-rollback guards were consciously bypassed for this one run (guard code untouched).