### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/manifest.json
+++ b/ichalaunch/data/manifest.json
@@ -1,14 +1,15 @@
 {
   "product": "RavenLaunch",
   "schema": 1,
-  "generated_at": "2026-09-04T22:40:00Z",
-  "updated_at": "2026-09-04T22:40:00Z",
+  "generated_at": "2026-09-05T16:44:25Z",
+  "updated_at": "2026-09-05T16:44:25Z",
   "catalogs": {
     "addons": "https://download.ravencraft.io/ichalaunch/data/addons.json",
     "addon_tips": "https://download.ravencraft.io/ichalaunch/data/addon_tips.json",
     "home_art": "https://download.ravencraft.io/ichalaunch/data/home_art.json",
     "mods": "https://download.ravencraft.io/ichalaunch/data/mods.json",
-    "client_manifest": "https://download.ravencraft.io/ichalaunch/data/client_manifest.json"
+    "client_manifest": "https://download.ravencraft.io/ichalaunch/data/client_manifest.json",
+    "client_inner": "https://download.ravencraft.io/ichalaunch/data/client_inner.json"
   },
   "client_zip": {
     "url": "https://download.ravencraft.io/RavenCraft.zip",
@@ -19,9 +20,9 @@
   "launcher": {
     "id": "ichalaunch",
     "url": "https://download.ravencraft.io/IchaLaunch.exe",
-    "version": "1.6.4",
-    "sha256": "7d7e48a22f189c27c9401d52ca9eeab2f885b94202fed8ef6b1f771047559768",
-    "size": 277608242
+    "version": "1.6.5",
+    "sha256": "6e3dca53cc830931512f9769aeb536f87a1f5ddce58af81b0552c33d57193180",
+    "size": 280469362
   },
   "news": {
     "url": "https://download.ravencraft.io/ichalaunch/data/news.json"

--- a/ichalaunch/data/manifest.json.sig
+++ b/ichalaunch/data/manifest.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "aDo921FXkWppkvuYwIMfSC6DuxgXwQT6KpCI1dmo7sKiDfSVxNrgOh7Tcv7xXR22FjifVQagmNzprYOaZGvwCw==",
+  "sig": "V0meMiCjb6YgdSF7sR3SEEjzq3ahmoEe919CVYQdVH1ndSnX64ov36pXaquGIYXE0lbbwt9XJVzxdKp65S8LCA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "38fc7298a271ca77209a84b3bdc5369d44d404bc4a58081e815b6d4b76d1c8e3"
+    "sha256": "a4eaf2b6933d55c6ac0b99c45706ff8b65a810ae9a7e418327f6c2740bb204ef"
   },
-  "attestation_sig": "zV1IKdb6aoVuxBH9oxWZUdUCXDT0Np56uScUNFwnFwjEvBC3wWQ2OMRNqN7FVmY4gwrbis5VE08EkvqiOtMYCQ=="
+  "attestation_sig": "0jsYcC1JBevNI7S+Nv/cQvYdQq54W5od3x9dLjK00m8irTpNRhn5zR/UCNioEx6tsHTY7YrbCPwaEpO1jv5zCw=="
 }

--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -1454,9 +1454,9 @@
       "type": "raw",
       "url": "https://download.ravencraft.io/IchaLaunch.exe",
       "filename": "IchaLaunch.exe",
-      "sha256": "7d7e48a22f189c27c9401d52ca9eeab2f885b94202fed8ef6b1f771047559768",
-      "version": "1.6.4",
-      "size": 277608242
+      "sha256": "6e3dca53cc830931512f9769aeb536f87a1f5ddce58af81b0552c33d57193180",
+      "version": "1.6.5",
+      "size": 280469362
     }
   }
 ]

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "vNEHMoVzRe0gcvMVBOW2Xt4+G9J0lY4aWBzSUdo91Hwc13H/TP53s/caD3+IYtcPT+VaEwIKT6x+tPdjoZ98DQ==",
+  "sig": "MsfPzpWKnuVsZO9PgF51OFRORwQQgTV8xJzqw+8/wZ+2De7Pw6JjW0KR13aqfvbXDC1X2iY7WtnWoW8VBJt5DA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "d95a370c1ea4b1dfd6e82ecb982cc7ac12c9e1d9e4773ca1655ae5e2bfefbe36"
+    "sha256": "690e20b67a9ea398e5260f9e666a216659582d88aa97888746f91852cc02f50d"
   },
-  "attestation_sig": "SLpkV1xu5x0hIDGjCAUsLHE/jNzv4kGv3HohjDLfYppN/h2gjYSktRsHhR9T/jcM7jUv8sFNsvSmnIidWJ1qAw=="
+  "attestation_sig": "WmsOjqZN+kulVC8qIpI1HF2eTsW3xYYXG6Y9Ao04XdWx9KQYiSSByyY8Kb2ZGDLBShjizUgiAC/44mTArubgCw=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong at `ichalaunch/data/<name>.sig` beside the JSON.
- Merge JSON + `.sig` together.
- Signing keys stay on the maintainer machine and never enter CI.
- After merge, publish to the CDN / update server: `python tools/publish_cdn.py --catalogs`
