### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/manifest.json
+++ b/ichalaunch/data/manifest.json
@@ -1,8 +1,8 @@
 {
   "product": "RavenLaunch",
   "schema": 1,
-  "generated_at": "2026-09-05T16:44:25Z",
-  "updated_at": "2026-09-05T16:44:25Z",
+  "generated_at": "2026-09-06T12:59:40Z",
+  "updated_at": "2026-09-06T12:59:40Z",
   "catalogs": {
     "addons": "https://download.ravencraft.io/ichalaunch/data/addons.json",
     "addon_tips": "https://download.ravencraft.io/ichalaunch/data/addon_tips.json",
@@ -20,9 +20,53 @@
   "launcher": {
     "id": "ichalaunch",
     "url": "https://download.ravencraft.io/IchaLaunch.exe",
-    "version": "1.6.5",
-    "sha256": "6e3dca53cc830931512f9769aeb536f87a1f5ddce58af81b0552c33d57193180",
-    "size": 280469362
+    "version": "1.6.6",
+    "sha256": "937de6f86b4fe0db4aa7b9b5b8bcff7240e0754792ab710045680bee1e6a7095",
+    "size": 55363433,
+    "platforms": {
+      "windows": {
+        "type": "raw",
+        "url": "https://download.ravencraft.io/IchaLaunch.exe",
+        "filename": "IchaLaunch.exe",
+        "sha256": "937de6f86b4fe0db4aa7b9b5b8bcff7240e0754792ab710045680bee1e6a7095",
+        "version": "1.6.6",
+        "size": 55363433
+      },
+      "linux": {
+        "type": "raw",
+        "url": "https://download.ravencraft.io/IchaLaunch-linux-x86_64",
+        "filename": "IchaLaunch-linux-x86_64",
+        "sha256": "ea92f57f1c700987db186404df7e107e9bc45ad962a1155700d8991f5b26a1e3",
+        "version": "1.6.6",
+        "size": 67906816
+      }
+    },
+    "downloads": {
+      "windows_exe": {
+        "type": "raw",
+        "url": "https://download.ravencraft.io/IchaLaunch.exe",
+        "filename": "IchaLaunch.exe",
+        "sha256": "937de6f86b4fe0db4aa7b9b5b8bcff7240e0754792ab710045680bee1e6a7095",
+        "version": "1.6.6",
+        "size": 55363433
+      },
+      "linux_appimage": {
+        "type": "raw",
+        "url": "https://download.ravencraft.io/Raven_Launcher-1.6.6-x86_64.AppImage",
+        "filename": "Raven_Launcher-1.6.6-x86_64.AppImage",
+        "sha256": "96d2a6657c8cd174853373b3314d6cc748bca0124d0727d587ba015bdd05ab9f",
+        "version": "1.6.6",
+        "size": 68434424
+      },
+      "linux_tarball": {
+        "type": "raw",
+        "url": "https://download.ravencraft.io/IchaLaunch-1.6.6-linux-x86_64.tar.gz",
+        "filename": "IchaLaunch-1.6.6-linux-x86_64.tar.gz",
+        "sha256": "5ba399b96b0b662536dc532cfc7380426614dd35c52d7c432fe67f5d7acc0920",
+        "version": "1.6.6",
+        "size": 67278928
+      }
+    }
   },
   "news": {
     "url": "https://download.ravencraft.io/ichalaunch/data/news.json"

--- a/ichalaunch/data/manifest.json.sig
+++ b/ichalaunch/data/manifest.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "V0meMiCjb6YgdSF7sR3SEEjzq3ahmoEe919CVYQdVH1ndSnX64ov36pXaquGIYXE0lbbwt9XJVzxdKp65S8LCA==",
+  "sig": "tKUSWdD6q4W0TwiN9XQTbLOP3NXpav7Zz1OTWcKwn8rNgOs4JfP920tdsDlETeCaFefhEgXz0saCldFqqKWyBg==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "a4eaf2b6933d55c6ac0b99c45706ff8b65a810ae9a7e418327f6c2740bb204ef"
+    "sha256": "0c1fef8ead80864280f7934bee9aa2e2588425a20a7ff93e17d16741b012a61f"
   },
-  "attestation_sig": "0jsYcC1JBevNI7S+Nv/cQvYdQq54W5od3x9dLjK00m8irTpNRhn5zR/UCNioEx6tsHTY7YrbCPwaEpO1jv5zCw=="
+  "attestation_sig": "ftnHC7F2WEVYeYmlIFC7p61lM9lQjpukH4MV/urLHq0RAKuMtddiOrdJt7JhMaIG6rx/IqwgDrVarNpC/hkOAQ=="
 }

--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -345,8 +345,8 @@
       "type": "github_release_latest",
       "repo": "brues-code/ClassicAPI",
       "asset_contains": "ClassicAPI.dll",
-      "sha256": "0c0d3887920d05589b76f52b003a7a671d902212e6c1c6bcd50fa994553686ef",
-      "pinned_tag": "v1.13.4"
+      "sha256": "367088ccbd6486417b96b67a5384f0bc921c3174b61b5364003d8a365689f43d",
+      "pinned_tag": "v1.14.0"
     },
     "files": [
       {
@@ -1420,19 +1420,19 @@
       ]
     },
     "source": {
-      "type": "github_release",
-      "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/ichalaunch-discord-1.3/ichalaunch_discord.dll",
+      "type": "raw",
+      "url": "https://download.ravencraft.io/ichalaunch/discord/1.6/ichalaunch_discord.dll",
       "filename": "ichalaunch_discord.dll",
-      "sha256": "fdfdb9c25c492de2196e9884bf14b17e959332029eef973e044e2a73dba6202f",
-      "dest_sha256": "fdfdb9c25c492de2196e9884bf14b17e959332029eef973e044e2a73dba6202f",
-      "version": "1.3",
+      "sha256": "076c530e19c2a67b420b22ba58acc63a89662cc60e043c6ef352c7b01c71df83",
+      "dest_sha256": "076c530e19c2a67b420b22ba58acc63a89662cc60e043c6ef352c7b01c71df83",
+      "version": "1.6",
       "path": "tools/_discord_presence/out/ichalaunch_discord.dll"
     },
     "files": [
       {
         "match": "ichalaunch_discord.dll",
         "destination": "ichalaunch_discord.dll",
-        "sha256": "fdfdb9c25c492de2196e9884bf14b17e959332029eef973e044e2a73dba6202f"
+        "sha256": "076c530e19c2a67b420b22ba58acc63a89662cc60e043c6ef352c7b01c71df83"
       }
     ],
     "dlls_txt": {
@@ -1454,9 +1454,53 @@
       "type": "raw",
       "url": "https://download.ravencraft.io/IchaLaunch.exe",
       "filename": "IchaLaunch.exe",
-      "sha256": "6e3dca53cc830931512f9769aeb536f87a1f5ddce58af81b0552c33d57193180",
-      "version": "1.6.5",
-      "size": 280469362
+      "sha256": "937de6f86b4fe0db4aa7b9b5b8bcff7240e0754792ab710045680bee1e6a7095",
+      "version": "1.6.6",
+      "size": 55363433,
+      "platforms": {
+        "windows": {
+          "type": "raw",
+          "url": "https://download.ravencraft.io/IchaLaunch.exe",
+          "filename": "IchaLaunch.exe",
+          "sha256": "937de6f86b4fe0db4aa7b9b5b8bcff7240e0754792ab710045680bee1e6a7095",
+          "version": "1.6.6",
+          "size": 55363433
+        },
+        "linux": {
+          "type": "raw",
+          "url": "https://download.ravencraft.io/IchaLaunch-linux-x86_64",
+          "filename": "IchaLaunch-linux-x86_64",
+          "sha256": "ea92f57f1c700987db186404df7e107e9bc45ad962a1155700d8991f5b26a1e3",
+          "version": "1.6.6",
+          "size": 67906816
+        }
+      },
+      "downloads": {
+        "windows_exe": {
+          "type": "raw",
+          "url": "https://download.ravencraft.io/IchaLaunch.exe",
+          "filename": "IchaLaunch.exe",
+          "sha256": "937de6f86b4fe0db4aa7b9b5b8bcff7240e0754792ab710045680bee1e6a7095",
+          "version": "1.6.6",
+          "size": 55363433
+        },
+        "linux_appimage": {
+          "type": "raw",
+          "url": "https://download.ravencraft.io/Raven_Launcher-1.6.6-x86_64.AppImage",
+          "filename": "Raven_Launcher-1.6.6-x86_64.AppImage",
+          "sha256": "96d2a6657c8cd174853373b3314d6cc748bca0124d0727d587ba015bdd05ab9f",
+          "version": "1.6.6",
+          "size": 68434424
+        },
+        "linux_tarball": {
+          "type": "raw",
+          "url": "https://download.ravencraft.io/IchaLaunch-1.6.6-linux-x86_64.tar.gz",
+          "filename": "IchaLaunch-1.6.6-linux-x86_64.tar.gz",
+          "sha256": "5ba399b96b0b662536dc532cfc7380426614dd35c52d7c432fe67f5d7acc0920",
+          "version": "1.6.6",
+          "size": 67278928
+        }
+      }
     }
   }
 ]

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "MsfPzpWKnuVsZO9PgF51OFRORwQQgTV8xJzqw+8/wZ+2De7Pw6JjW0KR13aqfvbXDC1X2iY7WtnWoW8VBJt5DA==",
+  "sig": "VXshmr7XOyPEzrKh2zGBIdNKgUwC/w0Q1CbS7uTV3N0ACYX2q9NY8KfcVOLb53r+v0wyOrb+7IwtkfsPZWW+Aw==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "690e20b67a9ea398e5260f9e666a216659582d88aa97888746f91852cc02f50d"
+    "sha256": "1615924522f628223fe164d76d4054c16abdb23cce22a923ff394958836bcfe5"
   },
-  "attestation_sig": "WmsOjqZN+kulVC8qIpI1HF2eTsW3xYYXG6Y9Ao04XdWx9KQYiSSByyY8Kb2ZGDLBShjizUgiAC/44mTArubgCw=="
+  "attestation_sig": "Io9p2ynOiFjYVrNCi3m+cd3NL0Nn3m5WzYy95o51yNcE7awp3YlteEl36hUqpE1gAtQMBLDYwgdA0T64/RUaBg=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong at `ichalaunch/data/<name>.sig` beside the JSON.
- Merge JSON + `.sig` together.
- Signing keys stay on the maintainer machine and never enter CI.
- After merge, publish to the CDN / update server: `python tools/publish_cdn.py --catalogs`
