### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/manifest.json
+++ b/ichalaunch/data/manifest.json
@@ -1,13 +1,13 @@
 {
   "product": "RavenLaunch",
   "schema": 1,
-  "generated_at": "2026-09-04T02:06:38Z",
-  "updated_at": "2026-09-04T02:17:55Z",
+  "generated_at": "2026-09-04T22:40:00Z",
+  "updated_at": "2026-09-04T22:40:00Z",
   "catalogs": {
-    "addons": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addons.json",
-    "addon_tips": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addon_tips.json",
-    "home_art": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/home_art.json",
-    "mods": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/mods.json",
+    "addons": "https://download.ravencraft.io/ichalaunch/data/addons.json",
+    "addon_tips": "https://download.ravencraft.io/ichalaunch/data/addon_tips.json",
+    "home_art": "https://download.ravencraft.io/ichalaunch/data/home_art.json",
+    "mods": "https://download.ravencraft.io/ichalaunch/data/mods.json",
     "client_manifest": "https://download.ravencraft.io/ichalaunch/data/client_manifest.json"
   },
   "client_zip": {
@@ -18,12 +18,12 @@
   },
   "launcher": {
     "id": "ichalaunch",
-    "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.3/IchaLaunch.exe",
-    "version": "1.6.3",
-    "sha256": "822a0b0a12a3fc9014df7e9afd33f7f6cdba70518ed54305c6588e4dd107c665",
-    "size": 277522639
+    "url": "https://download.ravencraft.io/IchaLaunch.exe",
+    "version": "1.6.4",
+    "sha256": "7d7e48a22f189c27c9401d52ca9eeab2f885b94202fed8ef6b1f771047559768",
+    "size": 277608242
   },
   "news": {
-    "url": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/news.json"
+    "url": "https://download.ravencraft.io/ichalaunch/data/news.json"
   }
 }

--- a/ichalaunch/data/manifest.json.sig
+++ b/ichalaunch/data/manifest.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "nh0Sb7Ud4vgHE6ld7GC4kYYFgJBevaRxzqX4O37gid6w+bpMU5n/g0KCVE34/OP4z+xN7nvkiFM/7nbbmCeNDw==",
+  "sig": "aDo921FXkWppkvuYwIMfSC6DuxgXwQT6KpCI1dmo7sKiDfSVxNrgOh7Tcv7xXR22FjifVQagmNzprYOaZGvwCw==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "bab2c8d77913424475a19fdeff46d0f26f4937041df5afd84ee7cef5f983c86a"
+    "sha256": "38fc7298a271ca77209a84b3bdc5369d44d404bc4a58081e815b6d4b76d1c8e3"
   },
-  "attestation_sig": "Vk2amfRjwk/YzLwESo5I9yvEpU3yILUKvYsbgl3vS9jUmWZKjcNId+yCMFyG4T1+ymqA9mo/0AZlp5dp1tCPCw=="
+  "attestation_sig": "zV1IKdb6aoVuxBH9oxWZUdUCXDT0Np56uScUNFwnFwjEvBC3wWQ2OMRNqN7FVmY4gwrbis5VE08EkvqiOtMYCQ=="
 }

--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -345,8 +345,8 @@
       "type": "github_release_latest",
       "repo": "brues-code/ClassicAPI",
       "asset_contains": "ClassicAPI.dll",
-      "sha256": "a3864f78fc90720a8143972f05d64caa0edfa572a94cc0149d7683ad4736b8ba",
-      "pinned_tag": "v1.13.3"
+      "sha256": "0c0d3887920d05589b76f52b003a7a671d902212e6c1c6bcd50fa994553686ef",
+      "pinned_tag": "v1.13.4"
     },
     "files": [
       {
@@ -1452,11 +1452,11 @@
     "name": "Raven Launcher",
     "source": {
       "type": "raw",
-      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.3/IchaLaunch.exe",
+      "url": "https://download.ravencraft.io/IchaLaunch.exe",
       "filename": "IchaLaunch.exe",
-      "sha256": "822a0b0a12a3fc9014df7e9afd33f7f6cdba70518ed54305c6588e4dd107c665",
-      "version": "1.6.3",
-      "size": 277522639
+      "sha256": "7d7e48a22f189c27c9401d52ca9eeab2f885b94202fed8ef6b1f771047559768",
+      "version": "1.6.4",
+      "size": 277608242
     }
   }
 ]

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "eqeHcg180GDBABjI40wfyBbE0yZjtVzqcbvd0HZlKoea78tBRy6brJt88xaJttDTBtOf+SBXiL9N+lE3C3uGBA==",
+  "sig": "vNEHMoVzRe0gcvMVBOW2Xt4+G9J0lY4aWBzSUdo91Hwc13H/TP53s/caD3+IYtcPT+VaEwIKT6x+tPdjoZ98DQ==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "b4e6f617dd3890ddb91ce0524c8b78ce71b6ab0be1db545d6457daf2647ac8a1"
+    "sha256": "d95a370c1ea4b1dfd6e82ecb982cc7ac12c9e1d9e4773ca1655ae5e2bfefbe36"
   },
-  "attestation_sig": "ST30JGFiU3e7myeB6Ml9TUWW4kCbTExKloJNYPvQngNwGgNytzHQqWE67AFpkkwfCZ/UOyjAUHMOLjtPwhx6Aw=="
+  "attestation_sig": "SLpkV1xu5x0hIDGjCAUsLHE/jNzv4kGv3HohjDLfYppN/h2gjYSktRsHhR9T/jcM7jUv8sFNsvSmnIidWJ1qAw=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong at `ichalaunch/data/<name>.sig` beside the JSON.
- Merge JSON + `.sig` together.
- Signing keys stay on the maintainer machine and never enter CI.
- After merge, publish to the CDN / update server: `python tools/publish_cdn.py --catalogs`
