### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/manifest.json
+++ b/ichalaunch/data/manifest.json
@@ -1,13 +1,13 @@
 {
   "product": "RavenLaunch",
   "schema": 1,
-  "generated_at": "2026-09-04T02:06:38Z",
-  "updated_at": "2026-09-04T02:17:55Z",
+  "generated_at": "2026-09-04T19:33:38Z",
+  "updated_at": "2026-09-04T19:33:38Z",
   "catalogs": {
-    "addons": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addons.json",
-    "addon_tips": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addon_tips.json",
-    "home_art": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/home_art.json",
-    "mods": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/mods.json",
+    "addons": "https://download.ravencraft.io/ichalaunch/data/addons.json",
+    "addon_tips": "https://download.ravencraft.io/ichalaunch/data/addon_tips.json",
+    "home_art": "https://download.ravencraft.io/ichalaunch/data/home_art.json",
+    "mods": "https://download.ravencraft.io/ichalaunch/data/mods.json",
     "client_manifest": "https://download.ravencraft.io/ichalaunch/data/client_manifest.json"
   },
   "client_zip": {
@@ -18,12 +18,12 @@
   },
   "launcher": {
     "id": "ichalaunch",
-    "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.3/IchaLaunch.exe",
-    "version": "1.6.3",
-    "sha256": "822a0b0a12a3fc9014df7e9afd33f7f6cdba70518ed54305c6588e4dd107c665",
-    "size": 277522639
+    "url": "https://download.ravencraft.io/IchaLaunch.exe",
+    "version": "1.6.4",
+    "sha256": "1183140474f68f722fd7c863658c50eb5bd0c0deecb10b68150b1149bef3de35",
+    "size": 277591617
   },
   "news": {
-    "url": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/news.json"
+    "url": "https://download.ravencraft.io/ichalaunch/data/news.json"
   }
 }

--- a/ichalaunch/data/manifest.json.sig
+++ b/ichalaunch/data/manifest.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "nh0Sb7Ud4vgHE6ld7GC4kYYFgJBevaRxzqX4O37gid6w+bpMU5n/g0KCVE34/OP4z+xN7nvkiFM/7nbbmCeNDw==",
+  "sig": "+egCK0BSz5uqQcFFvNpvbYIMk5qusjNXh9aFdWDxn59gZKyKfILa2Ugyfa3j4xgxoWBV0dO9h3nD47GeNan7Cg==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "bab2c8d77913424475a19fdeff46d0f26f4937041df5afd84ee7cef5f983c86a"
+    "sha256": "efdb94ea5925f6936072fe82c53bf00de223b9b3bd47c65af916ba6fd8782e43"
   },
-  "attestation_sig": "Vk2amfRjwk/YzLwESo5I9yvEpU3yILUKvYsbgl3vS9jUmWZKjcNId+yCMFyG4T1+ymqA9mo/0AZlp5dp1tCPCw=="
+  "attestation_sig": "JqF44cF97K5N7B7mKLzc9FdiPyS6hX12lHUMbuCE3vsOAczkqsKIvtRPKQt3zX4F09fEotWiO+FdGjOeqam1BQ=="
 }

--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -345,8 +345,8 @@
       "type": "github_release_latest",
       "repo": "brues-code/ClassicAPI",
       "asset_contains": "ClassicAPI.dll",
-      "sha256": "a3864f78fc90720a8143972f05d64caa0edfa572a94cc0149d7683ad4736b8ba",
-      "pinned_tag": "v1.13.3"
+      "sha256": "0c0d3887920d05589b76f52b003a7a671d902212e6c1c6bcd50fa994553686ef",
+      "pinned_tag": "v1.13.4"
     },
     "files": [
       {
@@ -1452,11 +1452,11 @@
     "name": "Raven Launcher",
     "source": {
       "type": "raw",
-      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.3/IchaLaunch.exe",
+      "url": "https://download.ravencraft.io/IchaLaunch.exe",
       "filename": "IchaLaunch.exe",
-      "sha256": "822a0b0a12a3fc9014df7e9afd33f7f6cdba70518ed54305c6588e4dd107c665",
-      "version": "1.6.3",
-      "size": 277522639
+      "sha256": "1183140474f68f722fd7c863658c50eb5bd0c0deecb10b68150b1149bef3de35",
+      "version": "1.6.4",
+      "size": 277591617
     }
   }
 ]

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "eqeHcg180GDBABjI40wfyBbE0yZjtVzqcbvd0HZlKoea78tBRy6brJt88xaJttDTBtOf+SBXiL9N+lE3C3uGBA==",
+  "sig": "z/vf+DmqjMpya39DQU9JajXwkPEyWFkNHG9eUvTgfUa0wYG/4zbFSATLHuOfozFf4q3kDxA2/e6h0e2pA28+CA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "b4e6f617dd3890ddb91ce0524c8b78ce71b6ab0be1db545d6457daf2647ac8a1"
+    "sha256": "08354c50f5de299b39ec48e4e44f86637f08f5f148b74c042be918247e5c55e4"
   },
-  "attestation_sig": "ST30JGFiU3e7myeB6Ml9TUWW4kCbTExKloJNYPvQngNwGgNytzHQqWE67AFpkkwfCZ/UOyjAUHMOLjtPwhx6Aw=="
+  "attestation_sig": "UXUEB+1S45RH0gstbAxEUN/YJ2VekPFD2JlvcHB44SZSM2Hb7R2m6a/Z7MEyb+OcFvg5RKjEsvV/elnnnB5YDw=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong at `ichalaunch/data/<name>.sig` beside the JSON.
- Merge JSON + `.sig` together.
- Signing keys stay on the maintainer machine and never enter CI.
- After merge, publish to the CDN / update server: `python tools/publish_cdn.py --catalogs`
