### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/manifest.json
+++ b/ichalaunch/data/manifest.json
@@ -1,13 +1,13 @@
 {
   "product": "RavenLaunch",
   "schema": 1,
-  "generated_at": "2026-09-07T13:27:51Z",
-  "updated_at": "2026-09-07T13:27:51Z",
+  "generated_at": "2026-09-07T13:33:20Z",
+  "updated_at": "2026-09-07T13:33:20Z",
   "catalogs": {
-    "addons": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addons.json",
-    "addon_tips": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addon_tips.json",
-    "home_art": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/home_art.json",
-    "mods": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/mods.json",
+    "addons": "https://download.ravencraft.io/ichalaunch/data/addons.json",
+    "addon_tips": "https://download.ravencraft.io/ichalaunch/data/addon_tips.json",
+    "home_art": "https://download.ravencraft.io/ichalaunch/data/home_art.json",
+    "mods": "https://download.ravencraft.io/ichalaunch/data/mods.json",
     "client_manifest": "https://download.ravencraft.io/ichalaunch/data/client_manifest.json",
     "client_inner": "https://download.ravencraft.io/ichalaunch/data/client_inner.json"
   },
@@ -15,12 +15,11 @@
     "url": "https://download.ravencraft.io/RavenCraft.zip",
     "filename": "RavenCraft.zip",
     "sha256": "86059fa229800050bbe066e5ae19f59eb936f10a077a9581596cb879d013e565",
-    "size": 9829040584,
-    "sig_url": "https://download.ravencraft.io/RavenCraft.zip.sig"
+    "size": 9829040584
   },
   "launcher": {
     "id": "ichalaunch",
-    "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.2/IchaLaunch.exe",
+    "url": "https://download.ravencraft.io/IchaLaunch.exe",
     "version": "1.6.6",
     "sha256": "937de6f86b4fe0db4aa7b9b5b8bcff7240e0754792ab710045680bee1e6a7095",
     "size": 55363433,

--- a/ichalaunch/data/manifest.json.sig
+++ b/ichalaunch/data/manifest.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "Z5fBiN4ftMD9cC2moHfyb9B0xG22iVf0FSLqpXYpYdgId89rXHZK5FecaFqaa1wWtXqCF+AIG2PrEQbht6RUDQ==",
+  "sig": "ZxGd29llPL7RQX2Et++1ncsUIPFJ1OZ/+MM/ntsseNGrqt3I1IVdgMaAmTP15VpyAIYXYT9uyBjUzV0K+XluCg==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "768e2f02b152e786f387d77081db53f44f56ff29d4254ea653531c444aa506a0"
+    "sha256": "846f9c792d47d89a75261ed8cc10d477cfaffce558b48b20b609943a5ae195c4"
   },
-  "attestation_sig": "ZrGjvELe7WsCuKov+j7PvpVz1po4mdGA7DT61RFsAuJ1UWbX4SUUnpPWaTkxtVefqfFboHvX5m3gGBLIFKC7AA=="
+  "attestation_sig": "0GJtY84/2GNYNXUYQT9vuGSu44HICviAJQZ79LNYEviJPbKNuQvNOV/vizfZhXrhZdsug0IpEvRhdnk/oOyLAw=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong at `ichalaunch/data/<name>.sig` beside the JSON.
- Merge JSON + `.sig` together.
- Signing keys stay on the maintainer machine and never enter CI.
- After merge, publish to the CDN / update server: `python tools/publish_cdn.py --catalogs`
