### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/manifest.json.sig
+++ b/ichalaunch/data/manifest.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "Z5fBiN4ftMD9cC2moHfyb9B0xG22iVf0FSLqpXYpYdgId89rXHZK5FecaFqaa1wWtXqCF+AIG2PrEQbht6RUDQ==",
+  "sig": "NitPwkGVV/+eyYCiuRHonSMsUV2wd7ygnN9A2NFlpI9BZvmTnYCD3Qxxx6EUdsTI27GRHmbWEfqXBh6Swc5ADQ==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "768e2f02b152e786f387d77081db53f44f56ff29d4254ea653531c444aa506a0"
+    "sha256": "c99b69997a45eb7e96b8269e9ae6c89bcc68134ea08106e1ada28fe2b9dbd344"
   },
-  "attestation_sig": "ZrGjvELe7WsCuKov+j7PvpVz1po4mdGA7DT61RFsAuJ1UWbX4SUUnpPWaTkxtVefqfFboHvX5m3gGBLIFKC7AA=="
+  "attestation_sig": "dSTvohNXYOitxTgHHgPduF667z3owqQuBq6NaIFkI1S+KkOwr+rVV3nvkAoQ1PzLpqixhWSnM+wEoYgQrS/6AA=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong at `ichalaunch/data/<name>.sig` beside the JSON.
- Merge JSON + `.sig` together.
- Signing keys stay on the maintainer machine and never enter CI.
- After merge, publish to the CDN / update server: `python tools/publish_cdn.py --catalogs`
