### PR TITLE
catalog: sync addons+tips hop from Gitea #126 (signed)

### DIFF
--- a/ichalaunch/data/addon_tips.json
+++ b/ichalaunch/data/addon_tips.json
@@ -2,2885 +2,11 @@
   "generated_at": "2026-09-02T01:18:18Z",
   "source": "git-upload-pack",
   "repos": {
-    "shirsig/clean_up": {
-      "default_branch": "master",
-      "sha": "285498f571c445e6ec126165fdeb3ec491575513",
-      "branches": {
-        "master": "285498f571c445e6ec126165fdeb3ec491575513"
-      }
-    },
-    "mcpewpew/bagnon": {
-      "default_branch": "master",
-      "sha": "06ee0b46ebda38470ef60ede699280454a812f97",
-      "branches": {
-        "master": "06ee0b46ebda38470ef60ede699280454a812f97"
-      }
-    },
-    "dyaxler/blizzmo_vanilla": {
-      "default_branch": "master",
-      "sha": "f599a4c80b80ca2eda534d12934aefb90bd52386",
-      "branches": {
-        "master": "f599a4c80b80ca2eda534d12934aefb90bd52386"
-      },
-      "latest_tag": "v0.1"
-    },
-    "road-block/cooldowntimers": {
-      "default_branch": "master",
-      "sha": "c7fca4a1dddabd69c61ee0590a80100707b2bbe6",
-      "branches": {
-        "master": "c7fca4a1dddabd69c61ee0590a80100707b2bbe6"
-      },
-      "latest_tag": "1.3-11200"
-    },
-    "xinleibird/cooldowntimers": {
-      "default_branch": "master",
-      "sha": "6b85a5f452204384b94bd984fc551689822c3229",
-      "branches": {
-        "master": "6b85a5f452204384b94bd984fc551689822c3229"
-      }
-    },
-    "adrianocastro189/destroy-cursor-item": {
-      "default_branch": "main",
-      "sha": "2e653d867768f52de7c69dfebdc4343619eee64d",
-      "branches": {
-        "main": "2e653d867768f52de7c69dfebdc4343619eee64d"
-      },
-      "latest_tag": "1.1.0"
-    },
-    "laytya/engbags": {
-      "default_branch": "main",
-      "sha": "d01c2c2c25cb563390ecbb6ec108a6bc55abb995",
-      "branches": {
-        "main": "d01c2c2c25cb563390ecbb6ec108a6bc55abb995"
-      }
-    },
-    "tolle44/engbags": {
-      "default_branch": "main",
-      "sha": "a73ae68a1b4f9ce0f63260a2a57316603903336b",
-      "branches": {
-        "main": "a73ae68a1b4f9ce0f63260a2a57316603903336b"
-      }
-    },
-    "indiemiao/engbags": {
-      "default_branch": "main",
-      "sha": "a69b533cbc8ef345c1f0ee78262abb12e75af7a6",
-      "branches": {
-        "main": "a69b533cbc8ef345c1f0ee78262abb12e75af7a6"
-      }
-    },
-    "brqje/enginventory": {
-      "default_branch": "master",
-      "sha": "10b1471b51bc3472f4a05a9bb7553646d61b47fe",
-      "branches": {
-        "master": "10b1471b51bc3472f4a05a9bb7553646d61b47fe"
-      }
-    },
-    "indiemiao/enginventory": {
-      "default_branch": "master",
-      "sha": "8ebaf3dee5e1bbd4d819f8f49b66319b0cb6aa80",
-      "branches": {
-        "master": "8ebaf3dee5e1bbd4d819f8f49b66319b0cb6aa80"
-      }
-    },
-    "drepetsky/enginventory": {
-      "default_branch": "master",
-      "sha": "a3f0355d2b52c09ac9d5b30d61e762d7ab70c35a",
-      "branches": {
-        "master": "a3f0355d2b52c09ac9d5b30d61e762d7ab70c35a"
-      }
-    },
-    "laytya/eqcompare-vanilla": {
-      "default_branch": "master",
-      "sha": "6871aa28a2e9fd5cdef743d5debfe333da528b05",
-      "branches": {
-        "master": "6871aa28a2e9fd5cdef743d5debfe333da528b05"
-      },
-      "latest_tag": "v1.5"
-    },
-    "trangoul/equipcolor": {
-      "default_branch": "main",
-      "sha": "94894163ec7a3aa1717bd8652554273ffe632b9b",
-      "branches": {
-        "main": "94894163ec7a3aa1717bd8652554273ffe632b9b"
-      }
-    },
-    "paokkerkir/equipcolor": {
-      "default_branch": "main",
-      "sha": "e403f1a1e0d97ea6b483c4a3e5714635cc76c3e5",
-      "branches": {
-        "main": "e403f1a1e0d97ea6b483c4a3e5714635cc76c3e5"
-      }
-    },
-    "anzz1/freebagslots": {
-      "default_branch": "master",
-      "sha": "4833907cba903a48442ae7c246ccc2d9036a76e4",
-      "branches": {
-        "master": "4833907cba903a48442ae7c246ccc2d9036a76e4"
-      }
-    },
-    "marcelinevq/gentlegc": {
-      "default_branch": "master",
-      "sha": "a41404979d9919ebb781e02ea6a493ad604ef2cc",
-      "branches": {
-        "master": "a41404979d9919ebb781e02ea6a493ad604ef2cc"
-      }
-    },
-    "jrc13245/gentlegc": {
-      "default_branch": "master",
-      "sha": "15ec914abb726c0acbadca4c77048257d0aecd7f",
-      "branches": {
-        "master": "15ec914abb726c0acbadca4c77048257d0aecd7f"
-      }
-    },
-    "therealfayz/gentlegc": {
-      "default_branch": "master",
-      "sha": "85626006c5c7022057c0ae5ce99db77811172626",
-      "branches": {
-        "master": "85626006c5c7022057c0ae5ce99db77811172626"
-      }
-    },
-    "whtmst/gentlegc": {
-      "default_branch": "master",
-      "sha": "a41404979d9919ebb781e02ea6a493ad604ef2cc",
-      "branches": {
-        "master": "a41404979d9919ebb781e02ea6a493ad604ef2cc"
-      }
-    },
-    "monteo/gfw_feedomatic": {
-      "default_branch": "master",
-      "sha": "2f0586f2fc0efb14ef9d2990056e5822acd97cf8",
-      "branches": {
-        "master": "2f0586f2fc0efb14ef9d2990056e5822acd97cf8"
-      }
-    },
-    "nosrednaski/gfw_feedomatic": {
-      "default_branch": "master",
-      "sha": "b644157b769edc4f2e5afcfd971be1aee6866fd2",
-      "branches": {
-        "master": "b644157b769edc4f2e5afcfd971be1aee6866fd2"
-      }
-    },
-    "goldenpipes/gfw_feedomatic": {
-      "default_branch": "master",
-      "sha": "cd56a92fb7e113e02fd978abd6c698148a6f2e87",
-      "branches": {
-        "master": "cd56a92fb7e113e02fd978abd6c698148a6f2e87"
-      }
-    },
-    "ttcremers/grayautosell": {
-      "default_branch": "master",
-      "sha": "a53ac93bfbe12a1a0b77b588060051e19123697f",
-      "branches": {
-        "master": "a53ac93bfbe12a1a0b77b588060051e19123697f"
-      },
-      "latest_tag": "v0.1.4"
-    },
-    "samahee/grayautosell": {
-      "default_branch": "master",
-      "sha": "7e431551d535fdc57b66721659c107c7b6e2326c",
-      "branches": {
-        "master": "7e431551d535fdc57b66721659c107c7b6e2326c"
-      },
-      "latest_tag": "1.0"
-    },
-    "vatichild/guda": {
-      "default_branch": "main",
-      "sha": "5eba9adcc2767ca40f2f71b1c74a7f84822edef7",
-      "branches": {
-        "main": "5eba9adcc2767ca40f2f71b1c74a7f84822edef7"
-      },
-      "latest_tag": "2.3.2"
-    },
-    "thezephyrsong/guda": {
-      "default_branch": "main",
-      "sha": "cf53686a53115c2020452595c0a02db63510788a",
-      "branches": {
-        "main": "cf53686a53115c2020452595c0a02db63510788a"
-      }
-    },
-    "kameleonuk/guda": {
-      "default_branch": "main",
-      "sha": "e52be32310fa79c7f191f42c4f91fe87e250bc7f",
-      "branches": {
-        "main": "e52be32310fa79c7f191f42c4f91fe87e250bc7f"
-      }
-    },
-    "al3xc1985/guda": {
-      "default_branch": "main",
-      "sha": "f1618b71bddf816bac82d1a0be67bc1417e8ba20",
-      "branches": {
-        "main": "f1618b71bddf816bac82d1a0be67bc1417e8ba20"
-      }
-    },
-    "bretharte89/guda": {
-      "default_branch": "main",
-      "sha": "f1618b71bddf816bac82d1a0be67bc1417e8ba20",
-      "branches": {
-        "main": "f1618b71bddf816bac82d1a0be67bc1417e8ba20"
-      }
-    },
-    "manrades/guda": {
-      "default_branch": "main",
-      "sha": "f1618b71bddf816bac82d1a0be67bc1417e8ba20",
-      "branches": {
-        "main": "f1618b71bddf816bac82d1a0be67bc1417e8ba20"
-      }
-    },
-    "paenthy/guda": {
-      "default_branch": "main",
-      "sha": "c1364abdb83f1419c9e837f248305bfbd61c39ad",
-      "branches": {
-        "main": "c1364abdb83f1419c9e837f248305bfbd61c39ad"
-      }
-    },
-    "ravenofseven/guda": {
-      "default_branch": "main",
-      "sha": "c1364abdb83f1419c9e837f248305bfbd61c39ad",
-      "branches": {
-        "main": "c1364abdb83f1419c9e837f248305bfbd61c39ad"
-      }
-    },
-    "indiemiao/guda": {
-      "default_branch": "main",
-      "sha": "7d0c023a8183242943cd845975a03b5bb2fa7028",
-      "branches": {
-        "main": "7d0c023a8183242943cd845975a03b5bb2fa7028"
-      },
-      "latest_tag": "2.0.9"
-    },
-    "scheffmr/guda": {
-      "default_branch": "main",
-      "sha": "bf83de013863c9bb007fcc1db98165fb4e85808c",
-      "branches": {
-        "main": "bf83de013863c9bb007fcc1db98165fb4e85808c"
-      }
-    },
-    "road-block/guildbank": {
-      "default_branch": "master",
-      "sha": "186dd49ab08936973902216d8a41e2418e2b0cf3",
-      "branches": {
-        "master": "186dd49ab08936973902216d8a41e2418e2b0cf3"
-      },
-      "latest_tag": "2.10-11200"
-    },
-    "jejkas/inventorysale": {
-      "default_branch": "master",
-      "sha": "86242cf1c30e1db2ab509709ad615c1766758cd9",
-      "branches": {
-        "master": "86242cf1c30e1db2ab509709ad615c1766758cd9"
-      }
-    },
-    "kangaroux/inventorysale": {
-      "default_branch": "master",
-      "sha": "1bf5961bff92f9fe0de89e2da94a191582d42ef1",
-      "branches": {
-        "master": "1bf5961bff92f9fe0de89e2da94a191582d42ef1"
-      }
-    },
-    "linae-kronos/itemrackfu": {
-      "default_branch": "master",
-      "sha": "78c032c3c78f6fa326d04ba2381592024ec94135",
-      "branches": {
-        "master": "78c032c3c78f6fa326d04ba2381592024ec94135"
-      }
-    },
-    "balakethelock/itemsplit": {
-      "default_branch": "master",
-      "sha": "51a435e531ec6822af83ef5960e608a77b608572",
-      "branches": {
-        "master": "51a435e531ec6822af83ef5960e608a77b608572"
-      }
-    },
-    "einbaum/keyringopener": {
-      "default_branch": "master",
-      "sha": "40511af0a994ae284f5057e3cfe3bdee8b41b4ae",
-      "branches": {
-        "master": "40511af0a994ae284f5057e3cfe3bdee8b41b4ae"
-      }
-    },
-    "mcpewpew/minimapbuttonbag": {
-      "default_branch": "master",
-      "sha": "a3ae16a352889ec491b8d917297aecb262d0b437",
-      "branches": {
-        "master": "a3ae16a352889ec491b8d917297aecb262d0b437"
-      },
-      "latest_tag": "v0.508"
-    },
-    "deceius/minimapbuttonbag": {
-      "default_branch": "master",
-      "sha": "b2bd0c5277552b7a2ed36bbb18cc3f7bad7e2885",
-      "branches": {
-        "master": "b2bd0c5277552b7a2ed36bbb18cc3f7bad7e2885"
-      },
-      "latest_tag": "v0.508"
-    },
-    "amonra/minimapbuttonbag-turtlewow": {
-      "default_branch": "master",
-      "sha": "410082b5d43a63dad5c0ac23ee30454f1725b775",
-      "branches": {
-        "master": "410082b5d43a63dad5c0ac23ee30454f1725b775"
-      }
-    },
-    "fsuhas/minimapbuttonbag-turtlewow": {
-      "default_branch": "master",
-      "sha": "65dd679c2ae9db41fb2afe54e3db227b1cf674ba",
-      "branches": {
-        "master": "65dd679c2ae9db41fb2afe54e3db227b1cf674ba"
-      },
-      "latest_tag": "v0.508"
-    },
-    "nehswu/minimapbuttonbag-turtlewow": {
-      "default_branch": "master",
-      "sha": "8629d64c329988fdff3db9e221bc1be9ca3d26d1",
-      "branches": {
-        "master": "8629d64c329988fdff3db9e221bc1be9ca3d26d1"
-      },
-      "latest_tag": "v0.508"
-    },
-    "ravenofseven/minimapbuttonbag": {
-      "default_branch": "master",
-      "sha": "a3ae16a352889ec491b8d917297aecb262d0b437",
-      "branches": {
-        "master": "a3ae16a352889ec491b8d917297aecb262d0b437"
-      }
-    },
-    "mrtoffee/minimapbuttonbag-turtlewow": {
-      "default_branch": "master",
-      "sha": "30088bff0861b6773e79bd4e4236a751777f0f31",
-      "branches": {
-        "master": "30088bff0861b6773e79bd4e4236a751777f0f31"
-      }
-    },
-    "asbakdave/minimapbuttonbag-turtlewow": {
-      "default_branch": "master",
-      "sha": "f60670877557999ff400c03f298292b9e0e7fdbd",
-      "branches": {
-        "master": "f60670877557999ff400c03f298292b9e0e7fdbd"
-      },
-      "latest_tag": "v0.508"
-    },
-    "stevensnoeijen/minimapbuttonbag-turtlewow": {
-      "default_branch": "master",
-      "sha": "825268ec882de6651dc8fde1f6f9b8252159292a",
-      "branches": {
-        "master": "825268ec882de6651dc8fde1f6f9b8252159292a"
-      }
-    },
-    "mcpewpew/mrplow": {
-      "default_branch": "master",
-      "sha": "865f76924c37060236ec60a3d7c136637debc6f5",
-      "branches": {
-        "master": "865f76924c37060236ec60a3d7c136637debc6f5"
-      }
-    },
-    "shagu/pfdebug": {
-      "default_branch": "master",
-      "sha": "6f305a9b141cead0d2d141e81dc4e860db3acbbc",
-      "branches": {
-        "master": "6f305a9b141cead0d2d141e81dc4e860db3acbbc"
-      }
-    },
-    "amonra/pfdebug": {
-      "default_branch": "master",
-      "sha": "6f305a9b141cead0d2d141e81dc4e860db3acbbc",
-      "branches": {
-        "master": "6f305a9b141cead0d2d141e81dc4e860db3acbbc"
-      }
-    },
-    "spawnedc/pfdebug": {
-      "default_branch": "master",
-      "sha": "6f305a9b141cead0d2d141e81dc4e860db3acbbc",
-      "branches": {
-        "master": "6f305a9b141cead0d2d141e81dc4e860db3acbbc"
-      }
-    },
-    "refaim/possessions": {
-      "default_branch": "master",
-      "sha": "71be69c850328e2bfdaa6176a295937a210a20b2",
-      "branches": {
-        "master": "71be69c850328e2bfdaa6176a295937a210a20b2"
-      }
-    },
-    "sica42/possessions": {
-      "default_branch": "master",
-      "sha": "71be69c850328e2bfdaa6176a295937a210a20b2",
-      "branches": {
-        "master": "71be69c850328e2bfdaa6176a295937a210a20b2"
-      }
-    },
-    "shagu/shaguinventory": {
-      "default_branch": "master",
-      "sha": "00eeeb2da84d33bb2f51f1a5bda97dc08978772c",
-      "branches": {
-        "master": "00eeeb2da84d33bb2f51f1a5bda97dc08978772c"
-      }
-    },
-    "jembawow/shaguinventory": {
-      "default_branch": "master",
-      "sha": "bc4002eb18bc266607b208cd42af761c0590ee4d",
-      "branches": {
-        "master": "bc4002eb18bc266607b208cd42af761c0590ee4d"
-      }
-    },
-    "refaim/shaguinventory": {
-      "default_branch": "master",
-      "sha": "b27840c425b665a3e8c0c9cd6fe3ddf0f72eeb6e",
-      "branches": {
-        "master": "b27840c425b665a3e8c0c9cd6fe3ddf0f72eeb6e"
-      }
-    },
-    "robs898/shaguinventory": {
-      "default_branch": "master",
-      "sha": "251b678d80dccb972cdde48820e0ff88b583aaaf",
-      "branches": {
-        "master": "251b678d80dccb972cdde48820e0ff88b583aaaf"
-      }
-    },
-    "shirsig/sortbags-vanilla": {
-      "default_branch": "master",
-      "sha": "1b59767ca41749e70d72f2991c27054beebcdfcd",
-      "branches": {
-        "master": "1b59767ca41749e70d72f2991c27054beebcdfcd"
-      }
-    },
-    "refaim/sortbags": {
-      "default_branch": "master",
-      "sha": "d1860047f1cd9ee73de84d96c46cbabb41639c16",
-      "branches": {
-        "master": "d1860047f1cd9ee73de84d96c46cbabb41639c16"
-      }
-    },
-    "liminalwarmth/sortbags-vanilla-fixed": {
-      "default_branch": "master",
-      "sha": "14db91333e15d1b4375918e234f103c86742c471",
-      "branches": {
-        "master": "14db91333e15d1b4375918e234f103c86742c471"
-      }
-    },
-    "otari98/sortbags": {
-      "default_branch": "master",
-      "sha": "ec05747667830b093e5b94d6cf3d9fafc303b42c",
-      "branches": {
-        "master": "ec05747667830b093e5b94d6cf3d9fafc303b42c"
-      }
-    },
-    "avirar/sortbags-vanilla": {
-      "default_branch": "master",
-      "sha": "f3233852a858ccce7b7b1f95e7cd534049d5d79a",
-      "branches": {
-        "master": "f3233852a858ccce7b7b1f95e7cd534049d5d79a"
-      }
-    },
-    "chad90b/sortbags-vanilla": {
-      "default_branch": "master",
-      "sha": "1b59767ca41749e70d72f2991c27054beebcdfcd",
-      "branches": {
-        "master": "1b59767ca41749e70d72f2991c27054beebcdfcd"
-      }
-    },
-    "lioryx/sortbags": {
-      "default_branch": "master",
-      "sha": "1b59767ca41749e70d72f2991c27054beebcdfcd",
-      "branches": {
-        "master": "1b59767ca41749e70d72f2991c27054beebcdfcd"
-      }
-    },
-    "ravenofseven/sortbags-vanilla": {
-      "default_branch": "master",
-      "sha": "1b59767ca41749e70d72f2991c27054beebcdfcd",
-      "branches": {
-        "master": "1b59767ca41749e70d72f2991c27054beebcdfcd"
-      }
-    },
-    "saxxonpike/sortbags": {
-      "default_branch": "master",
-      "sha": "1b59767ca41749e70d72f2991c27054beebcdfcd",
-      "branches": {
-        "master": "1b59767ca41749e70d72f2991c27054beebcdfcd"
-      }
-    },
-    "wasdcabb/sortbags-vanilla": {
-      "default_branch": "master",
-      "sha": "1b59767ca41749e70d72f2991c27054beebcdfcd",
-      "branches": {
-        "master": "1b59767ca41749e70d72f2991c27054beebcdfcd"
-      }
-    },
-    "blehz-be/sortbags-vanilla": {
-      "default_branch": "master",
-      "sha": "8f7bf57d91a2935600cd5857b29237dcdf9718cf",
-      "branches": {
-        "master": "8f7bf57d91a2935600cd5857b29237dcdf9718cf"
-      }
-    },
-    "ftkun/sortbags-vanilla-class-reagents-sorting-": {
-      "default_branch": "master",
-      "sha": "99c3d064cd70319a698b0d56d8d50a853bc163db",
-      "branches": {
-        "master": "99c3d064cd70319a698b0d56d8d50a853bc163db"
-      }
-    },
-    "refaim/soulshardmanager": {
-      "default_branch": "master",
-      "sha": "e2d124d5657a8b00f72218735b6c12137c8f6756",
-      "branches": {
-        "master": "e2d124d5657a8b00f72218735b6c12137c8f6756"
-      }
-    },
-    "otari98/succ-bag": {
-      "default_branch": "master",
-      "sha": "167c34673f34c233720d9c642a2854a6d8f08080",
-      "branches": {
-        "master": "167c34673f34c233720d9c642a2854a6d8f08080"
-      }
-    },
-    "ravenofseven/succ-bag": {
-      "default_branch": "master",
-      "sha": "167c34673f34c233720d9c642a2854a6d8f08080",
-      "branches": {
-        "master": "167c34673f34c233720d9c642a2854a6d8f08080"
-      }
-    },
-    "siyy/succ-bag": {
-      "default_branch": "master",
-      "sha": "2d79d8a2e3c0431b55d6a81f5f32246a0311d431",
-      "branches": {
-        "master": "2d79d8a2e3c0431b55d6a81f5f32246a0311d431"
-      }
-    },
-    "refaim/succ-bag": {
-      "default_branch": "master",
-      "sha": "8e0b52194d91f14bf90a457c1778509eb86db8a3",
-      "branches": {
-        "master": "8e0b52194d91f14bf90a457c1778509eb86db8a3"
-      }
-    },
-    "amonra/succ-bag": {
-      "default_branch": "master",
-      "sha": "8e0b52194d91f14bf90a457c1778509eb86db8a3",
-      "branches": {
-        "master": "8e0b52194d91f14bf90a457c1778509eb86db8a3"
-      }
-    },
-    "linae-kronos/tradedispenser": {
-      "default_branch": "master",
-      "sha": "63aee841b835e291a30c40b46c452a9aa47717b1",
-      "branches": {
-        "master": "63aee841b835e291a30c40b46c452a9aa47717b1"
-      }
-    },
-    "subbydk/tradedispenser": {
-      "default_branch": "master",
-      "sha": "81882960a6d0548f2447eee990a57c7f4d613729",
-      "branches": {
-        "master": "81882960a6d0548f2447eee990a57c7f4d613729"
-      }
-    },
-    "joey34kaze/tradedispenser": {
-      "default_branch": "master",
-      "sha": "954224618d48ccd6a3f03f0f8724b495f6409b0f",
-      "branches": {
-        "master": "954224618d48ccd6a3f03f0f8724b495f6409b0f"
-      }
-    },
-    "oldmanalpha/unitxp_sp3_addon": {
-      "default_branch": "latest",
-      "sha": "dbbf4f0f2fef33c1e50e9a4f2fd3640796ac0999",
-      "branches": {
-        "latest": "dbbf4f0f2fef33c1e50e9a4f2fd3640796ac0999"
-      }
-    },
-    "waverion/unitxp_sp3_addon": {
-      "default_branch": "main",
-      "sha": "6263fd66ff0e21f0aff63ebae3358e0e543387ca",
-      "branches": {
-        "main": "6263fd66ff0e21f0aff63ebae3358e0e543387ca"
-      }
-    },
-    "prodigystudios/akkio_consume_helper": {
-      "default_branch": "main",
-      "sha": "9af15e3c236d14d6d704d4db78cb210620849b24",
-      "branches": {
-        "main": "9af15e3c236d14d6d704d4db78cb210620849b24"
-      }
-    },
-    "itslusse/akkio_consume_helper": {
-      "default_branch": "main",
-      "sha": "658b11fb40dde610a2ca6f794695442966ae463b",
-      "branches": {
-        "main": "658b11fb40dde610a2ca6f794695442966ae463b"
-      }
-    },
-    "lythandrawow/lyth_consume_helper": {
-      "default_branch": "main",
-      "sha": "55224c3e005aa29a25d36afa99045d92728a5e08",
-      "branches": {
-        "main": "55224c3e005aa29a25d36afa99045d92728a5e08"
-      }
-    },
-    "1petru/akkio_consume_helper": {
-      "default_branch": "main",
-      "sha": "b2be5112690a5a302ef18b88e41b98f636ad1d41",
-      "branches": {
-        "main": "b2be5112690a5a302ef18b88e41b98f636ad1d41"
-      }
-    },
-    "thezephyrsong/akkio_consume_helper": {
-      "default_branch": "main",
-      "sha": "85e730dabbaad3cba35421f0bc539780b3d69f31",
-      "branches": {
-        "main": "85e730dabbaad3cba35421f0bc539780b3d69f31"
-      }
-    },
-    "ilivans/akkio_consume_helper": {
-      "default_branch": "main",
-      "sha": "f116b85ed338c1726abba4afef83955c5fb7f4f2",
-      "branches": {
-        "main": "f116b85ed338c1726abba4afef83955c5fb7f4f2"
-      }
-    },
-    "whtmst/akkio_consume_helper": {
-      "default_branch": "main",
-      "sha": "34dcbec42f82323f429e1ec477c628a65b0e31cd",
-      "branches": {
-        "main": "34dcbec42f82323f429e1ec477c628a65b0e31cd"
-      }
-    },
-    "seraphic8x2244/akkio_consume_helper": {
-      "default_branch": "main",
-      "sha": "919898418d579bf1478832f29bca7d2066aab72a",
-      "branches": {
-        "main": "919898418d579bf1478832f29bca7d2066aab72a"
-      }
-    },
-    "nikoichu/autobuff-turtle": {
-      "default_branch": "main",
-      "sha": "5d9bb8404ac80d344c3b4a8c3cf98015e0170d7b",
-      "branches": {
-        "main": "5d9bb8404ac80d344c3b4a8c3cf98015e0170d7b"
-      }
-    },
-    "zmarotrix/battlemusic": {
-      "default_branch": "main",
-      "sha": "82e9e93785e34741387da6aa4ae564c48a310ac2",
-      "branches": {
-        "main": "82e9e93785e34741387da6aa4ae564c48a310ac2"
-      }
-    },
-    "nelethor/battlemusic": {
-      "default_branch": "main",
-      "sha": "95beea1354136be4e9fcdd6aa2e3d7243d496f61",
-      "branches": {
-        "main": "95beea1354136be4e9fcdd6aa2e3d7243d496f61"
-      }
-    },
-    "gabcinder2004/battlescribe": {
-      "default_branch": "master",
-      "sha": "e7c702ed8b38867acf60b796f9545d8153a77d87",
-      "branches": {
-        "master": "e7c702ed8b38867acf60b796f9545d8153a77d87"
-      },
-      "latest_tag": "v1.1"
-    },
-    "tcavemant/benecast": {
-      "default_branch": "main",
-      "sha": "f6b875c385302f1c9015448c4f4a3ad8ad5c20c4",
-      "branches": {
-        "main": "f6b875c385302f1c9015448c4f4a3ad8ad5c20c4"
-      }
-    },
-    "allingaming/benecast": {
-      "default_branch": "main",
-      "sha": "e5b6728dc10662959c2ac1825f17b5aaf7de7023",
-      "branches": {
-        "main": "e5b6728dc10662959c2ac1825f17b5aaf7de7023"
-      }
-    },
-    "jrc13245/bonusscanner": {
-      "default_branch": "main",
-      "sha": "caf3cbf3836e84d740934b9fb8752eaa1a9b62c4",
-      "branches": {
-        "main": "caf3cbf3836e84d740934b9fb8752eaa1a9b62c4"
-      }
-    },
-    "brunt/buffalert": {
-      "default_branch": "main",
-      "sha": "7bb6f3526f9d39aa6a35eec4bfc2c4b08465f7b7",
-      "branches": {
-        "main": "7bb6f3526f9d39aa6a35eec4bfc2c4b08465f7b7"
-      }
-    },
-    "towneh/buffblock": {
-      "default_branch": "master",
-      "sha": "cbcd2d23d6860049bad69f52574f193fbeb3c93d",
-      "branches": {
-        "master": "cbcd2d23d6860049bad69f52574f193fbeb3c93d"
-      },
-      "latest_tag": "v1.0"
-    },
-    "uc9089/buffblock-tw": {
-      "default_branch": "master",
-      "sha": "503697db9a7047479049577f0c0c200ddf529539",
-      "branches": {
-        "master": "503697db9a7047479049577f0c0c200ddf529539"
-      }
-    },
-    "dsidirop/buffblock": {
-      "default_branch": "master",
-      "sha": "1a46f7c46981718356d8e2138a666caef65cff35",
-      "branches": {
-        "master": "1a46f7c46981718356d8e2138a666caef65cff35"
-      }
-    },
-    "slimewizzard/buffblock-tw": {
-      "default_branch": "master",
-      "sha": "3425bcb6fd1b5e89b78638dddb6b4fb0687bd2b6",
-      "branches": {
-        "master": "3425bcb6fd1b5e89b78638dddb6b4fb0687bd2b6"
-      }
-    },
-    "mobbeyy/buffblock-tw": {
-      "default_branch": "master",
-      "sha": "da2abfdced4cd74d54cbb352de3da1e31e3fa281",
-      "branches": {
-        "master": "da2abfdced4cd74d54cbb352de3da1e31e3fa281"
-      }
-    },
-    "geigerkind/buffcounter": {
-      "default_branch": "master",
-      "sha": "52101d1fc9570f5618ed0bb5c0c4f113cfeece75",
-      "branches": {
-        "master": "52101d1fc9570f5618ed0bb5c0c4f113cfeece75"
-      },
-      "latest_tag": "b1"
-    },
-    "schaka/buffhook": {
-      "default_branch": "master",
-      "sha": "3e40ae1c218f27521c99754b43b7b506d8348391",
-      "branches": {
-        "master": "3e40ae1c218f27521c99754b43b7b506d8348391"
-      }
-    },
-    "opcow/buffreminder": {
-      "default_branch": "master",
-      "sha": "db965f861184db02925fc2e7efdbada46de2a056",
-      "branches": {
-        "master": "db965f861184db02925fc2e7efdbada46de2a056"
-      },
-      "latest_tag": "1.2"
-    },
-    "shkarlsson/buffwatch": {
-      "default_branch": "main",
-      "sha": "926f3924e1860f0b7f95458194fb65dc23350e28",
-      "branches": {
-        "main": "926f3924e1860f0b7f95458194fb65dc23350e28"
-      }
-    },
-    "paokkerkir/buffwatch": {
-      "default_branch": "main",
-      "sha": "e33585c8ff770fb67b83911738c9935830e5a9c5",
-      "branches": {
-        "main": "e33585c8ff770fb67b83911738c9935830e5a9c5"
-      }
-    },
-    "cernie/catdruiddps": {
-      "default_branch": "master",
-      "sha": "3eeecbad23a584f265a17f559b7319d54d089d57",
-      "branches": {
-        "master": "3eeecbad23a584f265a17f559b7319d54d089d57"
-      }
-    },
-    "101arg101/catdruiddps": {
-      "default_branch": "master",
-      "sha": "e3f9a2dd156178b51d4b9a500fa679ca825bc138",
-      "branches": {
-        "master": "e3f9a2dd156178b51d4b9a500fa679ca825bc138"
-      }
-    },
-    "zirtox1992/combat": {
-      "default_branch": "main",
-      "sha": "d118c5b259fc925e086c00f5f4db5a77273e6894",
-      "branches": {
-        "main": "d118c5b259fc925e086c00f5f4db5a77273e6894"
-      }
-    },
-    "paenthy/combat": {
-      "default_branch": "main",
-      "sha": "d118c5b259fc925e086c00f5f4db5a77273e6894",
-      "branches": {
-        "main": "d118c5b259fc925e086c00f5f4db5a77273e6894"
-      }
-    },
-    "abstr4ctz/cooldowntracker": {
-      "default_branch": "main",
-      "sha": "36caab96f68d7b4477cab536089d6e8ad51e9d2d",
-      "branches": {
-        "main": "36caab96f68d7b4477cab536089d6e8ad51e9d2d"
-      }
-    },
-    "bretharte89/cooldowntracker": {
-      "default_branch": "main",
-      "sha": "36caab96f68d7b4477cab536089d6e8ad51e9d2d",
-      "branches": {
-        "main": "36caab96f68d7b4477cab536089d6e8ad51e9d2d"
-      }
-    },
-    "paenthy/cooldowntracker": {
-      "default_branch": "main",
-      "sha": "36caab96f68d7b4477cab536089d6e8ad51e9d2d",
-      "branches": {
-        "main": "36caab96f68d7b4477cab536089d6e8ad51e9d2d"
-      }
-    },
-    "redbu11dev/coolhealthbar": {
-      "default_branch": "main",
-      "sha": "f8146269b5b09954b0fa356dbd9c0b4a194844b5",
-      "branches": {
-        "main": "f8146269b5b09954b0fa356dbd9c0b4a194844b5"
-      }
-    },
-    "caracioly/critei": {
-      "default_branch": "main",
-      "sha": "eeee679dc03d47502477e10a9fa0fced04ee9895",
-      "branches": {
-        "main": "eeee679dc03d47502477e10a9fa0fced04ee9895"
-      },
-      "latest_tag": "v1.2.2"
-    },
-    "aeroscripts/ct_buffmod_sorted": {
-      "default_branch": "master",
-      "sha": "d924e88e81dd5645a64514061f173c63dedc75e2",
-      "branches": {
-        "master": "d924e88e81dd5645a64514061f173c63dedc75e2"
-      },
-      "latest_tag": "v0.1"
-    },
-    "vashin1/debufffilter": {
-      "default_branch": "master",
-      "sha": "9cf04734166fe087770354ecbd55643c894a83eb",
-      "branches": {
-        "master": "9cf04734166fe087770354ecbd55643c894a83eb"
-      }
-    },
-    "leenux/debufffilter": {
-      "default_branch": "master",
-      "sha": "bb049ddd7ee5a9e59e1764fa58626c6aae994150",
-      "branches": {
-        "master": "bb049ddd7ee5a9e59e1764fa58626c6aae994150"
-      }
-    },
-    "geigerkind/debufflistcheck": {
-      "default_branch": "master",
-      "sha": "fb4b5104094c3799a5c17d6bc585e386d293c936",
-      "branches": {
-        "master": "fb4b5104094c3799a5c17d6bc585e386d293c936"
-      },
-      "latest_tag": "b1"
-    },
-    "voidmenull/debufftimers": {
-      "default_branch": "master",
-      "sha": "9da80d56175f4772e6f3c59798eec19aea61bed0",
-      "branches": {
-        "master": "9da80d56175f4772e6f3c59798eec19aea61bed0"
-      }
-    },
-    "dbfblackbull/debufftimers": {
-      "default_branch": "master",
-      "sha": "99880e7cb950b90adfb5c094fbc30012ba3bdc6d",
-      "branches": {
-        "master": "99880e7cb950b90adfb5c094fbc30012ba3bdc6d"
-      }
-    },
-    "laytya/debufftimers": {
-      "default_branch": "master",
-      "sha": "fb552d5053ea4ccf7e423907d2ba692278ae29bf",
-      "branches": {
-        "master": "fb552d5053ea4ccf7e423907d2ba692278ae29bf"
-      }
-    },
-    "wardz/dispelborder": {
-      "default_branch": "master",
-      "sha": "db35de80e003af48c741df2e79c0ca7847a677c7",
-      "branches": {
-        "master": "db35de80e003af48c741df2e79c0ca7847a677c7"
-      },
-      "latest_tag": "v1.0.0"
-    },
-    "macumbafeh/dispelborder": {
-      "default_branch": "master",
-      "sha": "db35de80e003af48c741df2e79c0ca7847a677c7",
-      "branches": {
-        "master": "db35de80e003af48c741df2e79c0ca7847a677c7"
-      },
-      "latest_tag": "v1.0.0"
-    },
-    "player-doite/doiteauras": {
-      "default_branch": "main",
-      "sha": "cbb3e01b82bb84122bc5ccdf35a06ae803edd6df",
-      "branches": {
-        "main": "cbb3e01b82bb84122bc5ccdf35a06ae803edd6df"
-      }
-    },
-    "deceius/doiteauras": {
-      "default_branch": "main",
-      "sha": "15c444ea0214b5399020c0515bad9e8cef4a6593",
-      "branches": {
-        "main": "15c444ea0214b5399020c0515bad9e8cef4a6593"
-      }
-    },
-    "pepopo978/doiteauras": {
-      "default_branch": "main",
-      "sha": "4bf0064fb3ab9a3ee9741bb75f3bef0b78e05763",
-      "branches": {
-        "main": "4bf0064fb3ab9a3ee9741bb75f3bef0b78e05763"
-      }
-    },
-    "ayitsyaboi/doiteauras": {
-      "default_branch": "main",
-      "sha": "4487772ba5470a116c54119e819cc9eb59ce4419",
-      "branches": {
-        "main": "4487772ba5470a116c54119e819cc9eb59ce4419"
-      }
-    },
-    "bretharte89/doiteauras": {
-      "default_branch": "main",
-      "sha": "cbb3e01b82bb84122bc5ccdf35a06ae803edd6df",
-      "branches": {
-        "main": "cbb3e01b82bb84122bc5ccdf35a06ae803edd6df"
-      }
-    },
-    "koraykarakus/doiteauras": {
-      "default_branch": "main",
-      "sha": "cbb3e01b82bb84122bc5ccdf35a06ae803edd6df",
-      "branches": {
-        "main": "cbb3e01b82bb84122bc5ccdf35a06ae803edd6df"
-      }
-    },
-    "zedris/doiteauras": {
-      "default_branch": "main",
-      "sha": "cbb3e01b82bb84122bc5ccdf35a06ae803edd6df",
-      "branches": {
-        "main": "cbb3e01b82bb84122bc5ccdf35a06ae803edd6df"
-      }
-    },
-    "mentalxgit/doiteauras": {
-      "default_branch": "main",
-      "sha": "fe2aec8f06c7da79bb0a807d7a9de861d56d50af",
-      "branches": {
-        "main": "fe2aec8f06c7da79bb0a807d7a9de861d56d50af"
-      }
-    },
-    "ravenofseven/doiteauras": {
-      "default_branch": "main",
-      "sha": "10f108bbb438a212cd1965dc0989745901762e14",
-      "branches": {
-        "main": "10f108bbb438a212cd1965dc0989745901762e14"
-      }
-    },
-    "hippoom/doiteauras": {
-      "default_branch": "main",
-      "sha": "ab705bd772bd941900d42fb230ba1c43d51abc92",
-      "branches": {
-        "main": "ab705bd772bd941900d42fb230ba1c43d51abc92"
-      }
-    },
-    "logicsec/doiteauras": {
-      "default_branch": "main",
-      "sha": "08a04048140bc6252770d0eaabe845640533f5b3",
-      "branches": {
-        "main": "08a04048140bc6252770d0eaabe845640533f5b3"
-      }
-    },
-    "isfir/doiteauras": {
-      "default_branch": "main",
-      "sha": "5318c7bf25a6f262f85fe24a44720d60b1bac487",
-      "branches": {
-        "main": "5318c7bf25a6f262f85fe24a44720d60b1bac487"
-      }
-    },
-    "turinpt/fubar_dpsmate": {
-      "default_branch": "master",
-      "sha": "5f9b405c9b956580a25b08b471b38e9b717a405a",
-      "branches": {
-        "master": "5f9b405c9b956580a25b08b471b38e9b717a405a"
-      }
-    },
-    "laytya/eavesdrop": {
-      "default_branch": "master",
-      "sha": "244cba1c61f861bfc643a8b8617691a742e33c44",
-      "branches": {
-        "master": "244cba1c61f861bfc643a8b8617691a742e33c44"
-      },
-      "latest_tag": "1.4.1"
-    },
-    "sheed90/eavesdrop-turtlewow": {
-      "default_branch": "master",
-      "sha": "e7e5e265c2c82b026e778dceecf51d6c3140c57a",
-      "branches": {
-        "master": "e7e5e265c2c82b026e778dceecf51d6c3140c57a"
-      }
-    },
-    "goldenpipes/eavesdrop": {
-      "default_branch": "master",
-      "sha": "c51fe464e66c60a3bf93142e134e42a0e58bd772",
-      "branches": {
-        "master": "c51fe464e66c60a3bf93142e134e42a0e58bd772"
-      },
-      "latest_tag": "1.4.1"
-    },
-    "kirchlive/elkbuffbarhor": {
-      "default_branch": "master",
-      "sha": "b25a66da88af21cfccd7a5e0e5949c1b00ff41f9",
-      "branches": {
-        "master": "b25a66da88af21cfccd7a5e0e5949c1b00ff41f9"
-      }
-    },
-    "pepopo978/flamestriker": {
-      "default_branch": "master",
-      "sha": "ebcf8bdd1661b5dcc11b107f459c3d5006c44c00",
-      "branches": {
-        "master": "ebcf8bdd1661b5dcc11b107f459c3d5006c44c00"
-      }
-    },
-    "birdayz/fubar_buffleecherfu": {
-      "default_branch": "master",
-      "sha": "d694ab83b71692609b0cf50855f5fd65fbe7078e",
-      "branches": {
-        "master": "d694ab83b71692609b0cf50855f5fd65fbe7078e"
-      }
-    },
-    "trumpetx/gethead": {
-      "default_branch": "master",
-      "sha": "296fbc2bddc6bd043b29f359b80cb518c9890ce2",
-      "branches": {
-        "master": "296fbc2bddc6bd043b29f359b80cb518c9890ce2"
-      }
-    },
-    "yogo1212/healbot-classic": {
-      "default_branch": "master",
-      "sha": "6c78b6801556e52be829548b1305b2f4a53141e2",
-      "branches": {
-        "master": "6c78b6801556e52be829548b1305b2f4a53141e2"
-      }
-    },
-    "apgm82/healbot-classic-es-fix": {
-      "default_branch": "master",
-      "sha": "9d7d4961716a3faaef8d6d6c5cb39a7449ee48f4",
-      "branches": {
-        "master": "9d7d4961716a3faaef8d6d6c5cb39a7449ee48f4"
-      }
-    },
-    "cr45hcode/healbot-returtled": {
-      "default_branch": "master",
-      "sha": "6c78b6801556e52be829548b1305b2f4a53141e2",
-      "branches": {
-        "master": "6c78b6801556e52be829548b1305b2f4a53141e2"
-      }
-    },
-    "otari98/healcomm": {
-      "default_branch": "master",
-      "sha": "b53baabfa09eeac140980dd2b26f67e3aac76752",
-      "branches": {
-        "master": "b53baabfa09eeac140980dd2b26f67e3aac76752"
-      }
-    },
-    "voidmenull/vanillahealingassignments": {
-      "default_branch": "master",
-      "sha": "1d3077c586e71463864faadfc8b8e5b50eeaa769",
-      "branches": {
-        "master": "1d3077c586e71463864faadfc8b8e5b50eeaa769"
-      }
-    },
-    "shnibble/vanillahealingassignments": {
-      "default_branch": "master",
-      "sha": "e7cf4e9976f2a0fc874fdf95f6b2442e066fd139",
-      "branches": {
-        "master": "e7cf4e9976f2a0fc874fdf95f6b2442e066fd139"
-      }
-    },
-    "qrospars/holyshiftmiio": {
-      "default_branch": "master",
-      "sha": "9cb60822a0cf6391dd34828802b0c0965b752016",
-      "branches": {
-        "master": "9cb60822a0cf6391dd34828802b0c0965b752016"
-      }
-    },
-    "grymskvll/kangz": {
-      "default_branch": "master",
-      "sha": "a721a1d6ef0bc63cd34f86479a4a259778f3bd26",
-      "branches": {
-        "master": "a721a1d6ef0bc63cd34f86479a4a259778f3bd26"
-      }
-    },
-    "zensociety/lager": {
-      "default_branch": "main",
-      "sha": "19beb37b087acf8f92559d9485ff6902ac9b2803",
-      "branches": {
-        "main": "19beb37b087acf8f92559d9485ff6902ac9b2803"
-      }
-    },
-    "laytya/lazyspell": {
-      "default_branch": "master",
-      "sha": "1af9fc538bf010116290b3399ca67b9b2b95043f",
-      "branches": {
-        "master": "1af9fc538bf010116290b3399ca67b9b2b95043f"
-      }
-    },
-    "paleniyacc-oss/lazyspell": {
-      "default_branch": "master",
-      "sha": "63bfb63149b6e5780664ed25851d10d30c79e5ef",
-      "branches": {
-        "master": "63bfb63149b6e5780664ed25851d10d30c79e5ef"
-      }
-    },
-    "ziyassa/lazyspell": {
-      "default_branch": "master",
-      "sha": "1af9fc538bf010116290b3399ca67b9b2b95043f",
-      "branches": {
-        "master": "1af9fc538bf010116290b3399ca67b9b2b95043f"
-      }
-    },
-    "bigmoonz/lazyspell": {
-      "default_branch": "master",
-      "sha": "99b1a92c0e9587ac8d52f48cc1a098901421a077",
-      "branches": {
-        "master": "99b1a92c0e9587ac8d52f48cc1a098901421a077"
-      }
-    },
-    "marcelinevq/loatheborder": {
-      "default_branch": "master",
-      "sha": "2ae69de1aa38abe90acc9e24996ccf7546e704c3",
-      "branches": {
-        "master": "2ae69de1aa38abe90acc9e24996ccf7546e704c3"
-      }
-    },
-    "kc8pnd/mobhealth": {
-      "default_branch": "master",
-      "sha": "74982883284a6c79f50247e1cf7b5d4842ef37f3",
-      "branches": {
-        "master": "74982883284a6c79f50247e1cf7b5d4842ef37f3"
-      }
-    },
-    "frostshock/mobhealth": {
-      "default_branch": "master",
-      "sha": "d922aa3c1c9a17405e09b9b77aebeb1f51a6b39b",
-      "branches": {
-        "master": "d922aa3c1c9a17405e09b9b77aebeb1f51a6b39b"
-      }
-    },
-    "paparogue/mobhealth3-kronos3-edition": {
-      "default_branch": "master",
-      "sha": "198fec86d3213cad69d4fa4c2307355daa1a87e9",
-      "branches": {
-        "master": "198fec86d3213cad69d4fa4c2307355daa1a87e9"
-      }
-    },
-    "mongrul/mobhealth3-kronos4-edition": {
-      "default_branch": "master",
-      "sha": "a08d5fb9c18ed30b6ee99a50be7ba1dc4a16b04a",
-      "branches": {
-        "master": "a08d5fb9c18ed30b6ee99a50be7ba1dc4a16b04a"
-      },
-      "latest_tag": "2.0.3"
-    },
-    "leenux/mobresistanddmg": {
-      "default_branch": "main",
-      "sha": "f04af9fc33f76f989bae23f604f54a8aa1597c81",
-      "branches": {
-        "main": "f04af9fc33f76f989bae23f604f54a8aa1597c81"
-      }
-    },
-    "refaim/mobstats": {
-      "default_branch": "master",
-      "sha": "8835e8ebb554c3b5f3f2a74a0f4fd1c3e4ff4647",
-      "branches": {
-        "master": "8835e8ebb554c3b5f3f2a74a0f4fd1c3e4ff4647"
-      }
-    },
-    "crackion/mobstats": {
-      "default_branch": "master",
-      "sha": "3ff6580763b2726dd97cd6383a5842428830250c",
-      "branches": {
-        "master": "3ff6580763b2726dd97cd6383a5842428830250c"
-      }
-    },
-    "cryptopsy30/mobstats-bleedimmune": {
-      "default_branch": "master",
-      "sha": "bbfd39f2200637d1a2a7a5d52e324e78623d9720",
-      "branches": {
-        "master": "bbfd39f2200637d1a2a7a5d52e324e78623d9720"
-      }
-    },
-    "marcelinevq/modifiedpowerauras": {
-      "default_branch": "master",
-      "sha": "faf26552df05146251866a092dd6812999ed578d",
-      "branches": {
-        "master": "faf26552df05146251866a092dd6812999ed578d"
-      }
-    },
-    "sandworlds-mmo/modifiedpowerauras": {
-      "default_branch": "master",
-      "sha": "faf26552df05146251866a092dd6812999ed578d",
-      "branches": {
-        "master": "faf26552df05146251866a092dd6812999ed578d"
-      }
-    },
-    "marena/modifiedpowerauras": {
-      "default_branch": "master",
-      "sha": "9dd7e01c819895e56e015c259c6d4b1c90302866",
-      "branches": {
-        "master": "9dd7e01c819895e56e015c259c6d4b1c90302866"
-      }
-    },
-    "yani9o/modifiedpowerauras": {
-      "default_branch": "master",
-      "sha": "40725d500c138b73b0638818587280c3962369ed",
-      "branches": {
-        "master": "40725d500c138b73b0638818587280c3962369ed"
-      }
-    },
-    "dudusandsten/nbr": {
-      "default_branch": "master",
-      "sha": "074e06d2191380deec3758a10da3cf54b36c2eb5",
-      "branches": {
-        "master": "074e06d2191380deec3758a10da3cf54b36c2eb5"
-      }
-    },
-    "fastbond/nbr": {
-      "default_branch": "master",
-      "sha": "13980213ecc971dd8de165d3c69acd6b8829f6e5",
-      "branches": {
-        "master": "13980213ecc971dd8de165d3c69acd6b8829f6e5"
-      }
-    },
-    "liiora/pfui-lazyres": {
-      "default_branch": "master",
-      "sha": "d33a17af316de26595cbeac252a08767f7dcbf5f",
-      "branches": {
-        "master": "d33a17af316de26595cbeac252a08767f7dcbf5f"
-      }
-    },
-    "akzkak/pfui-lazyres": {
-      "default_branch": "master",
-      "sha": "d33a17af316de26595cbeac252a08767f7dcbf5f",
-      "branches": {
-        "master": "d33a17af316de26595cbeac252a08767f7dcbf5f"
-      }
-    },
-    "jrc13245/pfui-weakicons": {
-      "default_branch": "master",
-      "sha": "fe59bea6e70ef6ec54a1f84c914d070cdea065c8",
-      "branches": {
-        "master": "fe59bea6e70ef6ec54a1f84c914d070cdea065c8"
-      }
-    },
-    "cybula-real/pfui-weakicons-turtle": {
-      "default_branch": "master",
-      "sha": "274a9153fe738ff1e2b1f6628cffcce39e83925a",
-      "branches": {
-        "master": "274a9153fe738ff1e2b1f6628cffcce39e83925a"
-      }
-    },
-    "evannnn1996/pfui-weakicons": {
-      "default_branch": "master",
-      "sha": "fe59bea6e70ef6ec54a1f84c914d070cdea065c8",
-      "branches": {
-        "master": "fe59bea6e70ef6ec54a1f84c914d070cdea065c8"
-      }
-    },
-    "jsb/picopoisons": {
-      "default_branch": "master",
-      "sha": "92f89feb2959910106c960f71c9913279cee0073",
-      "branches": {
-        "master": "92f89feb2959910106c960f71c9913279cee0073"
-      },
-      "latest_tag": "v1.00"
-    },
-    "xinleibird/picopoisons": {
-      "default_branch": "master",
-      "sha": "937e93c4d8a4ed41a2e8a67b25c44e39949669d3",
-      "branches": {
-        "master": "937e93c4d8a4ed41a2e8a67b25c44e39949669d3"
-      }
-    },
-    "sentilix/pitty": {
-      "default_branch": "master",
-      "sha": "a6f7ee211029d9adbe9f0c7130a7361e44a19a13",
-      "branches": {
-        "master": "a6f7ee211029d9adbe9f0c7130a7361e44a19a13"
-      },
-      "latest_tag": "pitty-1.2.0-rc1"
-    },
-    "sulpitz/quickheal": {
-      "default_branch": "master",
-      "sha": "33a3172bbcfa930b57bb3f0b9002eb09f99d4760",
-      "branches": {
-        "master": "33a3172bbcfa930b57bb3f0b9002eb09f99d4760"
-      },
-      "latest_tag": "hc01"
-    },
-    "shikulja/quickheal": {
-      "default_branch": "master",
-      "sha": "8c974e9f1da0f1e439b087d2743f12891d7b585d",
-      "branches": {
-        "master": "8c974e9f1da0f1e439b087d2743f12891d7b585d"
-      },
-      "latest_tag": "hc01"
-    },
-    "metaroa/quickheal": {
-      "default_branch": "master",
-      "sha": "33a3172bbcfa930b57bb3f0b9002eb09f99d4760",
-      "branches": {
-        "master": "33a3172bbcfa930b57bb3f0b9002eb09f99d4760"
-      }
-    },
-    "weirdpuppy94/rallyhelper": {
-      "default_branch": "main",
-      "sha": "e38cb75f0cbee12bcf413e23787d94b5927e8daa",
-      "branches": {
-        "main": "e38cb75f0cbee12bcf413e23787d94b5927e8daa"
-      },
-      "latest_tag": "RallyHelperv1.4.7"
-    },
-    "ravenofseven/rallyhelper": {
-      "default_branch": "main",
-      "sha": "9819101ea22d0ffbbee7221accf6601a7321c1c8",
-      "branches": {
-        "main": "9819101ea22d0ffbbee7221accf6601a7321c1c8"
-      }
-    },
-    "dreaming-possum/recap": {
-      "default_branch": "master",
-      "sha": "c20ddb525c45e98be6cd7e6418e7ed3a19f272bf",
-      "branches": {
-        "master": "c20ddb525c45e98be6cd7e6418e7ed3a19f272bf"
-      }
-    },
-    "pokerbhind/roguepoker": {
-      "default_branch": "main",
-      "sha": "a7786ed09c548d4930d0d64715591a2c6c33ef97",
-      "branches": {
-        "main": "a7786ed09c548d4930d0d64715591a2c6c33ef97"
-      },
-      "latest_tag": "v1.2.1"
-    },
-    "shagu/shagucombat": {
-      "default_branch": "master",
-      "sha": "04e7a81a58d0e45d0529737d35a1d62dd3204f0c",
-      "branches": {
-        "master": "04e7a81a58d0e45d0529737d35a1d62dd3204f0c"
-      }
-    },
-    "yani9o/simpleauras": {
-      "default_branch": "main",
-      "sha": "84f95b068abbf8a8347b502548efaf054ea89a9c",
-      "branches": {
-        "main": "84f95b068abbf8a8347b502548efaf054ea89a9c"
-      }
-    },
-    "zanthor/simpleauras": {
-      "default_branch": "main",
-      "sha": "7193d563792b20a74e0c2743190d219fa21cfbc2",
-      "branches": {
-        "main": "7193d563792b20a74e0c2743190d219fa21cfbc2"
-      }
-    },
-    "loogosh/simpleauras": {
-      "default_branch": "main",
-      "sha": "9bc981deaafc1609f6b03e8f5a14991dda21719b",
-      "branches": {
-        "main": "9bc981deaafc1609f6b03e8f5a14991dda21719b"
-      }
-    },
-    "xinleibird/simpleauras": {
-      "default_branch": "main",
-      "sha": "f53724b76ea581593d49dc6c4ec437b529638650",
-      "branches": {
-        "main": "f53724b76ea581593d49dc6c4ec437b529638650"
-      }
-    },
-    "whtmst/simpleauras": {
-      "default_branch": "main",
-      "sha": "f53724b76ea581593d49dc6c4ec437b529638650",
-      "branches": {
-        "main": "f53724b76ea581593d49dc6c4ec437b529638650"
-      }
-    },
-    "eritzman/simpleauras": {
-      "default_branch": "main",
-      "sha": "a4ffc609fe739d251300c7ca30c8fcabf104e38c",
-      "branches": {
-        "main": "a4ffc609fe739d251300c7ca30c8fcabf104e38c"
-      }
-    },
-    "laubuur/simpleauras": {
-      "default_branch": "main",
-      "sha": "748900496a17aae8cea80175807af30b0fbc822a",
-      "branches": {
-        "main": "748900496a17aae8cea80175807af30b0fbc822a"
-      }
-    },
-    "road-block/simplecombatlog": {
-      "default_branch": "master",
-      "sha": "2f4b6035c07d3e09fe15e33c2e9fe8e00fa739b3",
-      "branches": {
-        "master": "2f4b6035c07d3e09fe15e33c2e9fe8e00fa739b3"
-      }
-    },
-    "laytya/simplecombatlog": {
-      "default_branch": "master",
-      "sha": "6fe81a43e446eb9b5f696ce3d82e61e72a4b6436",
-      "branches": {
-        "master": "6fe81a43e446eb9b5f696ce3d82e61e72a4b6436"
-      },
-      "latest_tag": "r27330"
-    },
-    "simon3/smartdebuffcheck": {
-      "default_branch": "master",
-      "sha": "2e9e292cb56284138fca06038ec26e56c7e46508",
-      "branches": {
-        "master": "2e9e292cb56284138fca06038ec26e56c7e46508"
-      }
-    },
-    "melbaa/smarthealer": {
-      "default_branch": "master",
-      "sha": "3c550f8ee8e185ee223d1a1f5910847fe81e92f9",
-      "branches": {
-        "master": "3c550f8ee8e185ee223d1a1f5910847fe81e92f9"
-      }
-    },
-    "dsidirop/smarthealer": {
-      "default_branch": "master",
-      "sha": "fe83d70a9dc8dec8642573c70e900ee374b794ad",
-      "branches": {
-        "master": "fe83d70a9dc8dec8642573c70e900ee374b794ad"
-      },
-      "latest_tag": "v001.02.01.00"
-    },
-    "zmarotrix/smarthealer": {
-      "default_branch": "master",
-      "sha": "e97889a080370ee5a7d8988965ff4b508e4301e1",
-      "branches": {
-        "master": "e97889a080370ee5a7d8988965ff4b508e4301e1"
-      }
-    },
-    "dauls/smartrestore": {
-      "default_branch": "main",
-      "sha": "ce7ccc9ba7bc18a52ab9fc85d1e85fbe2a78bc93",
-      "branches": {
-        "main": "ce7ccc9ba7bc18a52ab9fc85d1e85fbe2a78bc93"
-      },
-      "latest_tag": "v3.4.1"
-    },
-    "madscripting/snaguloatheb-turtleedition": {
-      "default_branch": "main",
-      "sha": "b111b5a6d5cecb0c928c60c05a0cb017706c8e08",
-      "branches": {
-        "main": "b111b5a6d5cecb0c928c60c05a0cb017706c8e08"
-      }
-    },
-    "kevmodrome/spellpowermulti": {
-      "default_branch": "master",
-      "sha": "de2d75a5b80543848094e01b7bc85c4255a32b09",
-      "branches": {
-        "master": "de2d75a5b80543848094e01b7bc85c4255a32b09"
-      },
-      "latest_tag": "0.1"
-    },
-    "stonneke/spellpowermulti": {
-      "default_branch": "master",
-      "sha": "f3a18600c24999896143a9edb5ba57a1237ea88b",
-      "branches": {
-        "master": "f3a18600c24999896143a9edb5ba57a1237ea88b"
-      }
-    },
-    "paparogue/stopduelbuffer": {
-      "default_branch": "master",
-      "sha": "5f46676befeb26a46beb670241cf622b0bd7c90e",
-      "branches": {
-        "master": "5f46676befeb26a46beb670241cf622b0bd7c90e"
-      }
-    },
-    "zerf/sw_stats-vanilla": {
-      "default_branch": "master",
-      "sha": "c000f0ddf31f5bfaa1511c5b15af7c56f24beb4f",
-      "branches": {
-        "master": "c000f0ddf31f5bfaa1511c5b15af7c56f24beb4f"
-      }
-    },
-    "hellowind777/sw_stats": {
-      "default_branch": "master",
-      "sha": "2d74332822b5801c4f7cb1a3a6c900810f39cda0",
-      "branches": {
-        "master": "2d74332822b5801c4f7cb1a3a6c900810f39cda0"
-      }
-    },
-    "xorann/tankheal": {
-      "default_branch": "master",
-      "sha": "c5642faca9d7f81ddc98e927781445f3f32d1691",
-      "branches": {
-        "master": "c5642faca9d7f81ddc98e927781445f3f32d1691"
-      }
-    },
-    "ziims/targetframebuff": {
-      "default_branch": "master",
-      "sha": "9ad8acbe28661b72e60185399ee79f67835fa72d",
-      "branches": {
-        "master": "9ad8acbe28661b72e60185399ee79f67835fa72d"
-      }
-    },
-    "pecheneg95/targetframebuff": {
-      "default_branch": "master",
-      "sha": "68034f1f3c99db2e1ff6806e38adc011ae161a20",
-      "branches": {
-        "master": "68034f1f3c99db2e1ff6806e38adc011ae161a20"
-      }
-    },
-    "hippoom/targetframebuff": {
-      "default_branch": "master",
-      "sha": "78c9f220da71af7047d6325ef12d82ebbc522800",
-      "branches": {
-        "master": "78c9f220da71af7047d6325ef12d82ebbc522800"
-      }
-    },
-    "thezephyrsong/targetframebuff": {
-      "default_branch": "master",
-      "sha": "830519bbc70433b4a26c586724868749390b7efc",
-      "branches": {
-        "master": "830519bbc70433b4a26c586724868749390b7efc"
-      }
-    },
-    "isitlove/titancritline": {
-      "default_branch": "master",
-      "sha": "e3dc9cf79a7a6f3188b838e0b5e2ae6c91d02c05",
-      "branches": {
-        "master": "e3dc9cf79a7a6f3188b838e0b5e2ae6c91d02c05"
-      }
-    },
-    "cosminpop/twassignments": {
-      "default_branch": "master",
-      "sha": "e4533a9809ec30fa1b27f0821130f08d237a5b14",
-      "branches": {
-        "master": "e4533a9809ec30fa1b27f0821130f08d237a5b14"
-      }
-    },
-    "szalor/unleashedtracker": {
-      "default_branch": "main",
-      "sha": "8422f5f9d5809b9f99ab1e38e1579189b3a3380d",
-      "branches": {
-        "main": "8422f5f9d5809b9f99ab1e38e1579189b3a3380d"
-      }
-    },
-    "rouzihiro/unleashedtracker": {
-      "default_branch": "main",
-      "sha": "8422f5f9d5809b9f99ab1e38e1579189b3a3380d",
-      "branches": {
-        "main": "8422f5f9d5809b9f99ab1e38e1579189b3a3380d"
-      }
-    },
-    "firenahzku/vanguardanticooldown": {
-      "default_branch": "master",
-      "sha": "f99ac37b0d858a287a7dc2b25fad043195bf92b0",
-      "branches": {
-        "master": "f99ac37b0d858a287a7dc2b25fad043195bf92b0"
-      }
-    },
-    "firenahzku/vgsmartunbuff": {
-      "default_branch": "master",
-      "sha": "c108a72250db707e98ecccceee78da967f88a356",
-      "branches": {
-        "master": "c108a72250db707e98ecccceee78da967f88a356"
-      }
-    },
-    "paulderaadt/vgsmartunbuff": {
-      "default_branch": "master",
-      "sha": "0bebe678cf2d7b3658bff23c014f857d7a61fd8d",
-      "branches": {
-        "master": "0bebe678cf2d7b3658bff23c014f857d7a61fd8d"
-      }
-    },
-    "faraso/warriorcombatmanager": {
-      "default_branch": "main",
-      "sha": "1b4f2a4d775f7035483746f9d1f294397a84a989",
-      "branches": {
-        "main": "1b4f2a4d775f7035483746f9d1f294397a84a989"
-      },
-      "latest_tag": "v0.1.0"
-    },
-    "numielle/worldbossalert": {
-      "default_branch": "master",
-      "sha": "17246aa8f3c73e0f6a357fbbad8ed989dbfffd40",
-      "branches": {
-        "master": "17246aa8f3c73e0f6a357fbbad8ed989dbfffd40"
-      }
-    },
-    "bergador/worldbuffsoundalert": {
-      "default_branch": "master",
-      "sha": "4058df754baae525cd6531622dc34dd10e89c0b5",
-      "branches": {
-        "master": "4058df754baae525cd6531622dc34dd10e89c0b5"
-      }
-    },
-    "acid9000/antiafk": {
-      "default_branch": "main",
-      "sha": "8ba518f52fb6bd6c4e12a924af9dfcf89af0add6",
-      "branches": {
-        "main": "8ba518f52fb6bd6c4e12a924af9dfcf89af0add6"
-      }
-    },
-    "kingfisher387/antiafk": {
-      "default_branch": "main",
-      "sha": "cfa303f8147c8bef19642cb9ea16e61e976f83b4",
-      "branches": {
-        "main": "cfa303f8147c8bef19642cb9ea16e61e976f83b4"
-      }
-    },
-    "shagu/antispam": {
-      "default_branch": "master",
-      "sha": "c1efb663f2fd722c23eef8c6087ec081bd151125",
-      "branches": {
-        "master": "c1efb663f2fd722c23eef8c6087ec081bd151125"
-      }
-    },
-    "buhfur/nolfg": {
-      "default_branch": "master",
-      "sha": "d437689a057cd27027e0528767adc7d7cdbf5776",
-      "branches": {
-        "master": "d437689a057cd27027e0528767adc7d7cdbf5776"
-      }
-    },
-    "einbaum/auctionaltbuy": {
-      "default_branch": "master",
-      "sha": "dca00f12e9a9290b6de5dc48de25a2ee018db7ab",
-      "branches": {
-        "master": "dca00f12e9a9290b6de5dc48de25a2ee018db7ab"
-      },
-      "latest_tag": "1.0.0"
-    },
-    "nimeral/auctionatorvanilla": {
-      "default_branch": "master",
-      "sha": "90c109351034d59e5987d9efa53989dcfe3eff62",
-      "branches": {
-        "master": "90c109351034d59e5987d9efa53989dcfe3eff62"
-      }
-    },
-    "naakarg/auctionatorvanillafixed": {
-      "default_branch": "master",
-      "sha": "ac332d5da47462d8d0a01a02dd7ce5226cb7125c",
-      "branches": {
-        "master": "ac332d5da47462d8d0a01a02dd7ce5226cb7125c"
-      }
-    },
-    "einbaum/auctionhelper": {
-      "default_branch": "master",
-      "sha": "09998b7d22ec2916826cf8e0eaf2fcce2e2863f8",
-      "branches": {
-        "master": "09998b7d22ec2916826cf8e0eaf2fcce2e2863f8"
-      }
-    },
-    "zerf/auctionlink": {
-      "default_branch": "master",
-      "sha": "a4f2092848244ebef4ee2f57c3ca32775af934a0",
-      "branches": {
-        "master": "a4f2092848244ebef4ee2f57c3ca32775af934a0"
-      },
-      "latest_tag": "v2.0.1"
-    },
-    "einbaum/auctionsearchtimer": {
-      "default_branch": "master",
-      "sha": "639a5b7765a6d3d1bb18a8e053865401e0493f89",
-      "branches": {
-        "master": "639a5b7765a6d3d1bb18a8e053865401e0493f89"
-      }
-    },
-    "road-block/autoprofit": {
-      "default_branch": "master",
-      "sha": "19ae2d47818c8405fd3ded54b2b5bbb74d443039",
-      "branches": {
-        "master": "19ae2d47818c8405fd3ded54b2b5bbb74d443039"
-      },
-      "latest_tag": "3.11a-11200"
-    },
-    "oldmanalpha/aux-addon": {
-      "default_branch": "master",
-      "sha": "c25ad2baeb2e8fd220166239be6a2f53443f5250",
-      "branches": {
-        "master": "c25ad2baeb2e8fd220166239be6a2f53443f5250"
-      }
-    },
-    "choogerdev/chaux-addon": {
-      "default_branch": "master",
-      "sha": "caebf5833c931f35d22a27def58cf9e8855e6ba5",
-      "branches": {
-        "master": "caebf5833c931f35d22a27def58cf9e8855e6ba5"
-      }
-    },
-    "neolectron/aux-addon": {
-      "default_branch": "master",
-      "sha": "419160eb4ddd3f55c1f570944ef492f51eab7222",
-      "branches": {
-        "master": "419160eb4ddd3f55c1f570944ef492f51eab7222"
-      }
-    },
-    "lioryx/aux-addon": {
-      "default_branch": "master",
-      "sha": "51407dfe9c2edc8a2a1e8a2ee12dcb44b24e9cbd",
-      "branches": {
-        "master": "51407dfe9c2edc8a2a1e8a2ee12dcb44b24e9cbd"
-      }
-    },
-    "otari98/aux-addon": {
-      "default_branch": "master",
-      "sha": "7d4b7f4591546345e43237684f8f957e5505e415",
-      "branches": {
-        "master": "7d4b7f4591546345e43237684f8f957e5505e415"
-      }
-    },
-    "bestoriop/aux-addon": {
-      "default_branch": "master",
-      "sha": "3d735190b3be8d4bbc17b7145edbb27a185641a2",
-      "branches": {
-        "master": "3d735190b3be8d4bbc17b7145edbb27a185641a2"
-      }
-    },
-    "adrianocastro189/aux-addon": {
-      "default_branch": "master",
-      "sha": "457f7537494a5c0e308f807800b4a3de531df0d0",
-      "branches": {
-        "master": "457f7537494a5c0e308f807800b4a3de531df0d0"
-      }
-    },
-    "uss-enterprise-guild/aux-addon": {
-      "default_branch": "master",
-      "sha": "4761752630c3214076f28a83d09fecdcb05bedfa",
-      "branches": {
-        "master": "4761752630c3214076f28a83d09fecdcb05bedfa"
-      }
-    },
-    "dsidirop/aux-addon": {
-      "default_branch": "master",
-      "sha": "dd859a84468b8ea555ef9d14bb360b303573aec3",
-      "branches": {
-        "master": "dd859a84468b8ea555ef9d14bb360b303573aec3"
-      }
-    },
-    "midanaaticoss/aux-addon-tsm-flavored-turtle-wow": {
-      "default_branch": "master",
-      "sha": "34fd65c0666636f5c476fbadda8e6ff7042f4fc8",
-      "branches": {
-        "master": "34fd65c0666636f5c476fbadda8e6ff7042f4fc8"
-      }
-    },
-    "tomek7667/aux-addon": {
-      "default_branch": "master",
-      "sha": "816df9e510b8e3d5eb9d7303581ed18f6e924f8b",
-      "branches": {
-        "master": "816df9e510b8e3d5eb9d7303581ed18f6e924f8b"
-      }
-    },
-    "acid9000/aux-addon": {
-      "default_branch": "master",
-      "sha": "09728c5a5a4c9b30c05a25d4fc23a9247683fadc",
-      "branches": {
-        "master": "09728c5a5a4c9b30c05a25d4fc23a9247683fadc"
-      },
-      "latest_tag": "1.0.3"
-    },
-    "convay89/aux-addon": {
-      "default_branch": "master",
-      "sha": "62bef57950810a989ac741c5e5f58257f2c780b9",
-      "branches": {
-        "master": "62bef57950810a989ac741c5e5f58257f2c780b9"
-      }
-    },
-    "razzeee/aux-addon": {
-      "default_branch": "master",
-      "sha": "09728c5a5a4c9b30c05a25d4fc23a9247683fadc",
-      "branches": {
-        "master": "09728c5a5a4c9b30c05a25d4fc23a9247683fadc"
-      }
-    },
-    "ftkun/aux-revamped-opaque": {
-      "default_branch": "master",
-      "sha": "ad976fb06112186baaf285ab72fadeec72d61a56",
-      "branches": {
-        "master": "ad976fb06112186baaf285ab72fadeec72d61a56"
-      }
-    },
-    "josh-sachs/aux-revamped-opaque": {
-      "default_branch": "master",
-      "sha": "7420d65782119c4cb850e4e20f5eeab59ef32aa2",
-      "branches": {
-        "master": "7420d65782119c4cb850e4e20f5eeab59ef32aa2"
-      }
-    },
-    "ravenofseven/aux-revamped-opaque": {
-      "default_branch": "master",
-      "sha": "10ca3b7dfc32b81f30f8fc1c6fa83d1472d1949d",
-      "branches": {
-        "master": "10ca3b7dfc32b81f30f8fc1c6fa83d1472d1949d"
-      }
-    },
-    "shirsig/aux_merchant_prices": {
-      "default_branch": "master",
-      "sha": "dc3b12d9f6ed4b37df78fdd84721552d00f5025e",
-      "branches": {
-        "master": "dc3b12d9f6ed4b37df78fdd84721552d00f5025e"
-      },
-      "latest_tag": "1"
-    },
-    "tusam3/aux_merchant_prices": {
-      "default_branch": "master",
-      "sha": "dc3b12d9f6ed4b37df78fdd84721552d00f5025e",
-      "branches": {
-        "master": "dc3b12d9f6ed4b37df78fdd84721552d00f5025e"
-      },
-      "latest_tag": "1"
-    },
-    "einherjarn/ct_mailmod": {
-      "default_branch": "master",
-      "sha": "4b51c285a48dd9a64f2a962781e4a45a98f22b0e",
-      "branches": {
-        "master": "4b51c285a48dd9a64f2a962781e4a45a98f22b0e"
-      }
-    },
-    "mcpewpew/diivskins": {
-      "default_branch": "master",
-      "sha": "4acd8225ac48844cd85280afaa75cee6eb5ab66c",
-      "branches": {
-        "master": "4acd8225ac48844cd85280afaa75cee6eb5ab66c"
-      }
-    },
-    "quakerzz/dkpauctionbidder": {
-      "default_branch": "master",
-      "sha": "8b38ae52ac3a3613216fb7dc37cfaddc73627c34",
-      "branches": {
-        "master": "8b38ae52ac3a3613216fb7dc37cfaddc73627c34"
-      }
-    },
-    "cinecom/easypoisons": {
-      "default_branch": "main",
-      "sha": "7c79f964118995c4cd7874704f561488cb02e2ce",
-      "branches": {
-        "main": "7c79f964118995c4cd7874704f561488cb02e2ce"
-      }
-    },
-    "email2340x5-byte/easypoisons": {
-      "default_branch": "main",
-      "sha": "7c79f964118995c4cd7874704f561488cb02e2ce",
-      "branches": {
-        "main": "7c79f964118995c4cd7874704f561488cb02e2ce"
-      }
-    },
-    "keijinde/keijinautovendor": {
-      "default_branch": "main",
-      "sha": "4cefadbc99d7c5d452e67c7c151bdf917c8de0cc",
-      "branches": {
-        "main": "4cefadbc99d7c5d452e67c7c151bdf917c8de0cc"
-      },
-      "latest_tag": "v0.1.4"
-    },
-    "paenthy/keijinautovendor": {
-      "default_branch": "main",
-      "sha": "4cefadbc99d7c5d452e67c7c151bdf917c8de0cc",
-      "branches": {
-        "main": "4cefadbc99d7c5d452e67c7c151bdf917c8de0cc"
-      }
-    },
-    "einbaum/mail": {
-      "default_branch": "master",
-      "sha": "59c04a41ea4110cd098cc6dddb6799be6edb5892",
-      "branches": {
-        "master": "59c04a41ea4110cd098cc6dddb6799be6edb5892"
-      }
-    },
-    "thrunk112/mail": {
-      "default_branch": "master",
-      "sha": "035ec1602581935674e1d7539e92f979f201d42c",
-      "branches": {
-        "master": "035ec1602581935674e1d7539e92f979f201d42c"
-      }
-    },
-    "bradleeharr/mail": {
-      "default_branch": "master",
-      "sha": "59c04a41ea4110cd098cc6dddb6799be6edb5892",
-      "branches": {
-        "master": "59c04a41ea4110cd098cc6dddb6799be6edb5892"
-      }
-    },
-    "zythdr/pageturner": {
-      "default_branch": "main",
-      "sha": "0e51751babef4abf5a66397c66620c7c73420738",
-      "branches": {
-        "main": "0e51751babef4abf5a66397c66620c7c73420738"
-      }
-    },
-    "coryo/rosterfilter": {
-      "default_branch": "master",
-      "sha": "a9ddd62e7ef70b890737d2d3583d1fb7db4052f0",
-      "branches": {
-        "master": "a9ddd62e7ef70b890737d2d3583d1fb7db4052f0"
-      },
-      "latest_tag": "v2.4"
-    },
-    "vortigern11/selffound": {
-      "default_branch": "main",
-      "sha": "fadf4c12dd9d9653c76cd9f6773d0e90cdb0c729",
-      "branches": {
-        "main": "fadf4c12dd9d9653c76cd9f6773d0e90cdb0c729"
-      }
-    },
-    "bretharte89/selffound": {
-      "default_branch": "main",
-      "sha": "fadf4c12dd9d9653c76cd9f6773d0e90cdb0c729",
-      "branches": {
-        "main": "fadf4c12dd9d9653c76cd9f6773d0e90cdb0c729"
-      }
-    },
-    "anzz1/sellvalue": {
-      "default_branch": "master",
-      "sha": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e",
-      "branches": {
-        "master": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e"
-      }
-    },
-    "dbfblackbull/sellvalue": {
-      "default_branch": "master",
-      "sha": "64c61ce1729dc3d9d573c03bef16e94ad36ad7dc",
-      "branches": {
-        "master": "64c61ce1729dc3d9d573c03bef16e94ad36ad7dc"
-      }
-    },
-    "angrysathan/sellvalue": {
-      "default_branch": "master",
-      "sha": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e",
-      "branches": {
-        "master": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e"
-      }
-    },
-    "proadran/sellvalue": {
-      "default_branch": "master",
-      "sha": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e",
-      "branches": {
-        "master": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e"
-      }
-    },
-    "scumbucky/sellvalue": {
-      "default_branch": "master",
-      "sha": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e",
-      "branches": {
-        "master": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e"
-      }
-    },
-    "duzga/sellvalue": {
-      "default_branch": "master",
-      "sha": "3294787b7bfec725b221177d2685812f95bd85cb",
-      "branches": {
-        "master": "3294787b7bfec725b221177d2685812f95bd85cb"
-      }
-    },
-    "shagu/shagujunk": {
-      "default_branch": "master",
-      "sha": "9a91065d8ef9078a9ea8b7d254e88605e8367567",
-      "branches": {
-        "master": "9a91065d8ef9078a9ea8b7d254e88605e8367567"
-      }
-    },
-    "ryanhope/cheebajunk": {
-      "default_branch": "master",
-      "sha": "a845c99d55166d52c3df8008d109f3ee7df86c85",
-      "branches": {
-        "master": "a845c99d55166d52c3df8008d109f3ee7df86c85"
-      }
-    },
-    "distrattos/shagujunk": {
-      "default_branch": "master",
-      "sha": "49e0b66b6d52fb4e085e2c11ff7fcb469cb52d8b",
-      "branches": {
-        "master": "49e0b66b6d52fb4e085e2c11ff7fcb469cb52d8b"
-      }
-    },
-    "amonra/shagujunk": {
-      "default_branch": "master",
-      "sha": "9a91065d8ef9078a9ea8b7d254e88605e8367567",
-      "branches": {
-        "master": "9a91065d8ef9078a9ea8b7d254e88605e8367567"
-      }
-    },
-    "dwbclz/shagujunk": {
-      "default_branch": "master",
-      "sha": "9a91065d8ef9078a9ea8b7d254e88605e8367567",
-      "branches": {
-        "master": "9a91065d8ef9078a9ea8b7d254e88605e8367567"
-      }
-    },
-    "jiangxt316/shagujunk": {
-      "default_branch": "master",
-      "sha": "9a91065d8ef9078a9ea8b7d254e88605e8367567",
-      "branches": {
-        "master": "9a91065d8ef9078a9ea8b7d254e88605e8367567"
-      }
-    },
-    "acidtib/shagujunk": {
-      "default_branch": "master",
-      "sha": "3ff9d5f2afb318c58cb9c03afa18226dbf751341",
-      "branches": {
-        "master": "3ff9d5f2afb318c58cb9c03afa18226dbf751341"
-      }
-    },
-    "shirsig/snipe": {
-      "default_branch": "master",
-      "sha": "bbd83684f7e18e38b41c74ee64a256792e4aa5e0",
-      "branches": {
-        "master": "bbd83684f7e18e38b41c74ee64a256792e4aa5e0"
-      }
-    },
-    "redbu11dev/sortbybuyout": {
-      "default_branch": "main",
-      "sha": "4c437a3c05777fd6b207d721bf5a7f6fc394279a",
-      "branches": {
-        "main": "4c437a3c05777fd6b207d721bf5a7f6fc394279a"
-      }
-    },
-    "yutsuku/spamsentry": {
-      "default_branch": "master",
-      "sha": "9651753920f1d8b07448c6e1f41754f87189ac79",
-      "branches": {
-        "master": "9651753920f1d8b07448c6e1f41754f87189ac79"
-      }
-    },
-    "melbaa/topmeoff": {
-      "default_branch": "master",
-      "sha": "5a3e66b6d9d0996238a2c01b030397344fc19097",
-      "branches": {
-        "master": "5a3e66b6d9d0996238a2c01b030397344fc19097"
-      }
-    },
-    "sica42/turtlemail": {
-      "default_branch": "master",
-      "sha": "322429e143db1f1f00afe0d1074678a844bf8c7c",
-      "branches": {
-        "master": "322429e143db1f1f00afe0d1074678a844bf8c7c"
-      }
-    },
-    "otari98/turtlemail": {
-      "default_branch": "master",
-      "sha": "f127bafbda0ed18402d8b515fd098440b1e8d71c",
-      "branches": {
-        "master": "f127bafbda0ed18402d8b515fd098440b1e8d71c"
-      }
-    },
-    "roby-brok/octomail": {
-      "default_branch": "master",
-      "sha": "3bc9470f5e76e4bca84ce278184ccd65a3f09f96",
-      "branches": {
-        "master": "3bc9470f5e76e4bca84ce278184ccd65a3f09f96"
-      }
-    },
-    "dusk-92/turtlemail": {
-      "default_branch": "master",
-      "sha": "6f41c63922fc5f3314a7a3330fe2e0a57039fd57",
-      "branches": {
-        "master": "6f41c63922fc5f3314a7a3330fe2e0a57039fd57"
-      }
-    },
-    "dsidirop/turtlemail": {
-      "default_branch": "master",
-      "sha": "010332eb25382cb3dbba2a573c8a808e9dee9d0a",
-      "branches": {
-        "master": "010332eb25382cb3dbba2a573c8a808e9dee9d0a"
-      }
-    },
-    "utensile/turtlemail": {
-      "default_branch": "master",
-      "sha": "2b40c45433cab27c1adbb6f674d1b90b505db059",
-      "branches": {
-        "master": "2b40c45433cab27c1adbb6f674d1b90b505db059"
-      }
-    },
-    "whtmst/turtlemail": {
-      "default_branch": "master",
-      "sha": "322429e143db1f1f00afe0d1074678a844bf8c7c",
-      "branches": {
-        "master": "322429e143db1f1f00afe0d1074678a844bf8c7c"
-      }
-    },
-    "evannnn1996/turtlemail": {
-      "default_branch": "master",
-      "sha": "322429e143db1f1f00afe0d1074678a844bf8c7c",
-      "branches": {
-        "master": "322429e143db1f1f00afe0d1074678a844bf8c7c"
-      }
-    },
-    "ravenofseven/turtlemail": {
-      "default_branch": "master",
-      "sha": "322429e143db1f1f00afe0d1074678a844bf8c7c",
-      "branches": {
-        "master": "322429e143db1f1f00afe0d1074678a844bf8c7c"
-      }
-    },
-    "amonra/turtlemail": {
-      "default_branch": "master",
-      "sha": "a4884f70ef3aac805a25956750bb92106a5c8cf3",
-      "branches": {
-        "master": "a4884f70ef3aac805a25956750bb92106a5c8cf3"
-      }
-    },
-    "madskrist/turtlemail": {
-      "default_branch": "master",
-      "sha": "2a8cc7204c93dd83b54ea95009fbc6c6075d7573",
-      "branches": {
-        "master": "2a8cc7204c93dd83b54ea95009fbc6c6075d7573"
-      }
-    },
-    "einbaum/vendorautobuy": {
-      "default_branch": "master",
-      "sha": "0e82fb2facfb5ab7e3ddaa28c5d9f1f6f81c9532",
-      "branches": {
-        "master": "0e82fb2facfb5ab7e3ddaa28c5d9f1f6f81c9532"
-      },
-      "latest_tag": "1.0.0"
-    },
-    "marcelinevq/vendorlist": {
-      "default_branch": "master",
-      "sha": "6fcec31fbf19fabec6dcb58075f677a766d0dda4",
-      "branches": {
-        "master": "6fcec31fbf19fabec6dcb58075f677a766d0dda4"
-      }
-    },
-    "gregdeichler/vizput": {
-      "default_branch": "main",
-      "sha": "ef28e445c11e5c48c87a099a6338d4932426a363",
-      "branches": {
-        "main": "ef28e445c11e5c48c87a099a6338d4932426a363"
-      }
-    },
-    "ladabr/whisperfilter": {
-      "default_branch": "universal",
-      "sha": "666977c9117ee5777f053ac9eedcae1e3961df3a",
-      "branches": {
-        "universal": "666977c9117ee5777f053ac9eedcae1e3961df3a"
-      }
-    },
-    "daribon/wrugs": {
-      "default_branch": "master",
-      "sha": "608e64dcbd79d4f8dd2823a4fb9a9b789150a0ea",
-      "branches": {
-        "master": "608e64dcbd79d4f8dd2823a4fb9a9b789150a0ea"
-      }
-    },
-    "shirsig/notoggle": {
-      "default_branch": "master",
-      "sha": "43fb54eac45d1f0f6a8ee1e31cc76ef9442d6629",
-      "branches": {
-        "master": "43fb54eac45d1f0f6a8ee1e31cc76ef9442d6629"
-      }
-    },
-    "niclaseriksen/4hmhelper": {
-      "default_branch": "main",
-      "sha": "2d270895ab5b2e645e70045a60043d4f2bb466da",
-      "branches": {
-        "main": "2d270895ab5b2e645e70045a60043d4f2bb466da"
-      }
-    },
-    "kiiruaa/_antinvite": {
-      "default_branch": "master",
-      "sha": "35257bba9cf9645c1c9a927525a6c3880d2381a5",
-      "branches": {
-        "master": "35257bba9cf9645c1c9a927525a6c3880d2381a5"
-      },
-      "latest_tag": "v0.3"
-    },
-    "xorann/abraxas": {
-      "default_branch": "master",
-      "sha": "9eb1bc1b81f27943c605bb39d383f10fad4fe0b7",
-      "branches": {
-        "master": "9eb1bc1b81f27943c605bb39d383f10fad4fe0b7"
-      },
-      "latest_tag": "r2"
-    },
-    "the-kludge-bureau/accountant": {
-      "default_branch": "main",
-      "sha": "9078a7cd0f30b328aa939cb63c636c818c4af204",
-      "branches": {
-        "main": "9078a7cd0f30b328aa939cb63c636c818c4af204"
-      },
-      "latest_tag": "3.1"
-    },
-    "evannnn1996/accountant": {
-      "default_branch": "main",
-      "sha": "1e2bc02396eebafd5e1e2e3720e3cae1bcdf47f7",
-      "branches": {
-        "main": "1e2bc02396eebafd5e1e2e3720e3cae1bcdf47f7"
-      }
-    },
-    "numielle/actionbuttonutils": {
-      "default_branch": "master",
-      "sha": "42b7b97ba37e7d5453650a482b2b3d1ec51e95ee",
-      "branches": {
-        "master": "42b7b97ba37e7d5453650a482b2b3d1ec51e95ee"
-      },
-      "latest_tag": "1.0.2"
-    },
-    "gashole/aero": {
-      "default_branch": "master",
-      "sha": "f6304c8834f1c8a0289f5ce93e49b29aed0585dc",
-      "branches": {
-        "master": "f6304c8834f1c8a0289f5ce93e49b29aed0585dc"
-      }
-    },
-    "nehswu/altoholic_vanilla": {
-      "default_branch": "master",
-      "sha": "d6929562ecbcd562dccba285935ecd36ee905435",
-      "branches": {
-        "master": "d6929562ecbcd562dccba285935ecd36ee905435"
-      },
-      "latest_tag": "1.0.9"
-    },
-    "gbl/altoholic_vanilla": {
-      "default_branch": "master",
-      "sha": "d4d5e8c0aa59a61f9cee07bc5444ba906fbde9bc",
-      "branches": {
-        "master": "d4d5e8c0aa59a61f9cee07bc5444ba906fbde9bc"
-      },
-      "latest_tag": "gbl1.0.0"
-    },
-    "zmarotrix/altoholic_vanilla": {
-      "default_branch": "master",
-      "sha": "a72a7f276882e619bda67793840479446b1382e5",
-      "branches": {
-        "master": "a72a7f276882e619bda67793840479446b1382e5"
-      }
-    },
-    "einbaum/announcekick": {
-      "default_branch": "master",
-      "sha": "95e17fc04b70eb48cee7051ff2d739927c0eaafb",
-      "branches": {
-        "master": "95e17fc04b70eb48cee7051ff2d739927c0eaafb"
-      },
-      "latest_tag": "1.0.0"
-    },
-    "thepparker/antispamstopcast": {
-      "default_branch": "master",
-      "sha": "fe861706d738d7fc3ec1389e29e70e2842c23d86",
-      "branches": {
-        "master": "fe861706d738d7fc3ec1389e29e70e2842c23d86"
-      }
-    },
-    "allingaming/arcanesurgewarning": {
-      "default_branch": "main",
-      "sha": "63fc40421336346cbaa67b521711101711d4212b",
-      "branches": {
-        "main": "63fc40421336346cbaa67b521711101711d4212b"
-      }
-    },
-    "pepopo978/arcanum": {
-      "default_branch": "main",
-      "sha": "00f90fca8e2cbacc8a0e43a8904377c692dc9319",
-      "branches": {
-        "main": "00f90fca8e2cbacc8a0e43a8904377c692dc9319"
-      }
-    },
-    "therealfayz/arcanum": {
-      "default_branch": "main",
-      "sha": "337f500abeeeb126e54a7bce90e65add4bec56e8",
-      "branches": {
-        "main": "337f500abeeeb126e54a7bce90e65add4bec56e8"
-      }
-    },
-    "codeshard/architotem": {
-      "default_branch": "master",
-      "sha": "b2aa56ca6ba10b52bcf3cdb7eb91c43f3a822abc",
-      "branches": {
-        "master": "b2aa56ca6ba10b52bcf3cdb7eb91c43f3a822abc"
-      },
-      "latest_tag": "v1.6.3"
-    },
-    "terongorus/architotem-teron": {
-      "default_branch": "master",
-      "sha": "3a9cef182a84873ea3c23268dbb9c53c61efbf0b",
-      "branches": {
-        "master": "3a9cef182a84873ea3c23268dbb9c53c61efbf0b"
-      }
-    },
-    "shirsig/attack": {
-      "default_branch": "master",
-      "sha": "2b6aa85fe9693f540fee8dfa3b90e6e0768237a3",
-      "branches": {
-        "master": "2b6aa85fe9693f540fee8dfa3b90e6e0768237a3"
-      }
-    },
-    "siventt/attackbar-twow": {
-      "default_branch": "master",
-      "sha": "9227d13c58c0b723678e69f79603aaff31e90a7f",
-      "branches": {
-        "master": "9227d13c58c0b723678e69f79603aaff31e90a7f"
-      }
-    },
-    "deceius/attackbar": {
-      "default_branch": "master",
-      "sha": "f0e6a588cb31484300aea9e864aa7b843233f9ed",
-      "branches": {
-        "master": "f0e6a588cb31484300aea9e864aa7b843233f9ed"
-      }
-    },
-    "paokkerkir/attackbar_dragonflightui": {
-      "default_branch": "master",
-      "sha": "f72b15cfad06b6487d9253f26f46d5a624163220",
-      "branches": {
-        "master": "f72b15cfad06b6487d9253f26f46d5a624163220"
-      }
-    },
-    "road-block/auldlangsyne": {
-      "default_branch": "master",
-      "sha": "e77bebedb909cc6defd946b49e456362c7825ceb",
-      "branches": {
-        "master": "e77bebedb909cc6defd946b49e456362c7825ceb"
-      },
-      "latest_tag": "1.1"
-    },
-    "refaim/auldlangsyne": {
-      "default_branch": "master",
-      "sha": "5263f9feac9598d356104e0f949851102a1e73e6",
-      "branches": {
-        "master": "5263f9feac9598d356104e0f949851102a1e73e6"
-      }
-    },
-    "kameleonuk/auldlangsyne": {
-      "default_branch": "master",
-      "sha": "33970b2ece4adb92278d4cc0c688454bae48e390",
-      "branches": {
-        "master": "33970b2ece4adb92278d4cc0c688454bae48e390"
-      }
-    },
-    "mcpewpew/autodecline": {
-      "default_branch": "master",
-      "sha": "119aa402925bc5a427b07c6eb0e21696e639b54d",
-      "branches": {
-        "master": "119aa402925bc5a427b07c6eb0e21696e639b54d"
-      }
-    },
-    "atreyyo/autodot": {
-      "default_branch": "master",
-      "sha": "707dae14bcba632c6ee41b046d54e1a26d313f19",
-      "branches": {
-        "master": "707dae14bcba632c6ee41b046d54e1a26d313f19"
-      }
-    },
-    "leenux/autoexpenable": {
-      "default_branch": "main",
-      "sha": "d4a134d62aae9ceab4e42152a7803a1556bb1015",
-      "branches": {
-        "main": "d4a134d62aae9ceab4e42152a7803a1556bb1015"
-      }
-    },
-    "einbaum/autohump": {
-      "default_branch": "master",
-      "sha": "f0df86e776daffa250f3e67b073e209d9eab8209",
-      "branches": {
-        "master": "f0df86e776daffa250f3e67b073e209d9eab8209"
-      }
-    },
-    "fsuhas/autolfm": {
-      "default_branch": "master",
-      "sha": "168f9e2966a5ddb980be05433e45bf648363b6bb",
-      "branches": {
-        "master": "168f9e2966a5ddb980be05433e45bf648363b6bb"
-      }
-    },
-    "monomode/turtlewow--autolfg": {
-      "default_branch": "master",
-      "sha": "6ec7b8150b44f5fed4891ac31e4d931ca914724f",
-      "branches": {
-        "master": "6ec7b8150b44f5fed4891ac31e4d931ca914724f"
-      }
-    },
-    "marcelinevq/automana": {
-      "default_branch": "master",
-      "sha": "4a38b3353a294667da04938e03957f53ce1518f1",
-      "branches": {
-        "master": "4a38b3353a294667da04938e03957f53ce1518f1"
-      }
-    },
-    "lythandrawow/lyth_automana": {
-      "default_branch": "master",
-      "sha": "e3c52bd2a97f64c08b65bc7bdc3eab3f4e4c4058",
-      "branches": {
-        "master": "e3c52bd2a97f64c08b65bc7bdc3eab3f4e4c4058"
-      }
-    },
     "0ldi/automessage": {
       "default_branch": "master",
       "sha": "c367bb48ae07c4bb1aa7e1d53b11fb0555623d2b",
       "branches": {
         "master": "c367bb48ae07c4bb1aa7e1d53b11fb0555623d2b"
-      }
-    },
-    "gbl/autoreputationbar": {
-      "default_branch": "master",
-      "sha": "9044eab904547cd5af101e7e8b29c9c21c8c4d60",
-      "branches": {
-        "master": "9044eab904547cd5af101e7e8b29c9c21c8c4d60"
-      }
-    },
-    "wouterbink/autoshot": {
-      "default_branch": "master",
-      "sha": "0a8b53551bda2bd1fd76c532b1f558d0bf6b30bb",
-      "branches": {
-        "master": "0a8b53551bda2bd1fd76c532b1f558d0bf6b30bb"
-      }
-    },
-    "cyaohiri/autoshot": {
-      "default_branch": "master",
-      "sha": "62e93212072fae64dad4525c161376d523c39e69",
-      "branches": {
-        "master": "62e93212072fae64dad4525c161376d523c39e69"
-      }
-    },
-    "dayfiree/autospellranker": {
-      "default_branch": "main",
-      "sha": "625e2088a50f2df30314b740356a06f875e13600",
-      "branches": {
-        "main": "625e2088a50f2df30314b740356a06f875e13600"
-      }
-    },
-    "mcpewpew/bartender2-read-instructions": {
-      "default_branch": "master",
-      "sha": "1eec247ecaf755916ece74009b367c5f7219f0c4",
-      "branches": {
-        "master": "1eec247ecaf755916ece74009b367c5f7219f0c4"
-      }
-    },
-    "bludmoon/bartender2-read-instructions": {
-      "default_branch": "master",
-      "sha": "1eec247ecaf755916ece74009b367c5f7219f0c4",
-      "branches": {
-        "master": "1eec247ecaf755916ece74009b367c5f7219f0c4"
-      }
-    },
-    "jogadoaoleu/bartender2-read-instructions": {
-      "default_branch": "master",
-      "sha": "1eec247ecaf755916ece74009b367c5f7219f0c4",
-      "branches": {
-        "master": "1eec247ecaf755916ece74009b367c5f7219f0c4"
-      }
-    },
-    "lastozavr1/bartender2-read-instructions": {
-      "default_branch": "master",
-      "sha": "1eec247ecaf755916ece74009b367c5f7219f0c4",
-      "branches": {
-        "master": "1eec247ecaf755916ece74009b367c5f7219f0c4"
-      }
-    },
-    "fiskehatt/bearcastbar": {
-      "default_branch": "master",
-      "sha": "64944e8c4c653ae9415eae64d4024c23241416c6",
-      "branches": {
-        "master": "64944e8c4c653ae9415eae64d4024c23241416c6"
-      }
-    },
-    "crackedmustache/bearcastbar_castbartoggle": {
-      "default_branch": "master",
-      "sha": "5e19c5b201effacc21f5ac1faa39c286772037ff",
-      "branches": {
-        "master": "5e19c5b201effacc21f5ac1faa39c286772037ff"
-      },
-      "latest_tag": "v1.0"
-    },
-    "s4intzzz/bearcastbar": {
-      "default_branch": "master",
-      "sha": "626d6648f135b27efe674520632ecffb9b62211e",
-      "branches": {
-        "master": "626d6648f135b27efe674520632ecffb9b62211e"
-      }
-    },
-    "cama-dev/turtlebeastiary": {
-      "default_branch": "main",
-      "sha": "6def1c555106db9d181b4820edd53f7a4ea3561f",
-      "branches": {
-        "main": "6def1c555106db9d181b4820edd53f7a4ea3561f"
-      }
-    },
-    "denniswg/betteralign": {
-      "default_branch": "master",
-      "sha": "b1ef86016dd0dee96e60870649f77b0a27a7b95e",
-      "branches": {
-        "master": "b1ef86016dd0dee96e60870649f77b0a27a7b95e"
-      },
-      "latest_tag": "1.0.0"
-    },
-    "yutsuku/betterbabelfish": {
-      "default_branch": "master",
-      "sha": "5fb2a05e826edd8895505317595bb86843a025c6",
-      "branches": {
-        "master": "5fb2a05e826edd8895505317595bb86843a025c6"
-      }
-    },
-    "otari98/bettercharacterstats": {
-      "default_branch": "main",
-      "sha": "0d5d84f42267b20263cb1b5aaaa8a55f08b227d4",
-      "branches": {
-        "main": "0d5d84f42267b20263cb1b5aaaa8a55f08b227d4"
-      }
-    },
-    "denisisk/bettercharacterstats-octowow": {
-      "default_branch": "main",
-      "sha": "3a7177253e07e5e564289a0a81c96597177879cd",
-      "branches": {
-        "main": "3a7177253e07e5e564289a0a81c96597177879cd"
-      }
-    },
-    "jrc13245/bettercharacterstats": {
-      "default_branch": "main",
-      "sha": "0eb361ee6df2891c5417d08bb690c0987c48c5a8",
-      "branches": {
-        "main": "0eb361ee6df2891c5417d08bb690c0987c48c5a8"
-      }
-    },
-    "jeromem/bettereverlookbroadcastingco": {
-      "default_branch": "master",
-      "sha": "1be039605b90931afbed8533034618da54a1504d",
-      "branches": {
-        "master": "1be039605b90931afbed8533034618da54a1504d"
-      },
-      "latest_tag": "v1.1.0"
-    },
-    "neolectron/betterhelp": {
-      "default_branch": "master",
-      "sha": "235d6e291e5d24afe9be29a0518dbd005d26f7a1",
-      "branches": {
-        "master": "235d6e291e5d24afe9be29a0518dbd005d26f7a1"
-      }
-    },
-    "yutsuku/betterscoreframe": {
-      "default_branch": "master",
-      "sha": "b28ef19635417ff6e1351fb631ae5e756132f014",
-      "branches": {
-        "master": "b28ef19635417ff6e1351fb631ae5e756132f014"
-      }
-    },
-    "einherjarn/bgflag": {
-      "default_branch": "master",
-      "sha": "043bb62a22f27f32a0095950b5df65ed52eda218",
-      "branches": {
-        "master": "043bb62a22f27f32a0095950b5df65ed52eda218"
-      }
-    },
-    "jejkas/bigbrother": {
-      "default_branch": "master",
-      "sha": "a1193b887b84067b21eb98ec8c14af6d32845c68",
-      "branches": {
-        "master": "a1193b887b84067b21eb98ec8c14af6d32845c68"
-      }
-    },
-    "gabcinder2004/bislist": {
-      "default_branch": "master",
-      "sha": "cbfa05df370d78047fbc34c2a55e15d9ba0eee78",
-      "branches": {
-        "master": "cbfa05df370d78047fbc34c2a55e15d9ba0eee78"
-      },
-      "latest_tag": "v1.1"
-    },
-    "dbfblackbull/bitescookbook": {
-      "default_branch": "master",
-      "sha": "36c919110a87bcadbc331f657bc962da00c3ef92",
-      "branches": {
-        "master": "36c919110a87bcadbc331f657bc962da00c3ef92"
-      }
-    },
-    "chrisbigart/bitescookbook": {
-      "default_branch": "master",
-      "sha": "371a84e3cdf2ae22c73755ff559b822be3051528",
-      "branches": {
-        "master": "371a84e3cdf2ae22c73755ff559b822be3051528"
-      }
-    },
-    "zerf/blacklist": {
-      "default_branch": "master",
-      "sha": "9a066c287d0f923a61beb601f2bec3e8eb9f648c",
-      "branches": {
-        "master": "9a066c287d0f923a61beb601f2bec3e8eb9f648c"
-      }
-    },
-    "matwebmasta/blacklist": {
-      "default_branch": "master",
-      "sha": "dab8cda0052b8b5ee565a6dae29a03c147c27c80",
-      "branches": {
-        "master": "dab8cda0052b8b5ee565a6dae29a03c147c27c80"
-      }
-    },
-    "gescht/blacklist": {
-      "default_branch": "master",
-      "sha": "12785fef160703218348fdc3d3da8ab96f0975c6",
-      "branches": {
-        "master": "12785fef160703218348fdc3d3da8ab96f0975c6"
-      }
-    },
-    "zmarotrix/blacklist": {
-      "default_branch": "master",
-      "sha": "1bcaa2cea91f82170fb1f9a308c753d237ed00c1",
-      "branches": {
-        "master": "1bcaa2cea91f82170fb1f9a308c753d237ed00c1"
-      }
-    },
-    "sondli/blockvalue": {
-      "default_branch": "main",
-      "sha": "7f65aed87e78ab0c85640cb909472e78c2a0e245",
-      "branches": {
-        "main": "7f65aed87e78ab0c85640cb909472e78c2a0e245"
-      },
-      "latest_tag": "1.0.0"
-    },
-    "muellerj/bloodrage": {
-      "default_branch": "master",
-      "sha": "9095d91c9a74724738601d0b3d814d755aaa5af5",
-      "branches": {
-        "master": "9095d91c9a74724738601d0b3d814d755aaa5af5"
-      }
-    },
-    "turinpt/bossalert": {
-      "default_branch": "master",
-      "sha": "aead2112b0ef4792975124c384196149e8baeec7",
-      "branches": {
-        "master": "aead2112b0ef4792975124c384196149e8baeec7"
-      }
-    },
-    "zensociety/bossdeathtimer": {
-      "default_branch": "main",
-      "sha": "bb74a18ca2ccfa4afe9a6ec3617cea937a3cdc7a",
-      "branches": {
-        "main": "bb74a18ca2ccfa4afe9a6ec3617cea937a3cdc7a"
-      },
-      "latest_tag": "v0.01"
-    },
-    "marcelinevq/brainsaver": {
-      "default_branch": "master",
-      "sha": "35aa13b050915862b5a7303eb43bd6525876fb09",
-      "branches": {
-        "master": "35aa13b050915862b5a7303eb43bd6525876fb09"
-      }
-    },
-    "al3xc1985/brainsaver": {
-      "default_branch": "master",
-      "sha": "35aa13b050915862b5a7303eb43bd6525876fb09",
-      "branches": {
-        "master": "35aa13b050915862b5a7303eb43bd6525876fb09"
-      }
-    },
-    "fsuhas/brainsaver": {
-      "default_branch": "master",
-      "sha": "5d8579a122613b9f209a2278a09212ce73d9420d",
-      "branches": {
-        "master": "5d8579a122613b9f209a2278a09212ce73d9420d"
-      }
-    },
-    "cinecom/brainwasherpro": {
-      "default_branch": "main",
-      "sha": "ec02c4ea74ebc59791873943bd57fdd1179c9cc7",
-      "branches": {
-        "main": "ec02c4ea74ebc59791873943bd57fdd1179c9cc7"
-      }
-    },
-    "fsuhas/bsalert-tw": {
-      "default_branch": "main",
-      "sha": "3104b532b0f0ac3d262be3398655adb0b115b5dc",
-      "branches": {
-        "main": "3104b532b0f0ac3d262be3398655adb0b115b5dc"
-      }
-    },
-    "computerequipmentgroup/bubbles": {
-      "default_branch": "main",
-      "sha": "d6e07f8b958ade654fa5e02be6f63ae22e7f634f",
-      "branches": {
-        "main": "d6e07f8b958ade654fa5e02be6f63ae22e7f634f"
-      },
-      "latest_tag": "1.2"
-    },
-    "orange-pig/bubbles": {
-      "default_branch": "main",
-      "sha": "fbce2aa48e1f9e6052d8b613ca79194636906725",
-      "branches": {
-        "main": "fbce2aa48e1f9e6052d8b613ca79194636906725"
-      }
-    },
-    "mcpewpew/bugsack": {
-      "default_branch": "master",
-      "sha": "163158abcd49464d285b5c3f3e547c4b873a687f",
-      "branches": {
-        "master": "163158abcd49464d285b5c3f3e547c4b873a687f"
-      }
-    },
-    "refaim/bugsack": {
-      "default_branch": "master",
-      "sha": "68115c8e9f02e924773860fed66c18734ef45f93",
-      "branches": {
-        "master": "68115c8e9f02e924773860fed66c18734ef45f93"
-      }
-    },
-    "obszczymucha/bugsack": {
-      "default_branch": "master",
-      "sha": "055b047896ff60f22dc81de6eb4e0f2a095ec5a6",
-      "branches": {
-        "master": "055b047896ff60f22dc81de6eb4e0f2a095ec5a6"
-      }
-    },
-    "road-block/calltoarms": {
-      "default_branch": "master",
-      "sha": "aef2cef25340a270b1f889f8ea4429409da78aa5",
-      "branches": {
-        "master": "aef2cef25340a270b1f889f8ea4429409da78aa5"
-      },
-      "latest_tag": "R12.5"
-    },
-    "sentilix/capslock": {
-      "default_branch": "master",
-      "sha": "2960f9fc9d0fdef39949729fbc71fbc4ea84a67d",
-      "branches": {
-        "master": "2960f9fc9d0fdef39949729fbc71fbc4ea84a67d"
-      },
-      "latest_tag": "0.3.1"
-    },
-    "mrtoffee/caramelnotes": {
-      "default_branch": "main",
-      "sha": "e607ec7c7a3c7d27c7cfcd391f5fb8a715ce4b07",
-      "branches": {
-        "main": "e607ec7c7a3c7d27c7cfcd391f5fb8a715ce4b07"
-      }
-    },
-    "linae-kronos/casterstats": {
-      "default_branch": "master",
-      "sha": "ed43393184e81d488b106c5b1b12a4382189e04d",
-      "branches": {
-        "master": "ed43393184e81d488b106c5b1b12a4382189e04d"
-      }
-    },
-    "abstr4ctz/casthistorytracker": {
-      "default_branch": "main",
-      "sha": "5de5cd4b40018c53cd2ee3291a077303b5969f28",
-      "branches": {
-        "main": "5de5cd4b40018c53cd2ee3291a077303b5969f28"
-      }
-    },
-    "bretharte89/casthistorytracker": {
-      "default_branch": "main",
-      "sha": "5de5cd4b40018c53cd2ee3291a077303b5969f28",
-      "branches": {
-        "main": "5de5cd4b40018c53cd2ee3291a077303b5969f28"
-      }
-    },
-    "vargv666/casthistorytracker": {
-      "default_branch": "main",
-      "sha": "20a70661983bb25510bbf9202b842dba65186e77",
-      "branches": {
-        "main": "20a70661983bb25510bbf9202b842dba65186e77"
-      }
-    },
-    "pepopo978/casttimer": {
-      "default_branch": "master",
-      "sha": "774a06f750f468c70dabea2d0b3378c866580b89",
-      "branches": {
-        "master": "774a06f750f468c70dabea2d0b3378c866580b89"
-      }
-    },
-    "shirsig/ccwatch": {
-      "default_branch": "master",
-      "sha": "b88c980aca96632a61406f525e776095be21a2bb",
-      "branches": {
-        "master": "b88c980aca96632a61406f525e776095be21a2bb"
-      }
-    },
-    "shirsig/cdframes": {
-      "default_branch": "master",
-      "sha": "e3242a6144f60e6e468430311ac070a2f6e1a43c",
-      "branches": {
-        "master": "e3242a6144f60e6e468430311ac070a2f6e1a43c"
-      }
-    },
-    "cyaohiri/censusplusturtle": {
-      "default_branch": "main",
-      "sha": "6dae25fad5fcf038083ded230c380cc56b142d3a",
-      "branches": {
-        "main": "6dae25fad5fcf038083ded230c380cc56b142d3a"
-      }
-    },
-    "xcornelius/censusplusturtle": {
-      "default_branch": "main",
-      "sha": "6dae25fad5fcf038083ded230c380cc56b142d3a",
-      "branches": {
-        "main": "6dae25fad5fcf038083ded230c380cc56b142d3a"
-      }
-    },
-    "cernie/cernieswonderfulfunctions": {
-      "default_branch": "master",
-      "sha": "c89ecbe4789323ee6396a60fee15447708f22759",
-      "branches": {
-        "master": "c89ecbe4789323ee6396a60fee15447708f22759"
-      }
-    },
-    "dsidirop/cernieswonderfulfunctions": {
-      "default_branch": "master",
-      "sha": "da7a16caa7e1b567f749e18f4b470b7155f461f8",
-      "branches": {
-        "master": "da7a16caa7e1b567f749e18f4b470b7155f461f8"
-      },
-      "latest_tag": "v01.10.01.00"
-    },
-    "shirsig/channel_monitor": {
-      "default_branch": "master",
-      "sha": "ed4297565efeb67c8bb743571e2280b79d2f05f7",
-      "branches": {
-        "master": "ed4297565efeb67c8bb743571e2280b79d2f05f7"
-      }
-    },
-    "saegiru/channel_monitor": {
-      "default_branch": "master",
-      "sha": "febfc02bccfc33214131d822cef75520c70f464c",
-      "branches": {
-        "master": "febfc02bccfc33214131d822cef75520c70f464c"
-      }
-    },
-    "akzkak/channelmonitorplus": {
-      "default_branch": "master",
-      "sha": "cb43cb64e51849c66a7cc299a5c4d0af8ec878de",
-      "branches": {
-        "master": "cb43cb64e51849c66a7cc299a5c4d0af8ec878de"
-      }
-    },
-    "goose404/channel_monitor": {
-      "default_branch": "master",
-      "sha": "ed3869ca3cfeff5ca5c7cfc27c01ffa1f72b2837",
-      "branches": {
-        "master": "ed3869ca3cfeff5ca5c7cfc27c01ffa1f72b2837"
-      }
-    },
-    "nanatot/channel_monitor": {
-      "default_branch": "master",
-      "sha": "3fbd7f205c86f3bc9f6ecd2b8f72c88ca9d9b0c3",
-      "branches": {
-        "master": "3fbd7f205c86f3bc9f6ecd2b8f72c88ca9d9b0c3"
-      }
-    },
-    "rnorden/chaosreserves": {
-      "default_branch": "master",
-      "sha": "d4f84111c69b54ed1aa8223714c709bad086a42c",
-      "branches": {
-        "master": "d4f84111c69b54ed1aa8223714c709bad086a42c"
-      },
-      "latest_tag": "0.72"
-    },
-    "celguar/characterprofiler": {
-      "default_branch": "master",
-      "sha": "8501d6991302d177776ace5f5843cd24b6308974",
-      "branches": {
-        "master": "8501d6991302d177776ace5f5843cd24b6308974"
-      },
-      "latest_tag": "1.0"
-    },
-    "al3xc1985/characterprofiler": {
-      "default_branch": "master",
-      "sha": "8501d6991302d177776ace5f5843cd24b6308974",
-      "branches": {
-        "master": "8501d6991302d177776ace5f5843cd24b6308974"
       }
     },
     "0ldi/chatbar": {
@@ -2889,42 +15,6 @@
       "branches": {
         "master": "ab3106bdfbd33bb871ceac1848e70f2d71e73f32"
       }
-    },
-    "lioryx/chatbar": {
-      "default_branch": "master",
-      "sha": "aee17453d3e15659cc3e665db579a70397c2f294",
-      "branches": {
-        "master": "aee17453d3e15659cc3e665db579a70397c2f294"
-      }
-    },
-    "evannnn1996/chatbar": {
-      "default_branch": "master",
-      "sha": "4570e5aad1d860ed3a8e6267d26ec71ad82487f9",
-      "branches": {
-        "master": "4570e5aad1d860ed3a8e6267d26ec71ad82487f9"
-      }
-    },
-    "daomatys/chatbar": {
-      "default_branch": "master",
-      "sha": "dab207f1e96748705115ffed1c2536b1a34a9575",
-      "branches": {
-        "master": "dab207f1e96748705115ffed1c2536b1a34a9575"
-      }
-    },
-    "amstiel/chatbar": {
-      "default_branch": "master",
-      "sha": "ab3106bdfbd33bb871ceac1848e70f2d71e73f32",
-      "branches": {
-        "master": "ab3106bdfbd33bb871ceac1848e70f2d71e73f32"
-      }
-    },
-    "road-block/chatemote": {
-      "default_branch": "master",
-      "sha": "8a8e8dee15ce89ae0cc3ed380a76de76e2653c47",
-      "branches": {
-        "master": "8a8e8dee15ce89ae0cc3ed380a76de76e2653c47"
-      },
-      "latest_tag": "1.11-11200"
     },
     "0ldi/chatfix": {
       "default_branch": "master",
@@ -2940,814 +30,6 @@
         "master": "6a0d97db6225e2fcae0444bf578b33efbc09c7bd"
       }
     },
-    "aleksiykotelnikov/chatlog": {
-      "default_branch": "master",
-      "sha": "efaebced41856b20138fe1892da93231111f418b",
-      "branches": {
-        "master": "efaebced41856b20138fe1892da93231111f418b"
-      }
-    },
-    "scotthamper/chatsuey": {
-      "default_branch": "master",
-      "sha": "c63bbef38a3f8989546f254c3867168567072fb0",
-      "branches": {
-        "master": "c63bbef38a3f8989546f254c3867168567072fb0"
-      },
-      "latest_tag": "1.2.0"
-    },
-    "lurexx/chatsuey": {
-      "default_branch": "master",
-      "sha": "42219504605a7db7dafa2df636a21f463423e1fd",
-      "branches": {
-        "master": "42219504605a7db7dafa2df636a21f463423e1fd"
-      },
-      "latest_tag": "1.2.0"
-    },
-    "wbb1977/chattimestamps": {
-      "default_branch": "master",
-      "sha": "ea11be079d5a61adf429973ded0ad8beda8c485e",
-      "branches": {
-        "master": "ea11be079d5a61adf429973ded0ad8beda8c485e"
-      },
-      "latest_tag": "1.6a"
-    },
-    "cyaohiri/chattimestamps": {
-      "default_branch": "master",
-      "sha": "eace4ae20f20102f0c4794b1da35ecf6d4b57854",
-      "branches": {
-        "master": "eace4ae20f20102f0c4794b1da35ecf6d4b57854"
-      }
-    },
-    "swizzpop/chickenjockey": {
-      "default_branch": "main",
-      "sha": "7ba0158232cc1faabdbb412bc70bec74937fb9ea",
-      "branches": {
-        "main": "7ba0158232cc1faabdbb412bc70bec74937fb9ea"
-      }
-    },
-    "satan666/lazyspell": {
-      "default_branch": "master",
-      "sha": "3e9a5eee251fca2bd6bcede98f71270fdb955dae",
-      "branches": {
-        "master": "3e9a5eee251fca2bd6bcede98f71270fdb955dae"
-      }
-    },
-    "refaim/classicons": {
-      "default_branch": "master",
-      "sha": "8c8f26181ba8eddbd2f5b14e2b2932a7f9d01e6c",
-      "branches": {
-        "master": "8c8f26181ba8eddbd2f5b14e2b2932a7f9d01e6c"
-      }
-    },
-    "road-block/classicsnowfall": {
-      "default_branch": "master",
-      "sha": "fd802c10662198d03a1dbe1ccc72aa314da515c6",
-      "branches": {
-        "master": "fd802c10662198d03a1dbe1ccc72aa314da515c6"
-      },
-      "latest_tag": "0.5-11200"
-    },
-    "ko0z/classportraits_vanilla": {
-      "default_branch": "master",
-      "sha": "1d98c52195de8f603b5c33ddf62bd13d9984319e",
-      "branches": {
-        "master": "1d98c52195de8f603b5c33ddf62bd13d9984319e"
-      }
-    },
-    "refaim/cleanchat": {
-      "default_branch": "master",
-      "sha": "84e0e57e306265ae4f5ace596678cefd27ff4475",
-      "branches": {
-        "master": "84e0e57e306265ae4f5ace596678cefd27ff4475"
-      }
-    },
-    "wbb1977/cleanplayerframe": {
-      "default_branch": "master",
-      "sha": "234eb6d89bb24adb956dcececa590d664cc6b558",
-      "branches": {
-        "master": "234eb6d89bb24adb956dcececa590d664cc6b558"
-      },
-      "latest_tag": "11200"
-    },
-    "shirsig/cleanup-vanilla": {
-      "default_branch": "master",
-      "sha": "4c83ecb84f376979a0ac6b4747a0bed467cb9b90",
-      "branches": {
-        "master": "4c83ecb84f376979a0ac6b4747a0bed467cb9b90"
-      }
-    },
-    "chad90b/cleanup-vanilla": {
-      "default_branch": "master",
-      "sha": "4c83ecb84f376979a0ac6b4747a0bed467cb9b90",
-      "branches": {
-        "master": "4c83ecb84f376979a0ac6b4747a0bed467cb9b90"
-      }
-    },
-    "saxxonpike/cleanup": {
-      "default_branch": "master",
-      "sha": "4c83ecb84f376979a0ac6b4747a0bed467cb9b90",
-      "branches": {
-        "master": "4c83ecb84f376979a0ac6b4747a0bed467cb9b90"
-      }
-    },
-    "danieladolfsson/clevermacro": {
-      "default_branch": "master",
-      "sha": "7b85b4c4e59cfea121e5460dfc19e0dde8c89472",
-      "branches": {
-        "master": "7b85b4c4e59cfea121e5460dfc19e0dde8c89472"
-      },
-      "latest_tag": "v1.4"
-    },
-    "ironscyde/clevermacro": {
-      "default_branch": "master",
-      "sha": "b31aa55e2276a7c99e11a65e55a25d9b7c8e4a60",
-      "branches": {
-        "master": "b31aa55e2276a7c99e11a65e55a25d9b7c8e4a60"
-      }
-    },
-    "nighttripperid/clevermacro": {
-      "default_branch": "master",
-      "sha": "7b85b4c4e59cfea121e5460dfc19e0dde8c89472",
-      "branches": {
-        "master": "7b85b4c4e59cfea121e5460dfc19e0dde8c89472"
-      }
-    },
-    "cutiepoka/cleveroidmacros": {
-      "default_branch": "main",
-      "sha": "9456c483dd21a77028aa6afc5952e8ef190426bf",
-      "branches": {
-        "main": "9456c483dd21a77028aa6afc5952e8ef190426bf"
-      }
-    },
-    "unemployedwaifu/cleveroidmacros": {
-      "default_branch": "main",
-      "sha": "9456c483dd21a77028aa6afc5952e8ef190426bf",
-      "branches": {
-        "main": "9456c483dd21a77028aa6afc5952e8ef190426bf"
-      }
-    },
-    "itslusse/clifftells": {
-      "default_branch": "main",
-      "sha": "eade44ff6dd3693584358eadb6851ea254a1aa7b",
-      "branches": {
-        "main": "eade44ff6dd3693584358eadb6851ea254a1aa7b"
-      }
-    },
-    "shagu/clique": {
-      "default_branch": "master",
-      "sha": "87717adc0ba5456aadfb88cb9fa0a2189c241763",
-      "branches": {
-        "master": "87717adc0ba5456aadfb88cb9fa0a2189c241763"
-      },
-      "latest_tag": "14063"
-    },
-    "marcelinevq/clique": {
-      "default_branch": "master",
-      "sha": "872d441ca796e08eba79747909632cf3097100a9",
-      "branches": {
-        "master": "872d441ca796e08eba79747909632cf3097100a9"
-      }
-    },
-    "cabro/clog": {
-      "default_branch": "master",
-      "sha": "e9fd281f7947bfeffe96decca152446e64b34ec8",
-      "branches": {
-        "master": "e9fd281f7947bfeffe96decca152446e64b34ec8"
-      }
-    },
-    "road-block/closeup": {
-      "default_branch": "master",
-      "sha": "01c0c296b0840b5732690716156c9958744248c0",
-      "branches": {
-        "master": "01c0c296b0840b5732690716156c9958744248c0"
-      },
-      "latest_tag": "11200"
-    },
-    "chad90b/codex": {
-      "default_branch": "main",
-      "sha": "dff918ab8a2c742982fa12df865d6224cf7d4a4f",
-      "branches": {
-        "main": "dff918ab8a2c742982fa12df865d6224cf7d4a4f"
-      }
-    },
-    "mr-rosh/colorpickerplus": {
-      "default_branch": "master",
-      "sha": "178e7b9980467a70bd353a9afb95db1ebf6b6a0b",
-      "branches": {
-        "master": "178e7b9980467a70bd353a9afb95db1ebf6b6a0b"
-      }
-    },
-    "road-block/colorsocialframe": {
-      "default_branch": "master",
-      "sha": "723fe40b9635fc96c48960cbb9b8bd189a4a4f06",
-      "branches": {
-        "master": "723fe40b9635fc96c48960cbb9b8bd189a4a4f06"
-      },
-      "latest_tag": "1.30"
-    },
-    "cysthen/comix": {
-      "default_branch": "main",
-      "sha": "0c1fb1c38260babf4194a4342f1f954ecce37a95",
-      "branches": {
-        "main": "0c1fb1c38260babf4194a4342f1f954ecce37a95"
-      }
-    },
-    "tubtubs/comix": {
-      "default_branch": "main",
-      "sha": "0c1fb1c38260babf4194a4342f1f954ecce37a95",
-      "branches": {
-        "main": "0c1fb1c38260babf4194a4342f1f954ecce37a95"
-      }
-    },
-    "sica42/companionmanager": {
-      "default_branch": "main",
-      "sha": "9efb42eb8c98a44c20918687c146374cceb4d56d",
-      "branches": {
-        "main": "9efb42eb8c98a44c20918687c146374cceb4d56d"
-      }
-    },
-    "pepordev/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
-      "branches": {
-        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
-      },
-      "latest_tag": "v0.17.3"
-    },
-    "jrc13245/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "cbe1925867e7ee59fa4c47fcc8921847b6bcbaec",
-      "branches": {
-        "main": "cbe1925867e7ee59fa4c47fcc8921847b6bcbaec"
-      }
-    },
-    "frontmage/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "96c65e3399a80e84dbaeb7678599a1cd3d3d4d67",
-      "branches": {
-        "main": "96c65e3399a80e84dbaeb7678599a1cd3d3d4d67"
-      },
-      "latest_tag": "v0.17.2"
-    },
-    "karstenbade/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "f264409395ee1fa9b05059e8b661c90e530f8072",
-      "branches": {
-        "main": "f264409395ee1fa9b05059e8b661c90e530f8072"
-      }
-    },
-    "wigmox/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
-      "branches": {
-        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
-      },
-      "latest_tag": "v0.15.0"
-    },
-    "alanli7991/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
-      "branches": {
-        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
-      }
-    },
-    "bretharte89/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
-      "branches": {
-        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
-      }
-    },
-    "litaosmile/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
-      "branches": {
-        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
-      }
-    },
-    "thencl/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
-      "branches": {
-        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
-      }
-    },
-    "wowshub/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
-      "branches": {
-        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
-      }
-    },
-    "xhwsd/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
-      "branches": {
-        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
-      }
-    },
-    "sovietcanuckistan/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "96c65e3399a80e84dbaeb7678599a1cd3d3d4d67",
-      "branches": {
-        "main": "96c65e3399a80e84dbaeb7678599a1cd3d3d4d67"
-      },
-      "latest_tag": "v0.17.1"
-    },
-    "shotoverpick/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "10e0fcea0815285b93c21325797b4f61c0811d16",
-      "branches": {
-        "main": "10e0fcea0815285b93c21325797b4f61c0811d16"
-      }
-    },
-    "tarkusx/consoleexperienceclassic": {
-      "default_branch": "main",
-      "sha": "10e0fcea0815285b93c21325797b4f61c0811d16",
-      "branches": {
-        "main": "10e0fcea0815285b93c21325797b4f61c0811d16"
-      }
-    },
-    "shirsig/cooline": {
-      "default_branch": "master",
-      "sha": "ee097857089e1573a6e6e12cde82035096db2b7f",
-      "branches": {
-        "master": "ee097857089e1573a6e6e12cde82035096db2b7f"
-      }
-    },
-    "seraphic8x2244/cooline": {
-      "default_branch": "master",
-      "sha": "b63b5ac4066b7067bf2d9cf12108da46992b1ea7",
-      "branches": {
-        "master": "b63b5ac4066b7067bf2d9cf12108da46992b1ea7"
-      }
-    },
-    "bahamutxd/cooline": {
-      "default_branch": "master",
-      "sha": "a48c6e8a20f22d4f204faa17b4dc753cc9651e2b",
-      "branches": {
-        "master": "a48c6e8a20f22d4f204faa17b4dc753cc9651e2b"
-      }
-    },
-    "joegnis/coolline": {
-      "default_branch": "master",
-      "sha": "b94fe3184074b8575cb4ac98d11d50d313a26678",
-      "branches": {
-        "master": "b94fe3184074b8575cb4ac98d11d50d313a26678"
-      }
-    },
-    "apostroll/cooline": {
-      "default_branch": "master",
-      "sha": "1c9cbe7cbc4b6c17626e18858159b23819cf245a",
-      "branches": {
-        "master": "1c9cbe7cbc4b6c17626e18858159b23819cf245a"
-      }
-    },
-    "dannychan94/cooline": {
-      "default_branch": "master",
-      "sha": "0596db4d3c05a26d68199c3651a37dc8eb550000",
-      "branches": {
-        "master": "0596db4d3c05a26d68199c3651a37dc8eb550000"
-      }
-    },
-    "ironscyde/cooline": {
-      "default_branch": "master",
-      "sha": "90513b67e740e5abe20342d42abf85e958fafcbe",
-      "branches": {
-        "master": "90513b67e740e5abe20342d42abf85e958fafcbe"
-      }
-    },
-    "wbb1977/corpseinfo": {
-      "default_branch": "master",
-      "sha": "493c18b6d6822b38cc9f030778970fc10be45e61",
-      "branches": {
-        "master": "493c18b6d6822b38cc9f030778970fc10be45e61"
-      },
-      "latest_tag": "v15"
-    },
-    "metalgrid/crapfilter": {
-      "default_branch": "master",
-      "sha": "1ab564e2ec7939b01e2203ba0fcade5467b3b7b9",
-      "branches": {
-        "master": "1ab564e2ec7939b01e2203ba0fcade5467b3b7b9"
-      },
-      "latest_tag": "v0.2"
-    },
-    "azgaardian/crusader": {
-      "default_branch": "main",
-      "sha": "41511322589daa959e8d36632b7abd7393109906",
-      "branches": {
-        "main": "41511322589daa959e8d36632b7abd7393109906"
-      }
-    },
-    "yutsuku/ct_unitframes": {
-      "default_branch": "master",
-      "sha": "a4366d256807816703612fb8d3668c72031289de",
-      "branches": {
-        "master": "a4366d256807816703612fb8d3668c72031289de"
-      }
-    },
-    "tarkusx/customicons": {
-      "default_branch": "main",
-      "sha": "694a3508a0a5994587bfb0d5a9e7645d08101b7f",
-      "branches": {
-        "main": "694a3508a0a5994587bfb0d5a9e7645d08101b7f"
-      }
-    },
-    "cephel/dankscore": {
-      "default_branch": "master",
-      "sha": "9c38910c9c6d66417c7e44762857b6781b0d38fe",
-      "branches": {
-        "master": "9c38910c9c6d66417c7e44762857b6781b0d38fe"
-      }
-    },
-    "determinedpanda/difficultbulletinboard": {
-      "default_branch": "master",
-      "sha": "6eb7629c36b3e767be1febb468ee24b30da7ff33",
-      "branches": {
-        "master": "6eb7629c36b3e767be1febb468ee24b30da7ff33"
-      },
-      "latest_tag": "V3.00"
-    },
-    "thezephyrsong/difficultbulletinboard": {
-      "default_branch": "master",
-      "sha": "78b78354dc51a75aa63058ad90ab3530ed64e9b1",
-      "branches": {
-        "master": "78b78354dc51a75aa63058ad90ab3530ed64e9b1"
-      },
-      "latest_tag": "V2.40"
-    },
-    "slimewizzard/difficultbulletinboard": {
-      "default_branch": "master",
-      "sha": "a4aa1aba13a511b42b6102d7d55be48c4b4f974f",
-      "branches": {
-        "master": "a4aa1aba13a511b42b6102d7d55be48c4b4f974f"
-      }
-    },
-    "kameleonuk/difficultbulletinboard": {
-      "default_branch": "master",
-      "sha": "ddbdd7a569e8688ec42c4b5738309ace5eb11c0e",
-      "branches": {
-        "master": "ddbdd7a569e8688ec42c4b5738309ace5eb11c0e"
-      }
-    },
-    "whtmst/difficultbulletinboard": {
-      "default_branch": "master",
-      "sha": "361aad842797547aec25550ba68a0e4ec8789272",
-      "branches": {
-        "master": "361aad842797547aec25550ba68a0e4ec8789272"
-      }
-    },
-    "bestoriop/difficultbulletinboard": {
-      "default_branch": "master",
-      "sha": "6dbeacec52cbd38dbc6d943e7da317fd0548daf6",
-      "branches": {
-        "master": "6dbeacec52cbd38dbc6d943e7da317fd0548daf6"
-      }
-    },
-    "willierpt/difficultbulletinboard": {
-      "default_branch": "master",
-      "sha": "5c66d874ba4d9527819749c12f9ea940d9700948",
-      "branches": {
-        "master": "5c66d874ba4d9527819749c12f9ea940d9700948"
-      }
-    },
-    "einbaum/disableescape": {
-      "default_branch": "master",
-      "sha": "14e12e29dfc4512c4d95d623eb02c41ee6c902b1",
-      "branches": {
-        "master": "14e12e29dfc4512c4d95d623eb02c41ee6c902b1"
-      },
-      "latest_tag": "1.0.0"
-    },
-    "linae-kronos/distance": {
-      "default_branch": "master",
-      "sha": "8e02c049d323e8557738981803214fd0f9b0b8e6",
-      "branches": {
-        "master": "8e02c049d323e8557738981803214fd0f9b0b8e6"
-      }
-    },
-    "uc9089/distancedisplay": {
-      "default_branch": "main",
-      "sha": "0f7fb5167387a37fc8e0150f88f42d597849eb38",
-      "branches": {
-        "main": "0f7fb5167387a37fc8e0150f88f42d597849eb38"
-      }
-    },
-    "utensile/distancedisplay": {
-      "default_branch": "main",
-      "sha": "dbc41068aa55e72e852ce108e7a2e8ad1a49ab8c",
-      "branches": {
-        "main": "dbc41068aa55e72e852ce108e7a2e8ad1a49ab8c"
-      }
-    },
-    "eriknikolajsen/distancedisplay": {
-      "default_branch": "main",
-      "sha": "66afd1b2ec2c053f6c332e0545817f01f2f0a538",
-      "branches": {
-        "main": "66afd1b2ec2c053f6c332e0545817f01f2f0a538"
-      }
-    },
-    "quakerzz/dkplist": {
-      "default_branch": "master",
-      "sha": "5c1b387e10d53eb246c0374536918b5b88ecd64e",
-      "branches": {
-        "master": "5c1b387e10d53eb246c0374536918b5b88ecd64e"
-      }
-    },
-    "einbaum/doomed": {
-      "default_branch": "master",
-      "sha": "2217376dc7af8170405db6a11afe510287ed3fc8",
-      "branches": {
-        "master": "2217376dc7af8170405db6a11afe510287ed3fc8"
-      }
-    },
-    "kc8pnd/dotimer": {
-      "default_branch": "master",
-      "sha": "90bad43fe9347cdeb5f2640f71f082255f6bb7a5",
-      "branches": {
-        "master": "90bad43fe9347cdeb5f2640f71f082255f6bb7a5"
-      }
-    },
-    "mmesnage/dotimer": {
-      "default_branch": "master",
-      "sha": "90bad43fe9347cdeb5f2640f71f082255f6bb7a5",
-      "branches": {
-        "master": "90bad43fe9347cdeb5f2640f71f082255f6bb7a5"
-      }
-    },
-    "numielle/dousereminder": {
-      "default_branch": "master",
-      "sha": "a5b3e2b7366b4b12e12afed3fd788612d381078f",
-      "branches": {
-        "master": "a5b3e2b7366b4b12e12afed3fd788612d381078f"
-      }
-    },
-    "cernie/druidconsumable": {
-      "default_branch": "master",
-      "sha": "7138b6f1919e2d3e8ea9a3011d2ef277dddcb14f",
-      "branches": {
-        "master": "7138b6f1919e2d3e8ea9a3011d2ef277dddcb14f"
-      }
-    },
-    "akzkak/drunktracker": {
-      "default_branch": "master",
-      "sha": "e12b77980ba35d47c1d2401b9bbb522fddd2f230",
-      "branches": {
-        "master": "e12b77980ba35d47c1d2401b9bbb522fddd2f230"
-      }
-    },
-    "numielle/easycloak": {
-      "default_branch": "master",
-      "sha": "2cf5e3e0a896e63a164e9cde81b00a7492b74f15",
-      "branches": {
-        "master": "2cf5e3e0a896e63a164e9cde81b00a7492b74f15"
-      },
-      "latest_tag": "v0.2"
-    },
-    "numielle/easyress": {
-      "default_branch": "master",
-      "sha": "57d355827c0f36198ade3883f0654f7845091ad6",
-      "branches": {
-        "master": "57d355827c0f36198ade3883f0654f7845091ad6"
-      }
-    },
-    "fulzamoth/eepanels-v": {
-      "default_branch": "master",
-      "sha": "2f5af623720a1a308abe3fdff4b9fc0b01e468b9",
-      "branches": {
-        "master": "2f5af623720a1a308abe3fdff4b9fc0b01e468b9"
-      },
-      "latest_tag": "v1.0.0"
-    },
-    "cubenicke/efcreport": {
-      "default_branch": "master",
-      "sha": "a4ae1f56c2e3fbfd34b2804d59a0e0b214d4b5d4",
-      "branches": {
-        "master": "a4ae1f56c2e3fbfd34b2804d59a0e0b214d4b5d4"
-      }
-    },
-    "medeah/egnar": {
-      "default_branch": "master",
-      "sha": "23a6b3ea9efe8eacce395e97a16a011958a0560f",
-      "branches": {
-        "master": "23a6b3ea9efe8eacce395e97a16a011958a0560f"
-      },
-      "latest_tag": "0.1"
-    },
-    "xinleibird/egnar": {
-      "default_branch": "master",
-      "sha": "9d288d4fae8a787aa7317a8e3da9aa29f12506e6",
-      "branches": {
-        "master": "9d288d4fae8a787aa7317a8e3da9aa29f12506e6"
-      }
-    },
-    "paenthy/egnar": {
-      "default_branch": "master",
-      "sha": "edf84647cac6f17fa4c1330d4d8f5bd2c8c0a72c",
-      "branches": {
-        "master": "edf84647cac6f17fa4c1330d4d8f5bd2c8c0a72c"
-      }
-    },
-    "jlabranche/elitewarriorttd": {
-      "default_branch": "main",
-      "sha": "bab48b161c016848ea9ff52b60015948622c0ade",
-      "branches": {
-        "main": "bab48b161c016848ea9ff52b60015948622c0ade"
-      }
-    },
-    "notkayoko/elitewarriorttd": {
-      "default_branch": "main",
-      "sha": "de04aff8771ea76920b2ec89ee9046ee21b9f8ae",
-      "branches": {
-        "main": "de04aff8771ea76920b2ec89ee9046ee21b9f8ae"
-      }
-    },
-    "rumchiller/em_monkeybuddy": {
-      "default_branch": "master",
-      "sha": "07137f6d32f67c5ffac9b35de6e150e1845f676d",
-      "branches": {
-        "master": "07137f6d32f67c5ffac9b35de6e150e1845f676d"
-      }
-    },
-    "rumchiller/em_wowquote": {
-      "default_branch": "master",
-      "sha": "8529606a5be5926bec4630ec63d48b9864fb01c8",
-      "branches": {
-        "master": "8529606a5be5926bec4630ec63d48b9864fb01c8"
-      },
-      "latest_tag": "0.2"
-    },
-    "rumchiller/em_critbam": {
-      "default_branch": "master",
-      "sha": "01c93b5ed63af6bf3d2140317a51e81ceb2bd1b6",
-      "branches": {
-        "master": "01c93b5ed63af6bf3d2140317a51e81ceb2bd1b6"
-      }
-    },
-    "zetone/enemyframes": {
-      "default_branch": "master",
-      "sha": "7a6591617b038e52153ee0eb5dba73c74978b887",
-      "branches": {
-        "master": "7a6591617b038e52153ee0eb5dba73c74978b887"
-      }
-    },
-    "jrc13245/enemyframes": {
-      "default_branch": "master",
-      "sha": "2f0f840b65cd1a3de76e1e416665a646ac99ce90",
-      "branches": {
-        "master": "2f0f840b65cd1a3de76e1e416665a646ac99ce90"
-      }
-    },
-    "diamondbond/enemyframes": {
-      "default_branch": "master",
-      "sha": "e02a66d0af5af1573bb895e9e2a75f50d7b38c08",
-      "branches": {
-        "master": "e02a66d0af5af1573bb895e9e2a75f50d7b38c08"
-      }
-    },
-    "bycfm2/enemyframes": {
-      "default_branch": "master",
-      "sha": "4ae5fd621e7f2207c97b8d42a4d94df3158efeb0",
-      "branches": {
-        "master": "4ae5fd621e7f2207c97b8d42a4d94df3158efeb0"
-      }
-    },
-    "lythandrawow/enemyframes": {
-      "default_branch": "master",
-      "sha": "2f0f840b65cd1a3de76e1e416665a646ac99ce90",
-      "branches": {
-        "master": "2f0f840b65cd1a3de76e1e416665a646ac99ce90"
-      }
-    },
-    "cache9527/enemyframes": {
-      "default_branch": "master",
-      "sha": "0ac29c1dde801593ada2a0c84800ed8ac9380906",
-      "branches": {
-        "master": "0ac29c1dde801593ada2a0c84800ed8ac9380906"
-      }
-    },
-    "smirgeli/es": {
-      "default_branch": "main",
-      "sha": "2782b20acce0beea71902ee0113858619456d0f7",
-      "branches": {
-        "main": "2782b20acce0beea71902ee0113858619456d0f7"
-      }
-    },
-    "shirsig/etl": {
-      "default_branch": "master",
-      "sha": "a50f6a9e4b25a0e3fb8ace1e11cf6ed5b7595b57",
-      "branches": {
-        "master": "a50f6a9e4b25a0e3fb8ace1e11cf6ed5b7595b57"
-      }
-    },
-    "rmarc29/etl_minute": {
-      "default_branch": "master",
-      "sha": "2c399c409438194c07acf4985167b6c02ad6b8f4",
-      "branches": {
-        "master": "2c399c409438194c07acf4985167b6c02ad6b8f4"
-      }
-    },
-    "theonereed/evtcalendar": {
-      "default_branch": "master",
-      "sha": "772c9201ace228edca2d1a5c0ae65b15a3abb286",
-      "branches": {
-        "master": "772c9201ace228edca2d1a5c0ae65b15a3abb286"
-      },
-      "latest_tag": "1.3"
-    },
-    "airchandler/evtcalendar": {
-      "default_branch": "master",
-      "sha": "c038e69fef9b1988ccebd5480d6884b164bbfc94",
-      "branches": {
-        "master": "c038e69fef9b1988ccebd5480d6884b164bbfc94"
-      },
-      "latest_tag": "1.3"
-    },
-    "yutsuku/ez-epgp": {
-      "default_branch": "master",
-      "sha": "db3732bb13605f920bab5d9d28aeea8a18626aff",
-      "branches": {
-        "master": "db3732bb13605f920bab5d9d28aeea8a18626aff"
-      }
-    },
-    "laytya/ezdismount": {
-      "default_branch": "master",
-      "sha": "e95b05be42a35f05367749dda6e8930ad592247d",
-      "branches": {
-        "master": "e95b05be42a35f05367749dda6e8930ad592247d"
-      }
-    },
-    "alex192777/ezdismount": {
-      "default_branch": "master",
-      "sha": "85ec75cb0ab32286785c98aaf15fdc140cacc495",
-      "branches": {
-        "master": "85ec75cb0ab32286785c98aaf15fdc140cacc495"
-      }
-    },
-    "wierdthing/ezpoison": {
-      "default_branch": "main",
-      "sha": "eb0184efaed84992dd652b2ad82a49679177d6f6",
-      "branches": {
-        "main": "eb0184efaed84992dd652b2ad82a49679177d6f6"
-      }
-    },
-    "evannnn1996/ezpoison": {
-      "default_branch": "main",
-      "sha": "9732ded02e74e80de57535af8da8ada4d4840ede",
-      "branches": {
-        "main": "9732ded02e74e80de57535af8da8ada4d4840ede"
-      }
-    },
-    "verge20/ezpoison": {
-      "default_branch": "main",
-      "sha": "fe029554048f4581a4bbf217adce00be9e4ff826",
-      "branches": {
-        "main": "fe029554048f4581a4bbf217adce00be9e4ff826"
-      }
-    },
-    "hcydlee/ezpoison": {
-      "default_branch": "main",
-      "sha": "3585762c82679ee8de274cc8cd52e5599c0ada7e",
-      "branches": {
-        "main": "3585762c82679ee8de274cc8cd52e5599c0ada7e"
-      }
-    },
-    "simsal/ezpoison": {
-      "default_branch": "main",
-      "sha": "f32dcf0bf19f70ba712f1aa4f9af0f4f8a1215de",
-      "branches": {
-        "main": "f32dcf0bf19f70ba712f1aa4f9af0f4f8a1215de"
-      }
-    },
-    "ezhug/ezpoison-mod": {
-      "default_branch": "main",
-      "sha": "edb6b0d872d002383ddc5da86318cfa238e2209e",
-      "branches": {
-        "main": "edb6b0d872d002383ddc5da86318cfa238e2209e"
-      }
-    },
-    "maistatv/ezpoison": {
-      "default_branch": "main",
-      "sha": "d83e25a5ed6c2e334f2df6161134a335adaebf11",
-      "branches": {
-        "main": "d83e25a5ed6c2e334f2df6161134a335adaebf11"
-      }
-    },
-    "ruskemiahahn/ezpoison": {
-      "default_branch": "main",
-      "sha": "7092059a8652d944b5c09aedfe140895857eff0e",
-      "branches": {
-        "main": "7092059a8652d944b5c09aedfe140895857eff0e"
-      }
-    },
-    "simonfrankeoctolearn/ezpoison": {
-      "default_branch": "main",
-      "sha": "51ffe613b17b890ed2f2a1b99180087602325468",
-      "branches": {
-        "main": "51ffe613b17b890ed2f2a1b99180087602325468"
-      }
-    },
     "0ldi/felwoodgather": {
       "default_branch": "master",
       "sha": "e99c99109bcd300565d5917f0703893b5fcfc56d",
@@ -3755,562 +37,11 @@
         "master": "e99c99109bcd300565d5917f0703893b5fcfc56d"
       }
     },
-    "marktiedemann/feralfire": {
+    "0ldi/imba": {
       "default_branch": "master",
-      "sha": "57dabfa970a5f7c6a123cc213df14d2a3813e855",
+      "sha": "88c87ffd4e73e7542e9f46aa411264419d1b815b",
       "branches": {
-        "master": "57dabfa970a5f7c6a123cc213df14d2a3813e855"
-      }
-    },
-    "stormhand81/finezoom": {
-      "default_branch": "main",
-      "sha": "bb9b18688ef6a764b6e721c2a3d712285a487de1",
-      "branches": {
-        "main": "bb9b18688ef6a764b6e721c2a3d712285a487de1"
-      },
-      "latest_tag": "1.3"
-    },
-    "wbb1977/fishinfo2": {
-      "default_branch": "master",
-      "sha": "acc91a08bbb7c13ce7b6c2d0b96ec05ed90c3f6f",
-      "branches": {
-        "master": "acc91a08bbb7c13ce7b6c2d0b96ec05ed90c3f6f"
-      },
-      "latest_tag": "v10"
-    },
-    "deffar/fishingvolume": {
-      "default_branch": "main",
-      "sha": "3f7dbd522844a994f945748b5dd1f1f2aef3f3cd",
-      "branches": {
-        "main": "3f7dbd522844a994f945748b5dd1f1f2aef3f3cd"
-      }
-    },
-    "draiscor/fishswap": {
-      "default_branch": "main",
-      "sha": "d502d96cf1037785649476807df4a6bc79c26d15",
-      "branches": {
-        "main": "d502d96cf1037785649476807df4a6bc79c26d15"
-      },
-      "latest_tag": "v1.1"
-    },
-    "mcpewpew/fizzle": {
-      "default_branch": "master",
-      "sha": "90ae4215bcde84cc8347f274de55d9d012063f42",
-      "branches": {
-        "master": "90ae4215bcde84cc8347f274de55d9d012063f42"
-      }
-    },
-    "amonra/fizzle": {
-      "default_branch": "master",
-      "sha": "1145df0eb8717990d990e934ed4fce4c47811cde",
-      "branches": {
-        "master": "1145df0eb8717990d990e934ed4fce4c47811cde"
-      }
-    },
-    "mcpewpew/gfw_huntershelper": {
-      "default_branch": "master",
-      "sha": "306a625f1b97e80013aae9887de8ba8d278e96ae",
-      "branches": {
-        "master": "306a625f1b97e80013aae9887de8ba8d278e96ae"
-      }
-    },
-    "conquistadorestwow/gfw_huntershelper": {
-      "default_branch": "master",
-      "sha": "306a625f1b97e80013aae9887de8ba8d278e96ae",
-      "branches": {
-        "master": "306a625f1b97e80013aae9887de8ba8d278e96ae"
-      }
-    },
-    "lookino/flyout": {
-      "default_branch": "main",
-      "sha": "f13633a7adc6169e9b5112b68322252b1e623740",
-      "branches": {
-        "main": "f13633a7adc6169e9b5112b68322252b1e623740"
-      }
-    },
-    "al3xc1985/flyout": {
-      "default_branch": "main",
-      "sha": "f13633a7adc6169e9b5112b68322252b1e623740",
-      "branches": {
-        "main": "f13633a7adc6169e9b5112b68322252b1e623740"
-      }
-    },
-    "blehz-be/flyout": {
-      "default_branch": "main",
-      "sha": "f13633a7adc6169e9b5112b68322252b1e623740",
-      "branches": {
-        "main": "f13633a7adc6169e9b5112b68322252b1e623740"
-      }
-    },
-    "kameleonuk/flyout": {
-      "default_branch": "main",
-      "sha": "067a4873808f0710b19f59a14cfc79c67fdd38a0",
-      "branches": {
-        "main": "067a4873808f0710b19f59a14cfc79c67fdd38a0"
-      }
-    },
-    "sourini/flyout": {
-      "default_branch": "main",
-      "sha": "4d27bdafe76d8a107510417ab4e83bbab46786cb",
-      "branches": {
-        "main": "4d27bdafe76d8a107510417ab4e83bbab46786cb"
-      }
-    },
-    "whitealion/flyout_items": {
-      "default_branch": "main",
-      "sha": "a2a1021a7a48ef00c75279ebecfb8abfb7b47f42",
-      "branches": {
-        "main": "a2a1021a7a48ef00c75279ebecfb8abfb7b47f42"
-      }
-    },
-    "mcpewpew/flyout": {
-      "default_branch": "main",
-      "sha": "17fef1f9988867e1d76429e77f70563fb888e844",
-      "branches": {
-        "main": "17fef1f9988867e1d76429e77f70563fb888e844"
-      }
-    },
-    "wardz/focusframe": {
-      "default_branch": "master",
-      "sha": "e438b7efb358b20d3f1950b5b42910f1d20e6f75",
-      "branches": {
-        "master": "e438b7efb358b20d3f1950b5b42910f1d20e6f75"
-      },
-      "latest_tag": "1.04"
-    },
-    "gashole/focusframe": {
-      "default_branch": "master",
-      "sha": "e438b7efb358b20d3f1950b5b42910f1d20e6f75",
-      "branches": {
-        "master": "e438b7efb358b20d3f1950b5b42910f1d20e6f75"
-      },
-      "latest_tag": "0.5"
-    },
-    "wardz/focusframe_targetcastbar": {
-      "default_branch": "master",
-      "sha": "44fa7fb810aacf17a8cc0f05b8bd6de3bf5f8c4e",
-      "branches": {
-        "master": "44fa7fb810aacf17a8cc0f05b8bd6de3bf5f8c4e"
-      },
-      "latest_tag": "v1.0.0"
-    },
-    "noo0b1/followmeenhanced": {
-      "default_branch": "master",
-      "sha": "53bf3f88b860ca4bdd184edfa07e08689398fcf0",
-      "branches": {
-        "master": "53bf3f88b860ca4bdd184edfa07e08689398fcf0"
-      }
-    },
-    "nemanuel/forged_pethappiness": {
-      "default_branch": "main",
-      "sha": "989cfebeb5a938e1dc49f7ff1b615063b7c5e53d",
-      "branches": {
-        "main": "989cfebeb5a938e1dc49f7ff1b615063b7c5e53d"
-      }
-    },
-    "nemanuel/forged_sellallgrays": {
-      "default_branch": "main",
-      "sha": "308a2e673f71e398c1e32f30b22c195630da9e6a",
-      "branches": {
-        "main": "308a2e673f71e398c1e32f30b22c195630da9e6a"
-      }
-    },
-    "fiskehatt/friendfinder": {
-      "default_branch": "master",
-      "sha": "e339f7c462e034ce49b98f5a1978b4d925cc3b4a",
-      "branches": {
-        "master": "e339f7c462e034ce49b98f5a1978b4d925cc3b4a"
-      }
-    },
-    "shellyoung/fubar_population": {
-      "default_branch": "main",
-      "sha": "9bf2673f876fb9700a6cef4265144e832d0f4b29",
-      "branches": {
-        "main": "9bf2673f876fb9700a6cef4265144e832d0f4b29"
-      },
-      "latest_tag": "2.3"
-    },
-    "laytya/fubar_portalfu": {
-      "default_branch": "main",
-      "sha": "d50fdbbe0765edd073640ed317bfade682cffb4f",
-      "branches": {
-        "main": "d50fdbbe0765edd073640ed317bfade682cffb4f"
-      }
-    },
-    "kluverua/portalfu": {
-      "default_branch": "main",
-      "sha": "1313a03b18c3e969f451428b144789d69206c481",
-      "branches": {
-        "main": "1313a03b18c3e969f451428b144789d69206c481"
-      },
-      "latest_tag": "2.2"
-    },
-    "road-block/fubar_possessionsfu": {
-      "default_branch": "master",
-      "sha": "3911af9ab97be76e0bd5a2fa7a22eb5b853ebb73",
-      "branches": {
-        "master": "3911af9ab97be76e0bd5a2fa7a22eb5b853ebb73"
-      },
-      "latest_tag": "11200.3"
-    },
-    "laytya/fubar_pursuefu": {
-      "default_branch": "main",
-      "sha": "135fbeb81ff01942d8ff308928c74b0e4b17db70",
-      "branches": {
-        "main": "135fbeb81ff01942d8ff308928c74b0e4b17db70"
-      },
-      "latest_tag": "v1.2"
-    },
-    "ebedanostalrius/fubar_zepmaster": {
-      "default_branch": "master",
-      "sha": "ddf6a5042ef9131dae9ffebe1fe0757253f590e9",
-      "branches": {
-        "master": "ddf6a5042ef9131dae9ffebe1fe0757253f590e9"
-      }
-    },
-    "otari98/fullsack": {
-      "default_branch": "master",
-      "sha": "8ce18159d3a3c3af415252096ad2294205973a6d",
-      "branches": {
-        "master": "8ce18159d3a3c3af415252096ad2294205973a6d"
-      }
-    },
-    "bretharte89/fullsack": {
-      "default_branch": "master",
-      "sha": "fc3b7f5a5f14539334d09bc8a99b5894b78d9c47",
-      "branches": {
-        "master": "fc3b7f5a5f14539334d09bc8a99b5894b78d9c47"
-      }
-    },
-    "xian55/fullsack": {
-      "default_branch": "master",
-      "sha": "697c1da2639fbadf1fd63263fbc5b724ba93200b",
-      "branches": {
-        "master": "697c1da2639fbadf1fd63263fbc5b724ba93200b"
-      }
-    },
-    "yutsuku/gamepad": {
-      "default_branch": "master",
-      "sha": "3986144052b8aed0a006fe7944b5022cfdba83c7",
-      "branches": {
-        "master": "3986144052b8aed0a006fe7944b5022cfdba83c7"
-      }
-    },
-    "voidmenull/gamonkilltimer": {
-      "default_branch": "master",
-      "sha": "202d8eab385cefd84103ba194cc6de7b219a9743",
-      "branches": {
-        "master": "202d8eab385cefd84103ba194cc6de7b219a9743"
-      }
-    },
-    "ageous27/gcdtimerbar": {
-      "default_branch": "main",
-      "sha": "ce25c463b743c3ffb0408b92e7fdea5c19ef25e0",
-      "branches": {
-        "main": "ce25c463b743c3ffb0408b92e7fdea5c19ef25e0"
-      }
-    },
-    "ragedunicorn/wow-vanilla-gearmenu": {
-      "default_branch": "master",
-      "sha": "06f9edc3d84835f9ec818a7b8e951ebc92c0ca71",
-      "branches": {
-        "master": "06f9edc3d84835f9ec818a7b8e951ebc92c0ca71"
-      },
-      "latest_tag": "v1.2.2"
-    },
-    "diff3/ghost": {
-      "default_branch": "master",
-      "sha": "fd2bbd44fdf7205f92d42548c4a2a7e6f1c4eb2f",
-      "branches": {
-        "master": "fd2bbd44fdf7205f92d42548c4a2a7e6f1c4eb2f"
-      },
-      "latest_tag": "3745561"
-    },
-    "frostshock/ghost": {
-      "default_branch": "master",
-      "sha": "e6bca7fc4368b28f0d4b0a178823a6cf318726d0",
-      "branches": {
-        "master": "e6bca7fc4368b28f0d4b0a178823a6cf318726d0"
-      },
-      "latest_tag": "3745561"
-    },
-    "trangoul/globalfriendslist": {
-      "default_branch": "main",
-      "sha": "00c2d8234097f0c72326820e131190d68491ea27",
-      "branches": {
-        "main": "00c2d8234097f0c72326820e131190d68491ea27"
-      }
-    },
-    "shagu/gmblacklist": {
-      "default_branch": "master",
-      "sha": "46ee64b772f809fd5d78a7773ddcc2a2335240c4",
-      "branches": {
-        "master": "46ee64b772f809fd5d78a7773ddcc2a2335240c4"
-      }
-    },
-    "mcpewpew/goblinbrainwashinghelper": {
-      "default_branch": "master",
-      "sha": "26159e4ef29e0af7259ae92b66dde3da4c68f7d2",
-      "branches": {
-        "master": "26159e4ef29e0af7259ae92b66dde3da4c68f7d2"
-      },
-      "latest_tag": "v0.1"
-    },
-    "ravenofseven/goblinbrainwashinghelper": {
-      "default_branch": "master",
-      "sha": "26159e4ef29e0af7259ae92b66dde3da4c68f7d2",
-      "branches": {
-        "master": "26159e4ef29e0af7259ae92b66dde3da4c68f7d2"
-      }
-    },
-    "vargv666/goblinbrainwashinghelper": {
-      "default_branch": "master",
-      "sha": "09157f672e826c7d26090ef93ecee66d958f69bf",
-      "branches": {
-        "master": "09157f672e826c7d26090ef93ecee66d958f69bf"
-      }
-    },
-    "jsb/gourmet": {
-      "default_branch": "master",
-      "sha": "f0a31d2b0baa4e595481b611fb185923a9981fc4",
-      "branches": {
-        "master": "f0a31d2b0baa4e595481b611fb185923a9981fc4"
-      }
-    },
-    "scoboose/grimoirekeeper": {
-      "default_branch": "main",
-      "sha": "05f70668d425d0c5073538c3ac8e85b6380ccd5b",
-      "branches": {
-        "main": "05f70668d425d0c5073538c3ac8e85b6380ccd5b"
-      }
-    },
-    "xorann/grimreaper": {
-      "default_branch": "master",
-      "sha": "18d52e0660dcd217b8717d457717832ce829b39b",
-      "branches": {
-        "master": "18d52e0660dcd217b8717d457717832ce829b39b"
-      }
-    },
-    "onnateldome/grindspots": {
-      "default_branch": "master",
-      "sha": "23a40786ce3066568c64fbfca500404a593f1db4",
-      "branches": {
-        "master": "23a40786ce3066568c64fbfca500404a593f1db4"
-      }
-    },
-    "monteo/groupcalendar": {
-      "default_branch": "master",
-      "sha": "41ec2f9313376530fd3854c7cd3ee04834a808db",
-      "branches": {
-        "master": "41ec2f9313376530fd3854c7cd3ee04834a808db"
-      }
-    },
-    "redshadowz/groupfinder": {
-      "default_branch": "main",
-      "sha": "51ebb9beca1b0880ea15f3e293132d10488b9450",
-      "branches": {
-        "main": "51ebb9beca1b0880ea15f3e293132d10488b9450"
-      }
-    },
-    "redmondgiant/groupfinder": {
-      "default_branch": "main",
-      "sha": "4776f0f2d1c144317cac2f4df281aa9b1e23da87",
-      "branches": {
-        "main": "4776f0f2d1c144317cac2f4df281aa9b1e23da87"
-      }
-    },
-    "wormuz/groupfinder": {
-      "default_branch": "main",
-      "sha": "0af1a4869d19cf809a54350693e6cf0a6be989ee",
-      "branches": {
-        "main": "0af1a4869d19cf809a54350693e6cf0a6be989ee"
-      }
-    },
-    "zarant/guidecreator": {
-      "default_branch": "master",
-      "sha": "36d92e3e9ec730991e8e65ca11d8310751d6142e",
-      "branches": {
-        "master": "36d92e3e9ec730991e8e65ca11d8310751d6142e"
-      }
-    },
-    "zygmuntbuszyk/z-z-guide-creator": {
-      "default_branch": "master",
-      "sha": "c047acb662fd6a65cedd01062ece1fd0fcfc0a61",
-      "branches": {
-        "master": "c047acb662fd6a65cedd01062ece1fd0fcfc0a61"
-      }
-    },
-    "nerque/guidecreator": {
-      "default_branch": "master",
-      "sha": "36d92e3e9ec730991e8e65ca11d8310751d6142e",
-      "branches": {
-        "master": "36d92e3e9ec730991e8e65ca11d8310751d6142e"
-      }
-    },
-    "oclavero/guidecreator": {
-      "default_branch": "master",
-      "sha": "36d92e3e9ec730991e8e65ca11d8310751d6142e",
-      "branches": {
-        "master": "36d92e3e9ec730991e8e65ca11d8310751d6142e"
-      }
-    },
-    "kpteam2024/guidecreator": {
-      "default_branch": "master",
-      "sha": "36d92e3e9ec730991e8e65ca11d8310751d6142e",
-      "branches": {
-        "master": "36d92e3e9ec730991e8e65ca11d8310751d6142e"
-      }
-    },
-    "jaydeshow/guidecreator": {
-      "default_branch": "master",
-      "sha": "d213fa83b71f0b9dd2613dd52ea85052bebd981a",
-      "branches": {
-        "master": "d213fa83b71f0b9dd2613dd52ea85052bebd981a"
-      }
-    },
-    "sica42/guildalts": {
-      "default_branch": "main",
-      "sha": "fe11010738b58565b97e8f382f7577ae942c2f9f",
-      "branches": {
-        "main": "fe11010738b58565b97e8f382f7577ae942c2f9f"
-      }
-    },
-    "graved/guildmaintagger": {
-      "default_branch": "main",
-      "sha": "37c259e18473445ad3c96c70e5b785b7d432b164",
-      "branches": {
-        "main": "37c259e18473445ad3c96c70e5b785b7d432b164"
-      }
-    },
-    "rollingsmile/guildroll": {
-      "default_branch": "main",
-      "sha": "cb5ccbb40cd81ab586e77d515e92a58883ff2176",
-      "branches": {
-        "main": "cb5ccbb40cd81ab586e77d515e92a58883ff2176"
-      }
-    },
-    "yutsuku/guildsearch": {
-      "default_branch": "master",
-      "sha": "e78dfbae6dc06600590e9d581288514ca5df3242",
-      "branches": {
-        "master": "e78dfbae6dc06600590e9d581288514ca5df3242"
-      }
-    },
-    "timanaku/hastedisplay": {
-      "default_branch": "main",
-      "sha": "7f9a7a11161af69402ce17a3ae5fc5855fa10005",
-      "branches": {
-        "main": "7f9a7a11161af69402ce17a3ae5fc5855fa10005"
-      }
-    },
-    "vakos1/hattrick": {
-      "default_branch": "main",
-      "sha": "fd14ab1622f2beb2c8af16ee2400752494f4a599",
-      "branches": {
-        "main": "fd14ab1622f2beb2c8af16ee2400752494f4a599"
-      }
-    },
-    "hitbutton/hbpowerinfusion": {
-      "default_branch": "master",
-      "sha": "87fa6f0a6989765592b8eb15a622f021f2a36b47",
-      "branches": {
-        "master": "87fa6f0a6989765592b8eb15a622f021f2a36b47"
-      }
-    },
-    "cosminpop/hendrishift": {
-      "default_branch": "master",
-      "sha": "22b05db2ee66e4555cce2263fc8854687a66134f",
-      "branches": {
-        "master": "22b05db2ee66e4555cce2263fc8854687a66134f"
-      }
-    },
-    "zirtox1992/hideerrorframe": {
-      "default_branch": "main",
-      "sha": "c65a36f01ab69c35779313f1b91ef8432c972fc6",
-      "branches": {
-        "main": "c65a36f01ab69c35779313f1b91ef8432c972fc6"
-      }
-    },
-    "pre-elysium/hordeironfoe": {
-      "default_branch": "master",
-      "sha": "a8e6fd1719c9e36d269405ce2566c08bb2d0f478",
-      "branches": {
-        "master": "a8e6fd1719c9e36d269405ce2566c08bb2d0f478"
-      }
-    },
-    "dudusandsten/hotbotpanel": {
-      "default_branch": "master",
-      "sha": "37bfac2799975c6d9902a4f7b252cc1c7abb8836",
-      "branches": {
-        "master": "37bfac2799975c6d9902a4f7b252cc1c7abb8836"
-      },
-      "latest_tag": "1"
-    },
-    "enn-wow-addons/hunterswissknife": {
-      "default_branch": "master",
-      "sha": "441cae66541d9031efeb29fb899b4021a56e35b2",
-      "branches": {
-        "master": "441cae66541d9031efeb29fb899b4021a56e35b2"
-      },
-      "latest_tag": "v1.1"
-    },
-    "macumbafeh/hunterswissknife": {
-      "default_branch": "master",
-      "sha": "ac63524189294b9f38b1fe60f7e8ab19275962bc",
-      "branches": {
-        "master": "ac63524189294b9f38b1fe60f7e8ab19275962bc"
-      }
-    },
-    "zomgits/hunterswissknife": {
-      "default_branch": "master",
-      "sha": "f9713c88020a4fe6e24600e1458a82897710e108",
-      "branches": {
-        "master": "f9713c88020a4fe6e24600e1458a82897710e108"
-      },
-      "latest_tag": "v1.1"
-    },
-    "rptb1/hunterswissknife": {
-      "default_branch": "master",
-      "sha": "206043ebfaa51ccdec19c6ef5b851c87335d03db",
-      "branches": {
-        "master": "206043ebfaa51ccdec19c6ef5b851c87335d03db"
-      },
-      "latest_tag": "v1.1"
-    },
-    "geigerkind/ibdf": {
-      "default_branch": "master",
-      "sha": "0dda784f22d7f405aab8ef1bf1ea8cd94023f861",
-      "branches": {
-        "master": "0dda784f22d7f405aab8ef1bf1ea8cd94023f861"
-      }
-    },
-    "alchem1ster/vanilla-iconic": {
-      "default_branch": "main",
-      "sha": "7d742251f2f42b91689ba40da4e8ad4fa0e7c630",
-      "branches": {
-        "main": "7d742251f2f42b91689ba40da4e8ad4fa0e7c630"
-      },
-      "latest_tag": "1.1_Vanilla"
-    },
-    "therealfayz/vanilla-iconic": {
-      "default_branch": "main",
-      "sha": "2ec0a7350cb91f4156c77e178e60e5c938a01e69",
-      "branches": {
-        "main": "2ec0a7350cb91f4156c77e178e60e5c938a01e69"
-      }
-    },
-    "abstr4ctz/ifalert": {
-      "default_branch": "master",
-      "sha": "864cc8d9edd09ac3b4b60978b6788c7afd376aaf",
-      "branches": {
-        "master": "864cc8d9edd09ac3b4b60978b6788c7afd376aaf"
-      }
-    },
-    "vakos1/ignite-status": {
-      "default_branch": "main",
-      "sha": "643d58cec868c1e4265653b44d8b277779709c30",
-      "branches": {
-        "main": "643d58cec868c1e4265653b44d8b277779709c30"
+        "master": "88c87ffd4e73e7542e9f46aa411264419d1b815b"
       }
     },
     "0ldi/imdead": {
@@ -4320,588 +51,6 @@
         "master": "48ef045409f9e506fc50376fe022e45e3112b523"
       }
     },
-    "twothe/improvedignore": {
-      "default_branch": "master",
-      "sha": "8fa195448453e881607e95bb8f8d4fc96bece6b8",
-      "branches": {
-        "master": "8fa195448453e881607e95bb8f8d4fc96bece6b8"
-      },
-      "latest_tag": "1.2"
-    },
-    "shirsig/inspect": {
-      "default_branch": "master",
-      "sha": "a91c16ebfe09a0ef8bfb92e4b593c8da795346e9",
-      "branches": {
-        "master": "a91c16ebfe09a0ef8bfb92e4b593c8da795346e9"
-      }
-    },
-    "doorknob6/inspector": {
-      "default_branch": "master",
-      "sha": "3298d70752b60475ad611242a7030c0bbacb02df",
-      "branches": {
-        "master": "3298d70752b60475ad611242a7030c0bbacb02df"
-      }
-    },
-    "rengoua/inspector": {
-      "default_branch": "master",
-      "sha": "e5070e2d528a697541bf8faad28b71fdf9081c4f",
-      "branches": {
-        "master": "e5070e2d528a697541bf8faad28b71fdf9081c4f"
-      }
-    },
-    "marcelinevq/instancetimers": {
-      "default_branch": "master",
-      "sha": "5d4e5535c92aeed47e06e7ee143263931401d96c",
-      "branches": {
-        "master": "5d4e5535c92aeed47e06e7ee143263931401d96c"
-      }
-    },
-    "al3xc1985/instancetimers": {
-      "default_branch": "master",
-      "sha": "5d4e5535c92aeed47e06e7ee143263931401d96c",
-      "branches": {
-        "master": "5d4e5535c92aeed47e06e7ee143263931401d96c"
-      }
-    },
-    "bretharte89/instancetimers": {
-      "default_branch": "master",
-      "sha": "5d4e5535c92aeed47e06e7ee143263931401d96c",
-      "branches": {
-        "master": "5d4e5535c92aeed47e06e7ee143263931401d96c"
-      }
-    },
-    "vargv666/instancetimers": {
-      "default_branch": "master",
-      "sha": "5d4e5535c92aeed47e06e7ee143263931401d96c",
-      "branches": {
-        "master": "5d4e5535c92aeed47e06e7ee143263931401d96c"
-      }
-    },
-    "pepopo978/instancetimers": {
-      "default_branch": "master",
-      "sha": "c36612b6d9118a5a78a7caf701aa9307273aa797",
-      "branches": {
-        "master": "c36612b6d9118a5a78a7caf701aa9307273aa797"
-      }
-    },
-    "jrc13245/intellisense": {
-      "default_branch": "main",
-      "sha": "e8968c2088054bd3f567529e9f177ebf032d4241",
-      "branches": {
-        "main": "e8968c2088054bd3f567529e9f177ebf032d4241"
-      }
-    },
-    "road-block/interruptor": {
-      "default_branch": "master",
-      "sha": "777585a52a447fc59f42a625c8a38b7d411e1052",
-      "branches": {
-        "master": "777585a52a447fc59f42a625c8a38b7d411e1052"
-      }
-    },
-    "alexpoatato/interruptor": {
-      "default_branch": "master",
-      "sha": "777585a52a447fc59f42a625c8a38b7d411e1052",
-      "branches": {
-        "master": "777585a52a447fc59f42a625c8a38b7d411e1052"
-      }
-    },
-    "road-block/itemhints": {
-      "default_branch": "master",
-      "sha": "4e33174b1fc403d395671eefcbbc70a57fb6e52a",
-      "branches": {
-        "master": "4e33174b1fc403d395671eefcbbc70a57fb6e52a"
-      },
-      "latest_tag": "1.11"
-    },
-    "cyaohiri/itemidtooltip": {
-      "default_branch": "main",
-      "sha": "f25c97e799ebd66d3e5e4318f4b513f3561c385d",
-      "branches": {
-        "main": "f25c97e799ebd66d3e5e4318f4b513f3561c385d"
-      }
-    },
-    "road-block/itemsofpower": {
-      "default_branch": "master",
-      "sha": "265fe97786de235ded987d984d853acec8740087",
-      "branches": {
-        "master": "265fe97786de235ded987d984d853acec8740087"
-      },
-      "latest_tag": "1.01-11200"
-    },
-    "bestoriop/itemsofpower": {
-      "default_branch": "turtle",
-      "sha": "46a0f66dfbfd788712ef15d00f14d3f2362bfa34",
-      "branches": {
-        "turtle": "46a0f66dfbfd788712ef15d00f14d3f2362bfa34"
-      }
-    },
-    "gabrwagn/itemsofpower": {
-      "default_branch": "master",
-      "sha": "335e9cf79457e1c8893a37d620beb2e07bf8186f",
-      "branches": {
-        "master": "335e9cf79457e1c8893a37d620beb2e07bf8186f"
-      }
-    },
-    "atreyyo/iwin": {
-      "default_branch": "master",
-      "sha": "ee65d68f44c45c26783f707deb22be965ff71bd3",
-      "branches": {
-        "master": "ee65d68f44c45c26783f707deb22be965ff71bd3"
-      }
-    },
-    "bear-lb/iwin": {
-      "default_branch": "master",
-      "sha": "e06bb939d976319445f8598e1e3dc43f901bd28f",
-      "branches": {
-        "master": "e06bb939d976319445f8598e1e3dc43f901bd28f"
-      }
-    },
-    "pushxd/jim_cooldownpulse": {
-      "default_branch": "master",
-      "sha": "bacb53bdee96dec5054193f5a69d22cb3e920c15",
-      "branches": {
-        "master": "bacb53bdee96dec5054193f5a69d22cb3e920c15"
-      }
-    },
-    "alchem1ster/jim_cooldownpulse": {
-      "default_branch": "master",
-      "sha": "0e664bd70b7b2e20a95250b0c59828b127b8dff0",
-      "branches": {
-        "master": "0e664bd70b7b2e20a95250b0c59828b127b8dff0"
-      }
-    },
-    "xniko/kallyoautoshot": {
-      "default_branch": "master",
-      "sha": "ee23361084583e26de4afff6685206ba9dcc3d7e",
-      "branches": {
-        "master": "ee23361084583e26de4afff6685206ba9dcc3d7e"
-      }
-    },
-    "keijinde/keijinachievementmonitor": {
-      "default_branch": "main",
-      "sha": "b7d4f1d3bad50446ffacfe460c7dcbb9f22d6381",
-      "branches": {
-        "main": "b7d4f1d3bad50446ffacfe460c7dcbb9f22d6381"
-      },
-      "latest_tag": "v1.0.0"
-    },
-    "refaim/kethodoc": {
-      "default_branch": "master",
-      "sha": "b7756d1395867ef87aa4f73d1a63443bc1510651",
-      "branches": {
-        "master": "b7756d1395867ef87aa4f73d1a63443bc1510651"
-      }
-    },
-    "e-oven/kethodoc": {
-      "default_branch": "master",
-      "sha": "b7756d1395867ef87aa4f73d1a63443bc1510651",
-      "branches": {
-        "master": "b7756d1395867ef87aa4f73d1a63443bc1510651"
-      }
-    },
-    "frostshock/killcounter": {
-      "default_branch": "main",
-      "sha": "1a938c71cca7700acff98b513ab49c8ba0c9dac2",
-      "branches": {
-        "main": "1a938c71cca7700acff98b513ab49c8ba0c9dac2"
-      }
-    },
-    "sumowares/killpro": {
-      "default_branch": "master",
-      "sha": "c20362378be481dc445aedddf9769eee197bba21",
-      "branches": {
-        "master": "c20362378be481dc445aedddf9769eee197bba21"
-      }
-    },
-    "sica42/killtrack": {
-      "default_branch": "main",
-      "sha": "4e6132ddffd2669ae7855ef241cb18d839183f83",
-      "branches": {
-        "main": "4e6132ddffd2669ae7855ef241cb18d839183f83"
-      }
-    },
-    "bergador/ktmemeaddon": {
-      "default_branch": "master",
-      "sha": "8c50d875e4089f0720abfadcf575cf18089254be",
-      "branches": {
-        "master": "8c50d875e4089f0720abfadcf575cf18089254be"
-      }
-    },
-    "bergador/ktp3shacklecounter": {
-      "default_branch": "master",
-      "sha": "eb7efedfdcb181f29d69561de1e2d997e873cc09",
-      "branches": {
-        "master": "eb7efedfdcb181f29d69561de1e2d997e873cc09"
-      }
-    },
-    "johnmichael/lagcast": {
-      "default_branch": "master",
-      "sha": "fccc0a815853d7add7994a2c6b31728fb1579384",
-      "branches": {
-        "master": "fccc0a815853d7add7994a2c6b31728fb1579384"
-      }
-    },
-    "road-block/languagefilter": {
-      "default_branch": "master",
-      "sha": "a64db8572ec0912e31b446bb6fd8168a1539f60e",
-      "branches": {
-        "master": "a64db8572ec0912e31b446bb6fd8168a1539f60e"
-      }
-    },
-    "laytya/lazyscript": {
-      "default_branch": "master",
-      "sha": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92",
-      "branches": {
-        "master": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92"
-      }
-    },
-    "cache9527/lazyscript": {
-      "default_branch": "master",
-      "sha": "041ce6efafb4ea8cc599a81200693051e8f52ed9",
-      "branches": {
-        "master": "041ce6efafb4ea8cc599a81200693051e8f52ed9"
-      }
-    },
-    "lichong8826/lazyscript": {
-      "default_branch": "master",
-      "sha": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92",
-      "branches": {
-        "master": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92"
-      }
-    },
-    "pfmiles/lazyscript": {
-      "default_branch": "master",
-      "sha": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92",
-      "branches": {
-        "master": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92"
-      }
-    },
-    "neyacinu/lazyscript": {
-      "default_branch": "master",
-      "sha": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92",
-      "branches": {
-        "master": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92"
-      }
-    },
-    "gvdn78/lazyscript": {
-      "default_branch": "master",
-      "sha": "861c035a966bb16c1a51b69d8e8245a1e5cf0422",
-      "branches": {
-        "master": "861c035a966bb16c1a51b69d8e8245a1e5cf0422"
-      }
-    },
-    "zimengle/lazyscript": {
-      "default_branch": "master",
-      "sha": "bf53d9c73d73963c99f944f128235ec285a639e4",
-      "branches": {
-        "master": "bf53d9c73d73963c99f944f128235ec285a639e4"
-      }
-    },
-    "esqariote/lazyscript": {
-      "default_branch": "master",
-      "sha": "9628d33fb535a08b39cf4b3d86a06861f0405bb8",
-      "branches": {
-        "master": "9628d33fb535a08b39cf4b3d86a06861f0405bb8"
-      }
-    },
-    "metaroa/lazyscript": {
-      "default_branch": "master",
-      "sha": "97e277bd060924da418becb945e321b54065ad4e",
-      "branches": {
-        "master": "97e277bd060924da418becb945e321b54065ad4e"
-      }
-    },
-    "mymacd/lazyscript": {
-      "default_branch": "master",
-      "sha": "97e277bd060924da418becb945e321b54065ad4e",
-      "branches": {
-        "master": "97e277bd060924da418becb945e321b54065ad4e"
-      }
-    },
-    "zhaoyu89730105/lazyscript": {
-      "default_branch": "master",
-      "sha": "97e277bd060924da418becb945e321b54065ad4e",
-      "branches": {
-        "master": "97e277bd060924da418becb945e321b54065ad4e"
-      }
-    },
-    "sxe/lazyscript-turtle": {
-      "default_branch": "master",
-      "sha": "d98aac01e934fcd2adb7dd70f697e94384d0a4b9",
-      "branches": {
-        "master": "d98aac01e934fcd2adb7dd70f697e94384d0a4b9"
-      }
-    },
-    "gamer4eg/lazyscript": {
-      "default_branch": "master",
-      "sha": "65f990efce9fbdab9c9353f0ed15bfe743b35952",
-      "branches": {
-        "master": "65f990efce9fbdab9c9353f0ed15bfe743b35952"
-      }
-    },
-    "mr-rosh/lern2spell": {
-      "default_branch": "master",
-      "sha": "eb66f354a363b29c7140edd857ea4cbd01b3d8f5",
-      "branches": {
-        "master": "eb66f354a363b29c7140edd857ea4cbd01b3d8f5"
-      }
-    },
-    "whtmst/lern2spell": {
-      "default_branch": "master",
-      "sha": "eb66f354a363b29c7140edd857ea4cbd01b3d8f5",
-      "branches": {
-        "master": "eb66f354a363b29c7140edd857ea4cbd01b3d8f5"
-      }
-    },
-    "ralliartse/lfghelper": {
-      "default_branch": "main",
-      "sha": "4a2c42668e859585c73642e12a03bd1bd3a7636f",
-      "branches": {
-        "main": "4a2c42668e859585c73642e12a03bd1bd3a7636f"
-      }
-    },
-    "bingete/lfghelper": {
-      "default_branch": "main",
-      "sha": "3ab8561286cd7215431043c2e3608e614585a1b6",
-      "branches": {
-        "main": "3ab8561286cd7215431043c2e3608e614585a1b6"
-      }
-    },
-    "turinpt/lhcp": {
-      "default_branch": "master",
-      "sha": "175d68371684b5d73d7cd26eda487791cb825ddf",
-      "branches": {
-        "master": "175d68371684b5d73d7cd26eda487791cb825ddf"
-      }
-    },
-    "jvaneg/libramswap": {
-      "default_branch": "main",
-      "sha": "46114022eb4a33eefcb2189f24ddb4d5b620b364",
-      "branches": {
-        "main": "46114022eb4a33eefcb2189f24ddb4d5b620b364"
-      }
-    },
-    "unclemilky/libramswap": {
-      "default_branch": "main",
-      "sha": "ac6048d78d15130e500c6c872b3aaf38dde13335",
-      "branches": {
-        "main": "ac6048d78d15130e500c6c872b3aaf38dde13335"
-      }
-    },
-    "mats391/libramswap": {
-      "default_branch": "main",
-      "sha": "46114022eb4a33eefcb2189f24ddb4d5b620b364",
-      "branches": {
-        "main": "46114022eb4a33eefcb2189f24ddb4d5b620b364"
-      }
-    },
-    "zanthor/libramswap": {
-      "default_branch": "main",
-      "sha": "263c8c28d0a3656bb44b113c005adf2fc7cfb570",
-      "branches": {
-        "main": "263c8c28d0a3656bb44b113c005adf2fc7cfb570"
-      }
-    },
-    "shirsig/linkmend": {
-      "default_branch": "master",
-      "sha": "d9e96234f589e9d38cdb60bf8e7d53477946e5bf",
-      "branches": {
-        "master": "d9e96234f589e9d38cdb60bf8e7d53477946e5bf"
-      }
-    },
-    "seacrabsam/lockport": {
-      "default_branch": "main",
-      "sha": "24c61e42b683d3b422d5c8744feb195e0137e04a",
-      "branches": {
-        "main": "24c61e42b683d3b422d5c8744feb195e0137e04a"
-      }
-    },
-    "avvatar/lockport": {
-      "default_branch": "main",
-      "sha": "3b2d049a2b593f189522d2c9b70711ed48b32819",
-      "branches": {
-        "main": "3b2d049a2b593f189522d2c9b70711ed48b32819"
-      }
-    },
-    "yani9o/lockport": {
-      "default_branch": "main",
-      "sha": "928e898521da69c950a8b1874f9aa905d0ba2c36",
-      "branches": {
-        "main": "928e898521da69c950a8b1874f9aa905d0ba2c36"
-      }
-    },
-    "randall05/lockport_plus": {
-      "default_branch": "main",
-      "sha": "1642962c3f3603f87c324815cf5ab6b1f13c1f4b",
-      "branches": {
-        "main": "1642962c3f3603f87c324815cf5ab6b1f13c1f4b"
-      }
-    },
-    "nanatot/lockport": {
-      "default_branch": "main",
-      "sha": "7148cb1119c9c8b942eeca2f117de5eabb7c61be",
-      "branches": {
-        "main": "7148cb1119c9c8b942eeca2f117de5eabb7c61be"
-      }
-    },
-    "road-block/losecontrol": {
-      "default_branch": "master",
-      "sha": "26f5e1db3aa74565dab0f620795949f2f346f44e",
-      "branches": {
-        "master": "26f5e1db3aa74565dab0f620795949f2f346f44e"
-      }
-    },
-    "cache9527/losecontrol-old": {
-      "default_branch": "master",
-      "sha": "5b228020d0f73231df1bdc31ffcfbd84b504878a",
-      "branches": {
-        "master": "5b228020d0f73231df1bdc31ffcfbd84b504878a"
-      }
-    },
-    "woblight/macrotextstop": {
-      "default_branch": "master",
-      "sha": "13e32571bce73afebfc505f81ccaaacde4ebfdd7",
-      "branches": {
-        "master": "13e32571bce73afebfc505f81ccaaacde4ebfdd7"
-      }
-    },
-    "undercityaddons-vanilla/macrott-v": {
-      "default_branch": "master",
-      "sha": "d9d173bda041771f17566353a012c67180331702",
-      "branches": {
-        "master": "d9d173bda041771f17566353a012c67180331702"
-      },
-      "latest_tag": "v1.1.0"
-    },
-    "terongorus/teronadvancedmacrotooltips": {
-      "default_branch": "master",
-      "sha": "daee1d39cae771ac55f5202907eae107f03b707e",
-      "branches": {
-        "master": "daee1d39cae771ac55f5202907eae107f03b707e"
-      }
-    },
-    "melbaa/manaminder": {
-      "default_branch": "master",
-      "sha": "ababafd952ef3d4b293c0dd9b64f2cc272fc477a",
-      "branches": {
-        "master": "ababafd952ef3d4b293c0dd9b64f2cc272fc477a"
-      },
-      "latest_tag": "v1.7"
-    },
-    "vargv666/manaminder": {
-      "default_branch": "master",
-      "sha": "ababafd952ef3d4b293c0dd9b64f2cc272fc477a",
-      "branches": {
-        "master": "ababafd952ef3d4b293c0dd9b64f2cc272fc477a"
-      }
-    },
-    "athenegenesis/vanilla_manyqtitemtooltips": {
-      "default_branch": "master",
-      "sha": "4571462e87ecc91d7eb1d711ff17c27e5c9ffcb8",
-      "branches": {
-        "master": "4571462e87ecc91d7eb1d711ff17c27e5c9ffcb8"
-      },
-      "latest_tag": "v1.0"
-    },
-    "asdaaf/mb-ca-icons": {
-      "default_branch": "master",
-      "sha": "8f4c0fcf61ac2305d60b2f8e8b1366a993e7b5b2",
-      "branches": {
-        "master": "8f4c0fcf61ac2305d60b2f8e8b1366a993e7b5b2"
-      }
-    },
-    "fsuhas/mcp-tw": {
-      "default_branch": "main",
-      "sha": "1f5dc1c2de08584fbf5cb6c2fd4bca9a8cc63aa6",
-      "branches": {
-        "main": "1f5dc1c2de08584fbf5cb6c2fd4bca9a8cc63aa6"
-      }
-    },
-    "phyx1u5/meeting": {
-      "default_branch": "master",
-      "sha": "1d35a221559f15d70e461cb1628858ddea4b5b0c",
-      "branches": {
-        "master": "1d35a221559f15d70e461cb1628858ddea4b5b0c"
-      }
-    },
-    "therealfayz/turtle-hub": {
-      "default_branch": "master",
-      "sha": "42692d59e49dde713e26d245e4698e769e9f9b80",
-      "branches": {
-        "master": "42692d59e49dde713e26d245e4698e769e9f9b80"
-      }
-    },
-    "jejkas/meleestats": {
-      "default_branch": "master",
-      "sha": "eb3adcbe9b1f35734a3a4e7b6f8c4133a3ade5a5",
-      "branches": {
-        "master": "eb3adcbe9b1f35734a3a4e7b6f8c4133a3ade5a5"
-      }
-    },
-    "tilare/messagebox": {
-      "default_branch": "main",
-      "sha": "eede932b062a764b7ff1b548106e2d95a9925737",
-      "branches": {
-        "main": "eede932b062a764b7ff1b548106e2d95a9925737"
-      }
-    },
-    "zedorff/messagebox": {
-      "default_branch": "main",
-      "sha": "0c63f1d624782163349a1100e46bc604f4117a32",
-      "branches": {
-        "main": "0c63f1d624782163349a1100e46bc604f4117a32"
-      }
-    },
-    "bretharte89/messagebox": {
-      "default_branch": "main",
-      "sha": "eede932b062a764b7ff1b548106e2d95a9925737",
-      "branches": {
-        "main": "eede932b062a764b7ff1b548106e2d95a9925737"
-      }
-    },
-    "ravenofseven/messagebox": {
-      "default_branch": "main",
-      "sha": "0c63f1d624782163349a1100e46bc604f4117a32",
-      "branches": {
-        "main": "0c63f1d624782163349a1100e46bc604f4117a32"
-      }
-    },
-    "oldmanalpha/messagebox": {
-      "default_branch": "main",
-      "sha": "d229d8bf01f91c391c9ff4bf3ac2cdb74f3e44ed",
-      "branches": {
-        "main": "d229d8bf01f91c391c9ff4bf3ac2cdb74f3e44ed"
-      }
-    },
-    "duvelcorp/metahunt": {
-      "default_branch": "master",
-      "sha": "270da5ab65180a01bfd24f59d126c1e32e06204c",
-      "branches": {
-        "master": "270da5ab65180a01bfd24f59d126c1e32e06204c"
-      },
-      "latest_tag": "v1.5.1"
-    },
-    "robs898/mobinfo2turtle": {
-      "default_branch": "master",
-      "sha": "72f07f7a5c55f84e7436bb192b3ed0f29297a476",
-      "branches": {
-        "master": "72f07f7a5c55f84e7436bb192b3ed0f29297a476"
-      }
-    },
-    "goldenpipes/mobinfo2": {
-      "default_branch": "master",
-      "sha": "9bac7af9ef86278b8c3e675fb9dab466aeb501d5",
-      "branches": {
-        "master": "9bac7af9ef86278b8c3e675fb9dab466aeb501d5"
-      }
-    },
-    "scoboose/mobinfo2-turtle": {
-      "default_branch": "master",
-      "sha": "e0b192b7f22586d1262be3b3d4de73508e14faaf",
-      "branches": {
-        "master": "e0b192b7f22586d1262be3b3d4de73508e14faaf"
-      }
-    },
     "0ldi/mobresist": {
       "default_branch": "master",
       "sha": "68c3dc00dedf3a615416b111e81fbe0651b2f0e8",
@@ -4909,33 +58,137 @@
         "master": "68c3dc00dedf3a615416b111e81fbe0651b2f0e8"
       }
     },
-    "gescht/mobresist": {
+    "0ldi/quickchat": {
       "default_branch": "master",
-      "sha": "3029ca3d6cb0363fa3e320bd467a8a7ad69b3552",
+      "sha": "52aeb268a9cd1d7ba3cb8dc1b31fdfdf0002ea9e",
       "branches": {
-        "master": "3029ca3d6cb0363fa3e320bd467a8a7ad69b3552"
+        "master": "52aeb268a9cd1d7ba3cb8dc1b31fdfdf0002ea9e"
       }
     },
-    "idontbyte/mobstolevel": {
+    "0ldi/rangecolor": {
       "default_branch": "master",
-      "sha": "5ea57074ce45d066ba58e321f04685aa8f8ceedb",
+      "sha": "86e303f1d97b0355010ed3a010bb7c611eb90112",
       "branches": {
-        "master": "5ea57074ce45d066ba58e321f04685aa8f8ceedb"
-      },
-      "latest_tag": "1.0"
-    },
-    "gordijnman/mobsonlevel": {
-      "default_branch": "master",
-      "sha": "b9c4cf5f766a5454065f18df2a92ed919d908d6f",
-      "branches": {
-        "master": "b9c4cf5f766a5454065f18df2a92ed919d908d6f"
+        "master": "86e303f1d97b0355010ed3a010bb7c611eb90112"
       }
     },
-    "cregham/mobstolevel": {
+    "0ldi/summonsmonitor": {
       "default_branch": "master",
-      "sha": "6a9466ca9b775e08a957bde72aa6d8189a983131",
+      "sha": "06c8f377bab24fd59f094a01674f1aaa7376aea0",
       "branches": {
-        "master": "6a9466ca9b775e08a957bde72aa6d8189a983131"
+        "master": "06c8f377bab24fd59f094a01674f1aaa7376aea0"
+      }
+    },
+    "0ldi/targetassist": {
+      "default_branch": "master",
+      "sha": "8167f541f1ba2d2cf8bc28711dad7973042124f7",
+      "branches": {
+        "master": "8167f541f1ba2d2cf8bc28711dad7973042124f7"
+      }
+    },
+    "0ldi/timers": {
+      "default_branch": "master",
+      "sha": "8c5645ad517589600049aacfbb1748297e372629",
+      "branches": {
+        "master": "8c5645ad517589600049aacfbb1748297e372629"
+      }
+    },
+    "0ldi/vanillamaps": {
+      "default_branch": "master",
+      "sha": "38babd3c213a6f1845f7b711f09d17295ef0fd78",
+      "branches": {
+        "master": "38babd3c213a6f1845f7b711f09d17295ef0fd78"
+      }
+    },
+    "0ninzya/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "ceae89b14544fd87a8449bd4a751802dd118809c",
+      "branches": {
+        "master": "ceae89b14544fd87a8449bd4a751802dd118809c"
+      }
+    },
+    "101arg101/catdruiddps": {
+      "default_branch": "master",
+      "sha": "e3f9a2dd156178b51d4b9a500fa679ca825bc138",
+      "branches": {
+        "master": "e3f9a2dd156178b51d4b9a500fa679ca825bc138"
+      }
+    },
+    "1petru/akkio_consume_helper": {
+      "default_branch": "main",
+      "sha": "b2be5112690a5a302ef18b88e41b98f636ad1d41",
+      "branches": {
+        "main": "b2be5112690a5a302ef18b88e41b98f636ad1d41"
+      }
+    },
+    "7aske/stealthoverlay": {
+      "default_branch": "master",
+      "sha": "8640ab06f92ea35d68cf78d5cc904a1b631c20e4",
+      "branches": {
+        "master": "8640ab06f92ea35d68cf78d5cc904a1b631c20e4"
+      }
+    },
+    "8eightysixed6/hardcoredeath": {
+      "default_branch": "main",
+      "sha": "38521a17b4fac0124151d5aa83ec96f681dd0239",
+      "branches": {
+        "main": "38521a17b4fac0124151d5aa83ec96f681dd0239"
+      }
+    },
+    "96rex/shagudps": {
+      "default_branch": "master",
+      "sha": "cbcba27d2e01d10072a29eb5e63639c6a838f689",
+      "branches": {
+        "master": "cbcba27d2e01d10072a29eb5e63639c6a838f689"
+      }
+    },
+    "aalandriel/guildrecipes": {
+      "default_branch": "main",
+      "sha": "740912132f4d66cc517ad567204c1ea9146916d5",
+      "branches": {
+        "main": "740912132f4d66cc517ad567204c1ea9146916d5"
+      }
+    },
+    "aalandriel/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "4237b12708d16d3b05bb376159cd9ceb81836bb9",
+      "branches": {
+        "master": "4237b12708d16d3b05bb376159cd9ceb81836bb9"
+      }
+    },
+    "abstr4ctz/adf": {
+      "default_branch": "master",
+      "sha": "ffc7cfd56dacf7ef186b637d6879283389d1fd9e",
+      "branches": {
+        "master": "ffc7cfd56dacf7ef186b637d6879283389d1fd9e"
+      }
+    },
+    "abstr4ctz/casthistorytracker": {
+      "default_branch": "main",
+      "sha": "5de5cd4b40018c53cd2ee3291a077303b5969f28",
+      "branches": {
+        "main": "5de5cd4b40018c53cd2ee3291a077303b5969f28"
+      }
+    },
+    "abstr4ctz/cooldowntracker": {
+      "default_branch": "main",
+      "sha": "36caab96f68d7b4477cab536089d6e8ad51e9d2d",
+      "branches": {
+        "main": "36caab96f68d7b4477cab536089d6e8ad51e9d2d"
+      }
+    },
+    "abstr4ctz/enhancer": {
+      "default_branch": "master",
+      "sha": "79a78ada52810a9cf6cb80ae127aeff0a0d45a4e",
+      "branches": {
+        "master": "79a78ada52810a9cf6cb80ae127aeff0a0d45a4e"
+      }
+    },
+    "abstr4ctz/ifalert": {
+      "default_branch": "master",
+      "sha": "864cc8d9edd09ac3b4b60978b6788c7afd376aaf",
+      "branches": {
+        "master": "864cc8d9edd09ac3b4b60978b6788c7afd376aaf"
       }
     },
     "abstr4ctz/modernfocusframe": {
@@ -4945,27 +198,6 @@
         "main": "6c6631b174e1a4450c32af801cd5a1f278f6e630"
       }
     },
-    "hippoom/modernfocusframe": {
-      "default_branch": "main",
-      "sha": "6a2288ff7133c3d69be0259af380bb884abf47e8",
-      "branches": {
-        "main": "6a2288ff7133c3d69be0259af380bb884abf47e8"
-      }
-    },
-    "bretharte89/modernfocusframe": {
-      "default_branch": "main",
-      "sha": "6c6631b174e1a4450c32af801cd5a1f278f6e630",
-      "branches": {
-        "main": "6c6631b174e1a4450c32af801cd5a1f278f6e630"
-      }
-    },
-    "laytya/modernfocusframe": {
-      "default_branch": "main",
-      "sha": "f9243c70da7b2725f158f093856687aa48457e36",
-      "branches": {
-        "main": "f9243c70da7b2725f158f093856687aa48457e36"
-      }
-    },
     "abstr4ctz/modernspellalert": {
       "default_branch": "main",
       "sha": "97486297904a360c0e0fddb4fcbc6ada731a476c",
@@ -4973,32 +205,274 @@
         "main": "97486297904a360c0e0fddb4fcbc6ada731a476c"
       }
     },
-    "bretharte89/modernspellalert": {
+    "acid9000/antiafk": {
       "default_branch": "main",
-      "sha": "97486297904a360c0e0fddb4fcbc6ada731a476c",
+      "sha": "8ba518f52fb6bd6c4e12a924af9dfcf89af0add6",
       "branches": {
-        "main": "97486297904a360c0e0fddb4fcbc6ada731a476c"
+        "main": "8ba518f52fb6bd6c4e12a924af9dfcf89af0add6"
       }
     },
-    "paenthy/modernspellalert": {
+    "acid9000/aux-addon": {
+      "default_branch": "master",
+      "sha": "09728c5a5a4c9b30c05a25d4fc23a9247683fadc",
+      "branches": {
+        "master": "09728c5a5a4c9b30c05a25d4fc23a9247683fadc"
+      },
+      "latest_tag": "1.0.3"
+    },
+    "acid9000/pizzaworldbuffs": {
       "default_branch": "main",
-      "sha": "97486297904a360c0e0fddb4fcbc6ada731a476c",
+      "sha": "72d6861926c1a2106c8773e8e251da27ab617471",
       "branches": {
-        "main": "97486297904a360c0e0fddb4fcbc6ada731a476c"
+        "main": "72d6861926c1a2106c8773e8e251da27ab617471"
       }
     },
-    "vegeta1k95/modernspellbook": {
+    "acid9000/rabuffs": {
       "default_branch": "master",
-      "sha": "88afad31729657175d1710c259d9e55081331920",
+      "sha": "6ae5e7cb86ddc6f5112903f7fa32e5f001c7613a",
       "branches": {
-        "master": "88afad31729657175d1710c259d9e55081331920"
+        "master": "6ae5e7cb86ddc6f5112903f7fa32e5f001c7613a"
       }
     },
-    "lioryx/modernspellbook": {
+    "acidtib/shagujunk": {
       "default_branch": "master",
-      "sha": "f55e71de726acd615393a59c91c8c95565d9aeb5",
+      "sha": "3ff9d5f2afb318c58cb9c03afa18226dbf751341",
       "branches": {
-        "master": "f55e71de726acd615393a59c91c8c95565d9aeb5"
+        "master": "3ff9d5f2afb318c58cb9c03afa18226dbf751341"
+      }
+    },
+    "adrianocastro189/aux-addon": {
+      "default_branch": "master",
+      "sha": "457f7537494a5c0e308f807800b4a3de531df0d0",
+      "branches": {
+        "master": "457f7537494a5c0e308f807800b4a3de531df0d0"
+      }
+    },
+    "adrianocastro189/destroy-cursor-item": {
+      "default_branch": "main",
+      "sha": "2e653d867768f52de7c69dfebdc4343619eee64d",
+      "branches": {
+        "main": "2e653d867768f52de7c69dfebdc4343619eee64d"
+      },
+      "latest_tag": "1.1.0"
+    },
+    "adrianocastro189/dialogui": {
+      "default_branch": "main",
+      "sha": "68177f7af67175453c157932a43fe648e0d8fa0f",
+      "branches": {
+        "main": "68177f7af67175453c157932a43fe648e0d8fa0f"
+      }
+    },
+    "aeroscripts/ct_buffmod_sorted": {
+      "default_branch": "master",
+      "sha": "d924e88e81dd5645a64514061f173c63dedc75e2",
+      "branches": {
+        "master": "d924e88e81dd5645a64514061f173c63dedc75e2"
+      },
+      "latest_tag": "v0.1"
+    },
+    "aethusx/shootyepgp": {
+      "default_branch": "master",
+      "sha": "c62c7481f4cbf298922fd7cf60f5b342a1411afb",
+      "branches": {
+        "master": "c62c7481f4cbf298922fd7cf60f5b342a1411afb"
+      }
+    },
+    "ageous27/gcdtimerbar": {
+      "default_branch": "main",
+      "sha": "ce25c463b743c3ffb0408b92e7fdea5c19ef25e0",
+      "branches": {
+        "main": "ce25c463b743c3ffb0408b92e7fdea5c19ef25e0"
+      }
+    },
+    "ageous27/jankyplates": {
+      "default_branch": "main",
+      "sha": "c40a9dd6f35eae609071e0d4a5a0fc81a12d706c",
+      "branches": {
+        "main": "c40a9dd6f35eae609071e0d4a5a0fc81a12d706c"
+      }
+    },
+    "ageous27/twmapreveal": {
+      "default_branch": "main",
+      "sha": "49015343ff0bb76366a9b0fcd377902e747fb5d0",
+      "branches": {
+        "main": "49015343ff0bb76366a9b0fcd377902e747fb5d0"
+      }
+    },
+    "aggromemnon/sp_revenge": {
+      "default_branch": "main",
+      "sha": "e19426df9bc586cefd2cc39ae61cfea549b6fd59",
+      "branches": {
+        "main": "e19426df9bc586cefd2cc39ae61cfea549b6fd59"
+      }
+    },
+    "ahhh-reptar/questannouncer": {
+      "default_branch": "main",
+      "sha": "cf324e82e89e3eb87d62c3aed717f93ab2656a02",
+      "branches": {
+        "main": "cf324e82e89e3eb87d62c3aed717f93ab2656a02"
+      }
+    },
+    "airchandler/evtcalendar": {
+      "default_branch": "master",
+      "sha": "c038e69fef9b1988ccebd5480d6884b164bbfc94",
+      "branches": {
+        "master": "c038e69fef9b1988ccebd5480d6884b164bbfc94"
+      },
+      "latest_tag": "1.3"
+    },
+    "airfinder/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "f43019aba2c7816d02a76265cfc827ddc566d064",
+      "branches": {
+        "master": "f43019aba2c7816d02a76265cfc827ddc566d064"
+      }
+    },
+    "akileos/happyprofs": {
+      "default_branch": "main",
+      "sha": "a9d75c380d14602c261a8b24bef4c7005fdf6cbf",
+      "branches": {
+        "main": "a9d75c380d14602c261a8b24bef4c7005fdf6cbf"
+      }
+    },
+    "akurutin/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
+      "branches": {
+        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
+      }
+    },
+    "akzkak/channelmonitorplus": {
+      "default_branch": "master",
+      "sha": "cb43cb64e51849c66a7cc299a5c4d0af8ec878de",
+      "branches": {
+        "master": "cb43cb64e51849c66a7cc299a5c4d0af8ec878de"
+      }
+    },
+    "akzkak/craftyplus": {
+      "default_branch": "master",
+      "sha": "ba31bc48b931ffe9b77903481a4f1cc6e1a8ff33",
+      "branches": {
+        "master": "ba31bc48b931ffe9b77903481a4f1cc6e1a8ff33"
+      }
+    },
+    "akzkak/drunktracker": {
+      "default_branch": "master",
+      "sha": "e12b77980ba35d47c1d2401b9bbb522fddd2f230",
+      "branches": {
+        "master": "e12b77980ba35d47c1d2401b9bbb522fddd2f230"
+      }
+    },
+    "akzkak/pfui-lazyres": {
+      "default_branch": "master",
+      "sha": "d33a17af316de26595cbeac252a08767f7dcbf5f",
+      "branches": {
+        "master": "d33a17af316de26595cbeac252a08767f7dcbf5f"
+      }
+    },
+    "akzkak/raidsummonplus": {
+      "default_branch": "master",
+      "sha": "dae4221d953f9f7a46d764d05d43a729be594bc5",
+      "branches": {
+        "master": "dae4221d953f9f7a46d764d05d43a729be594bc5"
+      }
+    },
+    "akzkak/rogueticker": {
+      "default_branch": "master",
+      "sha": "5110f54d89e043fc41fea8343a7e481ca4122d1f",
+      "branches": {
+        "master": "5110f54d89e043fc41fea8343a7e481ca4122d1f"
+      }
+    },
+    "akzkak/shardcapplus": {
+      "default_branch": "main",
+      "sha": "d352a79783f8e6d1a99ac122e7226de4e345b677",
+      "branches": {
+        "main": "d352a79783f8e6d1a99ac122e7226de4e345b677"
+      }
+    },
+    "akzkak/supertotem": {
+      "default_branch": "main",
+      "sha": "1cae895d69190037fe121b9fc5e88081adbf18e0",
+      "branches": {
+        "main": "1cae895d69190037fe121b9fc5e88081adbf18e0"
+      }
+    },
+    "al3xc1985/brainsaver": {
+      "default_branch": "master",
+      "sha": "35aa13b050915862b5a7303eb43bd6525876fb09",
+      "branches": {
+        "master": "35aa13b050915862b5a7303eb43bd6525876fb09"
+      }
+    },
+    "al3xc1985/characterprofiler": {
+      "default_branch": "master",
+      "sha": "8501d6991302d177776ace5f5843cd24b6308974",
+      "branches": {
+        "master": "8501d6991302d177776ace5f5843cd24b6308974"
+      }
+    },
+    "al3xc1985/dragonflightui-reforged": {
+      "default_branch": "main",
+      "sha": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8",
+      "branches": {
+        "main": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8"
+      }
+    },
+    "al3xc1985/flightmap": {
+      "default_branch": "main",
+      "sha": "8231f8f95de2f361774bb55162a731702409a26c",
+      "branches": {
+        "main": "8231f8f95de2f361774bb55162a731702409a26c"
+      }
+    },
+    "al3xc1985/flyout": {
+      "default_branch": "main",
+      "sha": "f13633a7adc6169e9b5112b68322252b1e623740",
+      "branches": {
+        "main": "f13633a7adc6169e9b5112b68322252b1e623740"
+      }
+    },
+    "al3xc1985/guda": {
+      "default_branch": "main",
+      "sha": "f1618b71bddf816bac82d1a0be67bc1417e8ba20",
+      "branches": {
+        "main": "f1618b71bddf816bac82d1a0be67bc1417e8ba20"
+      }
+    },
+    "al3xc1985/immersion": {
+      "default_branch": "main",
+      "sha": "e87aa4b025da9b810866f64f769af1fb48e3ffe6",
+      "branches": {
+        "main": "e87aa4b025da9b810866f64f769af1fb48e3ffe6"
+      }
+    },
+    "al3xc1985/instancetimers": {
+      "default_branch": "master",
+      "sha": "5d4e5535c92aeed47e06e7ee143263931401d96c",
+      "branches": {
+        "master": "5d4e5535c92aeed47e06e7ee143263931401d96c"
+      }
+    },
+    "al3xc1985/lootblare": {
+      "default_branch": "master",
+      "sha": "eccea47172a2d600aa73001008cc3c1f34b221da",
+      "branches": {
+        "master": "eccea47172a2d600aa73001008cc3c1f34b221da"
+      }
+    },
+    "al3xc1985/mastertradeskills": {
+      "default_branch": "master",
+      "sha": "3c79aa916488a1703ccd83bdc6ca653c5db99436",
+      "branches": {
+        "master": "3c79aa916488a1703ccd83bdc6ca653c5db99436"
+      }
+    },
+    "al3xc1985/modernmapmarkers": {
+      "default_branch": "main",
+      "sha": "5311be6a24979d4119ed59e9f48f90beb41ecfb4",
+      "branches": {
+        "main": "5311be6a24979d4119ed59e9f48f90beb41ecfb4"
       }
     },
     "al3xc1985/modernspellbook": {
@@ -5008,247 +482,110 @@
         "master": "88afad31729657175d1710c259d9e55081331920"
       }
     },
-    "tubtubs/modernspellbook": {
-      "default_branch": "master",
-      "sha": "88afad31729657175d1710c259d9e55081331920",
-      "branches": {
-        "master": "88afad31729657175d1710c259d9e55081331920"
-      }
-    },
-    "ravenofseven/modernspellbook": {
-      "default_branch": "master",
-      "sha": "33ada544a85eb97fea4401e8cb25ebce4f93895b",
-      "branches": {
-        "master": "33ada544a85eb97fea4401e8cb25ebce4f93895b"
-      }
-    },
-    "obble/modguide": {
-      "default_branch": "master",
-      "sha": "4863fcefbc84680f05d3d989704b2eb983f216f2",
-      "branches": {
-        "master": "4863fcefbc84680f05d3d989704b2eb983f216f2"
-      }
-    },
-    "zebouski/mopgeartooltips": {
-      "default_branch": "master",
-      "sha": "fc9000fab3f5576db2740169652caaa79674fe1f",
-      "branches": {
-        "master": "fc9000fab3f5576db2740169652caaa79674fe1f"
-      }
-    },
-    "otari98/mopgeartooltips": {
-      "default_branch": "master",
-      "sha": "b3af2843dbcd77376671a663d45f996743b35958",
-      "branches": {
-        "master": "b3af2843dbcd77376671a663d45f996743b35958"
-      }
-    },
-    "freohr/mopgeartooltips": {
-      "default_branch": "master",
-      "sha": "fc9000fab3f5576db2740169652caaa79674fe1f",
-      "branches": {
-        "master": "fc9000fab3f5576db2740169652caaa79674fe1f"
-      }
-    },
-    "goamania/mousehighlightcircle": {
+    "al3xc1985/panda": {
       "default_branch": "main",
-      "sha": "dced58f6a87b7a7ae7b15cfe098acb951f7b1a0e",
+      "sha": "a328bbc165db8e8e4fe113d751db74b5d227f96b",
       "branches": {
-        "main": "dced58f6a87b7a7ae7b15cfe098acb951f7b1a0e"
+        "main": "a328bbc165db8e8e4fe113d751db74b5d227f96b"
       }
     },
-    "dsidirop/mousehighlightcircle": {
+    "al3xc1985/pfextend": {
       "default_branch": "main",
-      "sha": "95c3b2e0c53fe98f13d8b005b59955fd7f1fc381",
+      "sha": "7281b5d3747591f7b043ccb5656283ce5dec8c7f",
       "branches": {
-        "main": "95c3b2e0c53fe98f13d8b005b59955fd7f1fc381"
+        "main": "7281b5d3747591f7b043ccb5656283ce5dec8c7f"
+      }
+    },
+    "al3xc1985/pfquest": {
+      "default_branch": "main",
+      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
+      "branches": {
+        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
+      }
+    },
+    "al3xc1985/pfquest-turtle": {
+      "default_branch": "main",
+      "sha": "d11e7631774f390edb5b26b86cd84cf43aee5e20",
+      "branches": {
+        "main": "d11e7631774f390edb5b26b86cd84cf43aee5e20"
+      }
+    },
+    "al3xc1985/questrepeat": {
+      "default_branch": "master",
+      "sha": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf",
+      "branches": {
+        "master": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf"
+      }
+    },
+    "al3xc1985/rinse": {
+      "default_branch": "master",
+      "sha": "edfefd858cbf6f6f36e88f8a45c89474dddebdbd",
+      "branches": {
+        "master": "edfefd858cbf6f6f36e88f8a45c89474dddebdbd"
+      }
+    },
+    "al3xc1985/roid-macros": {
+      "default_branch": "master",
+      "sha": "019afbcc018dc3765bc802b8c2fea2811f300689",
+      "branches": {
+        "master": "019afbcc018dc3765bc802b8c2fea2811f300689"
+      }
+    },
+    "al3xc1985/tankplates": {
+      "default_branch": "master",
+      "sha": "8f5c98fed26d3a90e0653db96a64fa9852fc055c",
+      "branches": {
+        "master": "8f5c98fed26d3a90e0653db96a64fa9852fc055c"
+      }
+    },
+    "al3xc1985/turtlechatcolors": {
+      "default_branch": "main",
+      "sha": "3360599bccf37e0d7965cddb9c91c85009d931dd",
+      "branches": {
+        "main": "3360599bccf37e0d7965cddb9c91c85009d931dd"
+      }
+    },
+    "al3xc1985/vanillastoryline": {
+      "default_branch": "master",
+      "sha": "47bf6bbd174db51623a1b6bb27879f08e04dc390",
+      "branches": {
+        "master": "47bf6bbd174db51623a1b6bb27879f08e04dc390"
+      }
+    },
+    "alandarev/pfquest": {
+      "default_branch": "main",
+      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
+      "branches": {
+        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
       },
-      "latest_tag": "v02.00.00.00"
+      "latest_tag": "8.0.0"
     },
-    "rfelleto/mlooklock": {
+    "alanli7991/consoleexperienceclassic": {
       "default_branch": "main",
-      "sha": "c47a7598c4139cef7420b99da1ad063073f08e73",
+      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
       "branches": {
-        "main": "c47a7598c4139cef7420b99da1ad063073f08e73"
+        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
       }
     },
-    "megaevilz/mlooklock": {
-      "default_branch": "main",
-      "sha": "ca36e990a7d01993d28d3d11febcf6d7f0fa86f7",
-      "branches": {
-        "main": "ca36e990a7d01993d28d3d11febcf6d7f0fa86f7"
-      }
-    },
-    "ftkun/mouseoversounds": {
-      "default_branch": "main",
-      "sha": "e094b2ae6b4c84dba0d13fcd44c36677644e43e8",
-      "branches": {
-        "main": "e094b2ae6b4c84dba0d13fcd44c36677644e43e8"
-      }
-    },
-    "jembawow/moveanything": {
-      "default_branch": "main",
-      "sha": "01b20a0a35d7526a31f136227beac5b23bf544ab",
-      "branches": {
-        "main": "01b20a0a35d7526a31f136227beac5b23bf544ab"
-      }
-    },
-    "iroido/moveanything": {
-      "default_branch": "main",
-      "sha": "5949166413384b8f8d01463c83ee775fb2fa1385",
-      "branches": {
-        "main": "5949166413384b8f8d01463c83ee775fb2fa1385"
-      }
-    },
-    "brutaliccus/moveanything": {
-      "default_branch": "main",
-      "sha": "d63834dcda25ed2bfb510e4196560299d0488f46",
-      "branches": {
-        "main": "d63834dcda25ed2bfb510e4196560299d0488f46"
-      }
-    },
-    "patlamontagne/moveanything": {
-      "default_branch": "main",
-      "sha": "eaf4c5fe9fc55bb10917909424f8e6d1159598e2",
-      "branches": {
-        "main": "eaf4c5fe9fc55bb10917909424f8e6d1159598e2"
-      }
-    },
-    "kastelmarra-stack/moveanything": {
-      "default_branch": "main",
-      "sha": "01b20a0a35d7526a31f136227beac5b23bf544ab",
-      "branches": {
-        "main": "01b20a0a35d7526a31f136227beac5b23bf544ab"
-      }
-    },
-    "amonra/moveanything": {
-      "default_branch": "main",
-      "sha": "5949166413384b8f8d01463c83ee775fb2fa1385",
-      "branches": {
-        "main": "5949166413384b8f8d01463c83ee775fb2fa1385"
-      }
-    },
-    "tilare/movementtracker": {
-      "default_branch": "main",
-      "sha": "fb0ac54c3e9a615b766ddcc3cc805ce14b8fb305",
-      "branches": {
-        "main": "fb0ac54c3e9a615b766ddcc3cc805ce14b8fb305"
-      }
-    },
-    "shirsig/mre": {
+    "alanli7991/vanillastoryline": {
       "default_branch": "master",
-      "sha": "f3b5b43b61c83df106439f0b7ac0f2b4f948600d",
+      "sha": "47bf6bbd174db51623a1b6bb27879f08e04dc390",
       "branches": {
-        "master": "f3b5b43b61c83df106439f0b7ac0f2b4f948600d"
+        "master": "47bf6bbd174db51623a1b6bb27879f08e04dc390"
       }
     },
-    "otari98/mre": {
+    "alchem1ster/jim_cooldownpulse": {
       "default_branch": "master",
-      "sha": "139c35fcaf14f6717f723bc7a26aeeab3a7f4067",
+      "sha": "0e664bd70b7b2e20a95250b0c59828b127b8dff0",
       "branches": {
-        "master": "139c35fcaf14f6717f723bc7a26aeeab3a7f4067"
+        "master": "0e664bd70b7b2e20a95250b0c59828b127b8dff0"
       }
     },
-    "cubenicke/mule": {
+    "alchem1ster/missingtradeskillslist": {
       "default_branch": "master",
-      "sha": "c90acd5139ae8a5bff7d4a04d7024d4071fb5bc0",
+      "sha": "545095062c5609e2cdb9d853faeb17c0c9dfc34d",
       "branches": {
-        "master": "c90acd5139ae8a5bff7d4a04d7024d4071fb5bc0"
-      }
-    },
-    "kameleonuk/mutecities": {
-      "default_branch": "main",
-      "sha": "2d038834b06ac6b0749479ff2151d2998a66191e",
-      "branches": {
-        "main": "2d038834b06ac6b0749479ff2151d2998a66191e"
-      }
-    },
-    "zirtox1992/namechangescript": {
-      "default_branch": "main",
-      "sha": "6f9915267b6822b4bf7278e9435d9d8a929548a6",
-      "branches": {
-        "main": "6f9915267b6822b4bf7278e9435d9d8a929548a6"
-      }
-    },
-    "tubtubs/namechangescript": {
-      "default_branch": "main",
-      "sha": "6f9915267b6822b4bf7278e9435d9d8a929548a6",
-      "branches": {
-        "main": "6f9915267b6822b4bf7278e9435d9d8a929548a6"
-      }
-    },
-    "road-block/nauticus": {
-      "default_branch": "master",
-      "sha": "a70898e2db91fdca139c336663a0fb3efe7a6890",
-      "branches": {
-        "master": "a70898e2db91fdca139c336663a0fb3efe7a6890"
-      },
-      "latest_tag": "2.01-11200"
-    },
-    "nedlinin/necrosis-twow": {
-      "default_branch": "main",
-      "sha": "91a40cb87a8a452c7882e3e2dc32683883f7cc67",
-      "branches": {
-        "main": "91a40cb87a8a452c7882e3e2dc32683883f7cc67"
-      }
-    },
-    "heschlie/necrosis-twow": {
-      "default_branch": "main",
-      "sha": "91a40cb87a8a452c7882e3e2dc32683883f7cc67",
-      "branches": {
-        "main": "91a40cb87a8a452c7882e3e2dc32683883f7cc67"
-      }
-    },
-    "garethfromwales/nerfedbuttons4wow": {
-      "default_branch": "main",
-      "sha": "59eb02ae49be594df6a234206c0d76079b199311",
-      "branches": {
-        "main": "59eb02ae49be594df6a234206c0d76079b199311"
-      },
-      "latest_tag": "v1.7beta"
-    },
-    "alchem1ster/vanilla-newlevelframe": {
-      "default_branch": "main",
-      "sha": "ae0a23812409ae3c4dc731136b9cdc25cb44b09c",
-      "branches": {
-        "main": "ae0a23812409ae3c4dc731136b9cdc25cb44b09c"
-      },
-      "latest_tag": "1.1"
-    },
-    "paenthy/vanilla-newlevelframe": {
-      "default_branch": "main",
-      "sha": "ae0a23812409ae3c4dc731136b9cdc25cb44b09c",
-      "branches": {
-        "main": "ae0a23812409ae3c4dc731136b9cdc25cb44b09c"
-      }
-    },
-    "beardedrasta/noscursor": {
-      "default_branch": "main",
-      "sha": "fb59ba7dcc739b45ba7aaaa231a5ebe6536510a1",
-      "branches": {
-        "main": "fb59ba7dcc739b45ba7aaaa231a5ebe6536510a1"
-      }
-    },
-    "rgd87/nugcombobar": {
-      "default_branch": "master",
-      "sha": "96638740c04f0532bf098a262006115bf2baeb7d",
-      "branches": {
-        "master": "96638740c04f0532bf098a262006115bf2baeb7d"
-      },
-      "latest_tag": "11.0.7"
-    },
-    "xinleibird/nugcombobar": {
-      "default_branch": "master",
-      "sha": "96638740c04f0532bf098a262006115bf2baeb7d",
-      "branches": {
-        "master": "96638740c04f0532bf098a262006115bf2baeb7d"
-      }
-    },
-    "geopold/nugcombobar": {
-      "default_branch": "master",
-      "sha": "96638740c04f0532bf098a262006115bf2baeb7d",
-      "branches": {
-        "master": "96638740c04f0532bf098a262006115bf2baeb7d"
+        "master": "545095062c5609e2cdb9d853faeb17c0c9dfc34d"
       }
     },
     "alchem1ster/nugcombobar": {
@@ -5259,298 +596,111 @@
       },
       "latest_tag": "11.0.3"
     },
-    "rgd87/nugenergy": {
-      "default_branch": "master",
-      "sha": "8d169f83b4d85834d2d648c62f3256195bd2556f",
-      "branches": {
-        "master": "8d169f83b4d85834d2d648c62f3256195bd2556f"
-      },
-      "latest_tag": "11.0.3"
-    },
-    "wierdthing/nugenergy": {
-      "default_branch": "master",
-      "sha": "ecf0d4a8f3a5bb08e9d1741d9d9014420e24cda7",
-      "branches": {
-        "master": "ecf0d4a8f3a5bb08e9d1741d9d9014420e24cda7"
-      },
-      "latest_tag": "11.0.2"
-    },
-    "falumir/nugenergy": {
-      "default_branch": "master",
-      "sha": "ecf0d4a8f3a5bb08e9d1741d9d9014420e24cda7",
-      "branches": {
-        "master": "ecf0d4a8f3a5bb08e9d1741d9d9014420e24cda7"
-      }
-    },
-    "wyfyhdzbsb-lang/nugenergy": {
-      "default_branch": "master",
-      "sha": "5340b74bdf5b014176fc9c7bc544d93e35ca3a58",
-      "branches": {
-        "master": "5340b74bdf5b014176fc9c7bc544d93e35ca3a58"
-      }
-    },
-    "dbtdsilva/nugenergy": {
-      "default_branch": "vanilla",
-      "sha": "96370aecaefe7ff9fdc8a28029562a169fc81ffa",
-      "branches": {
-        "vanilla": "96370aecaefe7ff9fdc8a28029562a169fc81ffa"
-      },
-      "latest_tag": "11.0.1"
-    },
-    "bmclare19/nugenergy": {
-      "default_branch": "master",
-      "sha": "7f40e648383cbd8ab94f340a53210ce24428738c",
-      "branches": {
-        "master": "7f40e648383cbd8ab94f340a53210ce24428738c"
-      },
-      "latest_tag": "10.0.0"
-    },
-    "laytya/vanilla_ocb": {
-      "default_branch": "master",
-      "sha": "0c6ff25a2acf38cbe0d93e831b7401577c8967aa",
-      "branches": {
-        "master": "0c6ff25a2acf38cbe0d93e831b7401577c8967aa"
-      },
-      "latest_tag": "v3.3.3"
-    },
-    "otari98/omnicc": {
-      "default_branch": "master",
-      "sha": "fd60e8570be099ae4975afb3da4242b48d9a6311",
-      "branches": {
-        "master": "fd60e8570be099ae4975afb3da4242b48d9a6311"
-      }
-    },
-    "paokkerkir/omnicc": {
-      "default_branch": "master",
-      "sha": "2213b5334dc7fc7e9419b9e32aaedb02b3214f9b",
-      "branches": {
-        "master": "2213b5334dc7fc7e9419b9e32aaedb02b3214f9b"
-      }
-    },
-    "oleksii-pavlikovskii-eleks-com/omnicc": {
-      "default_branch": "master",
-      "sha": "fd60e8570be099ae4975afb3da4242b48d9a6311",
-      "branches": {
-        "master": "fd60e8570be099ae4975afb3da4242b48d9a6311"
-      }
-    },
-    "tanoh/omnicc": {
-      "default_branch": "master",
-      "sha": "fbf883e5a1d65de9abdfbb45807b70071c2e1232",
-      "branches": {
-        "master": "fbf883e5a1d65de9abdfbb45807b70071c2e1232"
-      }
-    },
-    "geigerkind/onebuttonhunter": {
-      "default_branch": "master",
-      "sha": "f1f5b440014059df63042df8584abc3bac809bfe",
-      "branches": {
-        "master": "f1f5b440014059df63042df8584abc3bac809bfe"
-      },
-      "latest_tag": "b1"
-    },
-    "meyyday/onebuttonhunter": {
-      "default_branch": "master",
-      "sha": "25d08ba9e7da6e50805579344baaaa1c0cbc9aaf",
-      "branches": {
-        "master": "25d08ba9e7da6e50805579344baaaa1c0cbc9aaf"
-      }
-    },
-    "terrabaddie/onebuttonhunter-vanillaplus": {
-      "default_branch": "master",
-      "sha": "8c67900528813ce76263027891b48640f29a7f1c",
-      "branches": {
-        "master": "8c67900528813ce76263027891b48640f29a7f1c"
-      }
-    },
-    "srazdokunebil/onebuttonhunter": {
-      "default_branch": "master",
-      "sha": "f1f5b440014059df63042df8584abc3bac809bfe",
-      "branches": {
-        "master": "f1f5b440014059df63042df8584abc3bac809bfe"
-      }
-    },
-    "txuscolchonero/onebuttonhunter": {
-      "default_branch": "master",
-      "sha": "f1f5b440014059df63042df8584abc3bac809bfe",
-      "branches": {
-        "master": "f1f5b440014059df63042df8584abc3bac809bfe"
-      },
-      "latest_tag": "b1"
-    },
-    "ericschn/onlyascii": {
+    "alchem1ster/vanilla-iconic": {
       "default_branch": "main",
-      "sha": "bc9e839976419db0bcc8213c432c94c8a01a6cbe",
+      "sha": "7d742251f2f42b91689ba40da4e8ad4fa0e7c630",
       "branches": {
-        "main": "bc9e839976419db0bcc8213c432c94c8a01a6cbe"
-      }
+        "main": "7d742251f2f42b91689ba40da4e8ad4fa0e7c630"
+      },
+      "latest_tag": "1.1_Vanilla"
     },
-    "jejkas/ooi": {
-      "default_branch": "master",
-      "sha": "fc2bfe8d7ac2ea596295ae87a92d417905b10f2d",
-      "branches": {
-        "master": "fc2bfe8d7ac2ea596295ae87a92d417905b10f2d"
-      }
-    },
-    "pepopo978/outfitter": {
-      "default_branch": "master",
-      "sha": "9e8d2c6101280c995118f2195374ffbd8dbcf283",
-      "branches": {
-        "master": "9e8d2c6101280c995118f2195374ffbd8dbcf283"
-      }
-    },
-    "marcelinevq/outfitter": {
-      "default_branch": "master",
-      "sha": "779af2766aedd03e72d57750389b66ddb2ff7b3d",
-      "branches": {
-        "master": "779af2766aedd03e72d57750389b66ddb2ff7b3d"
-      }
-    },
-    "sica42/outfitter": {
-      "default_branch": "master",
-      "sha": "c6d42c7d96ad9555ebbc739d520928d15501cb75",
-      "branches": {
-        "master": "c6d42c7d96ad9555ebbc739d520928d15501cb75"
-      }
-    },
-    "evannnn1996/outfitter": {
-      "default_branch": "master",
-      "sha": "74a833699b3a3a6f54cc3f3049e28162c01a34d0",
-      "branches": {
-        "master": "74a833699b3a3a6f54cc3f3049e28162c01a34d0"
-      }
-    },
-    "esco-twow/outfitter": {
-      "default_branch": "master",
-      "sha": "1662b8280a79a3065646eb5680eeaf069632c155",
-      "branches": {
-        "master": "1662b8280a79a3065646eb5680eeaf069632c155"
-      }
-    },
-    "wormuz/outfitter": {
-      "default_branch": "master",
-      "sha": "7e24cae8b93ca9f57440855e6b470c610b825109",
-      "branches": {
-        "master": "7e24cae8b93ca9f57440855e6b470c610b825109"
-      }
-    },
-    "bahamutxd/outfitter": {
-      "default_branch": "master",
-      "sha": "5adc5b553e4fe18c564e734fbd7880cf28753601",
-      "branches": {
-        "master": "5adc5b553e4fe18c564e734fbd7880cf28753601"
-      }
-    },
-    "dsidirop/outfitter": {
-      "default_branch": "master",
-      "sha": "e6827a55d07a4a06b9df9e879ed6c0862badec79",
-      "branches": {
-        "master": "e6827a55d07a4a06b9df9e879ed6c0862badec79"
-      }
-    },
-    "andrgita/outfitter": {
-      "default_branch": "master",
-      "sha": "9e8d2c6101280c995118f2195374ffbd8dbcf283",
-      "branches": {
-        "master": "9e8d2c6101280c995118f2195374ffbd8dbcf283"
-      }
-    },
-    "diginfotek/outfitter": {
-      "default_branch": "master",
-      "sha": "eac031d8a2ee37cbf31a55dfa9382da78f79ef60",
-      "branches": {
-        "master": "eac031d8a2ee37cbf31a55dfa9382da78f79ef60"
-      }
-    },
-    "zanthor/outfitter": {
-      "default_branch": "master",
-      "sha": "07bf4ab4132519585287d0b45b2dbeb4e94152eb",
-      "branches": {
-        "master": "07bf4ab4132519585287d0b45b2dbeb4e94152eb"
-      }
-    },
-    "balkirrium/outfitter": {
-      "default_branch": "master",
-      "sha": "8ab8cf5ba9cdfee9ff0256bc5457e806d12225f7",
-      "branches": {
-        "master": "8ab8cf5ba9cdfee9ff0256bc5457e806d12225f7"
-      }
-    },
-    "xeropresence/outfitter": {
-      "default_branch": "master",
-      "sha": "449c6a8cdd1f466a34825b5ea486dfbe7d469a9c",
-      "branches": {
-        "master": "449c6a8cdd1f466a34825b5ea486dfbe7d469a9c"
-      }
-    },
-    "maxcodk/paladinlibramswap": {
+    "alchem1ster/vanilla-newlevelframe": {
       "default_branch": "main",
-      "sha": "62142d89d734a03faf4030ad1925a75d981f1dd7",
+      "sha": "ae0a23812409ae3c4dc731136b9cdc25cb44b09c",
       "branches": {
-        "main": "62142d89d734a03faf4030ad1925a75d981f1dd7"
-      }
+        "main": "ae0a23812409ae3c4dc731136b9cdc25cb44b09c"
+      },
+      "latest_tag": "1.1"
     },
-    "ericraio/vanilla-wow-addons": {
+    "aleksiykotelnikov/chatlog": {
       "default_branch": "master",
-      "sha": "238c6d633d5a5b8a0cc4ee7a8cbb548ea80da081",
+      "sha": "efaebced41856b20138fe1892da93231111f418b",
       "branches": {
-        "master": "238c6d633d5a5b8a0cc4ee7a8cbb548ea80da081"
+        "master": "efaebced41856b20138fe1892da93231111f418b"
       }
     },
-    "assassingbg/vanilla-wow-addons": {
+    "alex192777/ezdismount": {
       "default_branch": "master",
-      "sha": "8f6feb94325135c090a891e5d81f0f760c4371e8",
+      "sha": "85ec75cb0ab32286785c98aaf15fdc140cacc495",
       "branches": {
-        "master": "8f6feb94325135c090a891e5d81f0f760c4371e8"
+        "master": "85ec75cb0ab32286785c98aaf15fdc140cacc495"
       }
     },
-    "waelelechi/vanilla-wow-addons": {
+    "alexpoatato/blizzplates": {
       "default_branch": "master",
-      "sha": "8f6feb94325135c090a891e5d81f0f760c4371e8",
+      "sha": "8aa50c0fe0d50aabeab39472abebb3f5f241672b",
       "branches": {
-        "master": "8f6feb94325135c090a891e5d81f0f760c4371e8"
+        "master": "8aa50c0fe0d50aabeab39472abebb3f5f241672b"
       }
     },
-    "zerger3/vanilla-wow-addons": {
+    "alexpoatato/interruptor": {
       "default_branch": "master",
-      "sha": "8f6feb94325135c090a891e5d81f0f760c4371e8",
+      "sha": "777585a52a447fc59f42a625c8a38b7d411e1052",
       "branches": {
-        "master": "8f6feb94325135c090a891e5d81f0f760c4371e8"
+        "master": "777585a52a447fc59f42a625c8a38b7d411e1052"
       }
     },
-    "cregham/partyplus": {
+    "allingaming/arcanesurgewarning": {
       "default_branch": "main",
-      "sha": "81027ce5b13da8ad81dd312dabcbba0f444babf6",
+      "sha": "63fc40421336346cbaa67b521711101711d4212b",
       "branches": {
-        "main": "81027ce5b13da8ad81dd312dabcbba0f444babf6"
+        "main": "63fc40421336346cbaa67b521711101711d4212b"
       }
     },
-    "thelilmagi/partyplus": {
+    "allingaming/benecast": {
       "default_branch": "main",
-      "sha": "23341d2f5acaf845c7f7702d51db6b5a0112204a",
+      "sha": "e5b6728dc10662959c2ac1825f17b5aaf7de7023",
       "branches": {
-        "main": "23341d2f5acaf845c7f7702d51db6b5a0112204a"
+        "main": "e5b6728dc10662959c2ac1825f17b5aaf7de7023"
       }
     },
-    "shagu/pfdesktop": {
+    "amonra/cartographer": {
       "default_branch": "master",
-      "sha": "7d65013e01838d96c8750127850da7d517859141",
+      "sha": "9b2997bf85f2758e9d3a94028fa0ad158b001245",
       "branches": {
-        "master": "7d65013e01838d96c8750127850da7d517859141"
+        "master": "9b2997bf85f2758e9d3a94028fa0ad158b001245"
       }
     },
-    "shagu/pfstudio": {
+    "amonra/fizzle": {
       "default_branch": "master",
-      "sha": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78",
+      "sha": "1145df0eb8717990d990e934ed4fce4c47811cde",
       "branches": {
-        "master": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78"
+        "master": "1145df0eb8717990d990e934ed4fce4c47811cde"
       }
     },
-    "jprothwell/pfstudio": {
+    "amonra/minimapbuttonbag-turtlewow": {
       "default_branch": "master",
-      "sha": "094f940476137bc1638c1274242a1b3735a4d6bf",
+      "sha": "410082b5d43a63dad5c0ac23ee30454f1725b775",
       "branches": {
-        "master": "094f940476137bc1638c1274242a1b3735a4d6bf"
+        "master": "410082b5d43a63dad5c0ac23ee30454f1725b775"
+      }
+    },
+    "amonra/modernmapmarkers": {
+      "default_branch": "main",
+      "sha": "6873ba5fc85739cdf0185c5cad1dd5bfc98791a2",
+      "branches": {
+        "main": "6873ba5fc85739cdf0185c5cad1dd5bfc98791a2"
+      }
+    },
+    "amonra/moveanything": {
+      "default_branch": "main",
+      "sha": "5949166413384b8f8d01463c83ee775fb2fa1385",
+      "branches": {
+        "main": "5949166413384b8f8d01463c83ee775fb2fa1385"
+      }
+    },
+    "amonra/pfdebug": {
+      "default_branch": "master",
+      "sha": "6f305a9b141cead0d2d141e81dc4e860db3acbbc",
+      "branches": {
+        "master": "6f305a9b141cead0d2d141e81dc4e860db3acbbc"
+      }
+    },
+    "amonra/pfquest-icons": {
+      "default_branch": "master",
+      "sha": "709ba275b7198b93713b5b06cf896dc9006ebeea",
+      "branches": {
+        "master": "709ba275b7198b93713b5b06cf896dc9006ebeea"
       }
     },
     "amonra/pfstudio": {
@@ -5560,876 +710,11 @@
         "master": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78"
       }
     },
-    "dwbclz/pfstudio": {
+    "amonra/pfui-eliteoverlay": {
       "default_branch": "master",
-      "sha": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
       "branches": {
-        "master": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78"
-      }
-    },
-    "jiangxt316/pfstudio": {
-      "default_branch": "master",
-      "sha": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78",
-      "branches": {
-        "master": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78"
-      }
-    },
-    "spawnedc/pfstudio": {
-      "default_branch": "master",
-      "sha": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78",
-      "branches": {
-        "master": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78"
-      }
-    },
-    "likesc/pfstudio": {
-      "default_branch": "master",
-      "sha": "616f06a4132f90a7eebea5a2496bc813fa7de059",
-      "branches": {
-        "master": "616f06a4132f90a7eebea5a2496bc813fa7de059"
-      }
-    },
-    "shagu/pfui-fonts": {
-      "default_branch": "master",
-      "sha": "21000056503a71c349584c34b159e1a04974de78",
-      "branches": {
-        "master": "21000056503a71c349584c34b159e1a04974de78"
-      }
-    },
-    "gescht/pfui-fonts": {
-      "default_branch": "master",
-      "sha": "77900ec3b1fd0fa440e0b4c3a3f1d00dd5507854",
-      "branches": {
-        "master": "77900ec3b1fd0fa440e0b4c3a3f1d00dd5507854"
-      }
-    },
-    "doorknob6/pfui-turtle": {
-      "default_branch": "master",
-      "sha": "4cba1b4e07a70b0c3a53122016c25cd9745bec7a",
-      "branches": {
-        "master": "4cba1b4e07a70b0c3a53122016c25cd9745bec7a"
-      }
-    },
-    "dsidirop/pfui-turtle": {
-      "default_branch": "master",
-      "sha": "0bb7c903060339c08979d24a713c9f6fa2744ca1",
-      "branches": {
-        "master": "0bb7c903060339c08979d24a713c9f6fa2744ca1"
-      }
-    },
-    "aalandriel/pfui-turtle": {
-      "default_branch": "master",
-      "sha": "4237b12708d16d3b05bb376159cd9ceb81836bb9",
-      "branches": {
-        "master": "4237b12708d16d3b05bb376159cd9ceb81836bb9"
-      }
-    },
-    "yani9o/pfui-turtle": {
-      "default_branch": "master",
-      "sha": "815873bea7c18d039ddeddab241f2484627b2903",
-      "branches": {
-        "master": "815873bea7c18d039ddeddab241f2484627b2903"
-      }
-    },
-    "neimad-mp/pizzaslices": {
-      "default_branch": "main",
-      "sha": "59bcdda1e70a7f3f93362fbe4d0778f6c3e9c867",
-      "branches": {
-        "main": "59bcdda1e70a7f3f93362fbe4d0778f6c3e9c867"
-      }
-    },
-    "andrgita/pizzaslices": {
-      "default_branch": "master",
-      "sha": "16349ed21935b8e3207c549d44b7f34272f78310",
-      "branches": {
-        "master": "16349ed21935b8e3207c549d44b7f34272f78310"
-      }
-    },
-    "pepopo978/pizzaslices": {
-      "default_branch": "main",
-      "sha": "160df95e2c803b4abc91663b3e474cbfa1090147",
-      "branches": {
-        "main": "160df95e2c803b4abc91663b3e474cbfa1090147"
-      }
-    },
-    "tubtubs/pizzaslices": {
-      "default_branch": "main",
-      "sha": "59bcdda1e70a7f3f93362fbe4d0778f6c3e9c867",
-      "branches": {
-        "main": "59bcdda1e70a7f3f93362fbe4d0778f6c3e9c867"
-      }
-    },
-    "road-block/playerstates": {
-      "default_branch": "master",
-      "sha": "48c53ef9cdd03fcb490b4f50f3cfe8ebfa903ec8",
-      "branches": {
-        "master": "48c53ef9cdd03fcb490b4f50f3cfe8ebfa903ec8"
-      },
-      "latest_tag": "1.1-11200"
-    },
-    "staforddev/poisoncharges": {
-      "default_branch": "Classic",
-      "sha": "1afb71e7138986f30bd6c8fa5d31864705a6052c",
-      "branches": {
-        "Classic": "1afb71e7138986f30bd6c8fa5d31864705a6052c"
-      },
-      "latest_tag": "v1.1"
-    },
-    "paenthy/poisoncharges": {
-      "default_branch": "Classic",
-      "sha": "1afb71e7138986f30bd6c8fa5d31864705a6052c",
-      "branches": {
-        "Classic": "1afb71e7138986f30bd6c8fa5d31864705a6052c"
-      }
-    },
-    "porkfriedlumpia/porknotes": {
-      "default_branch": "main",
-      "sha": "229e81106cc1c9da39c200d68999f345a69febf9",
-      "branches": {
-        "main": "229e81106cc1c9da39c200d68999f345a69febf9"
-      },
-      "latest_tag": "0.4.1"
-    },
-    "numielle/priestbinds": {
-      "default_branch": "master",
-      "sha": "3be3a65d19126917bb0aff6e39b0e55ebe76082f",
-      "branches": {
-        "master": "3be3a65d19126917bb0aff6e39b0e55ebe76082f"
-      }
-    },
-    "thezephyrsong/procdoc": {
-      "default_branch": "main",
-      "sha": "7c29a57a9ce28749782dc26aa938bf85ef4e4dc0",
-      "branches": {
-        "main": "7c29a57a9ce28749782dc26aa938bf85ef4e4dc0"
-      }
-    },
-    "thaerlo/procdoc": {
-      "default_branch": "main",
-      "sha": "c2eec0c5ab5b6d6d93da60e1971d9b21db4b37cd",
-      "branches": {
-        "main": "c2eec0c5ab5b6d6d93da60e1971d9b21db4b37cd"
-      }
-    },
-    "cernie/pummeler": {
-      "default_branch": "master",
-      "sha": "5094843163426678e129316910672515af58ee72",
-      "branches": {
-        "master": "5094843163426678e129316910672515af58ee72"
-      }
-    },
-    "attero/punschrulle": {
-      "default_branch": "master",
-      "sha": "92c6fe367a31ba5b1c5a841ea4dc2caf5cc8e354",
-      "branches": {
-        "master": "92c6fe367a31ba5b1c5a841ea4dc2caf5cc8e354"
-      }
-    },
-    "monteo/punschrulle": {
-      "default_branch": "master",
-      "sha": "b181e7b17416e1a52327a0e1b167e4e9acc6e6de",
-      "branches": {
-        "master": "b181e7b17416e1a52327a0e1b167e4e9acc6e6de"
-      }
-    },
-    "laytya/quartz": {
-      "default_branch": "main",
-      "sha": "2df6312bef7d7d05a122f16cf7e35b3d5b658493",
-      "branches": {
-        "main": "2df6312bef7d7d05a122f16cf7e35b3d5b658493"
-      }
-    },
-    "timanaku/quartz": {
-      "default_branch": "main",
-      "sha": "3a5000c782a3d456abf5904c39b99df2e7a5decd",
-      "branches": {
-        "main": "3a5000c782a3d456abf5904c39b99df2e7a5decd"
-      }
-    },
-    "razzeee/quartz": {
-      "default_branch": "main",
-      "sha": "c1d102d140216ab70ebfa9d8fe4b080e7ef6483d",
-      "branches": {
-        "main": "c1d102d140216ab70ebfa9d8fe4b080e7ef6483d"
-      }
-    },
-    "0ldi/quickchat": {
-      "default_branch": "master",
-      "sha": "52aeb268a9cd1d7ba3cb8dc1b31fdfdf0002ea9e",
-      "branches": {
-        "master": "52aeb268a9cd1d7ba3cb8dc1b31fdfdf0002ea9e"
-      }
-    },
-    "sabinewren/quiver": {
-      "default_branch": "main",
-      "sha": "5a8ecd852efab6b4b0ef74573e33d855f39d1006",
-      "branches": {
-        "main": "5a8ecd852efab6b4b0ef74573e33d855f39d1006"
-      },
-      "latest_tag": "v3.1.5"
-    },
-    "sandworlds-mmo/quiver": {
-      "default_branch": "main",
-      "sha": "b56546408b0163ac7439cd2a6fd28da38108bdf7",
-      "branches": {
-        "main": "b56546408b0163ac7439cd2a6fd28da38108bdf7"
-      }
-    },
-    "xleone1/quiver": {
-      "default_branch": "main",
-      "sha": "109108a10dc94a3905b26158c783623d5e426cc6",
-      "branches": {
-        "main": "109108a10dc94a3905b26158c783623d5e426cc6"
-      },
-      "latest_tag": "v3.1.4"
-    },
-    "desocode/quiver": {
-      "default_branch": "yaht-feel",
-      "sha": "3e80ae9a8913249aaa8457e128e9746a8768d5e1",
-      "branches": {
-        "yaht-feel": "3e80ae9a8913249aaa8457e128e9746a8768d5e1"
-      },
-      "latest_tag": "v3.1.4-twow.1"
-    },
-    "dyzlexik/quiver": {
-      "default_branch": "main",
-      "sha": "109108a10dc94a3905b26158c783623d5e426cc6",
-      "branches": {
-        "main": "109108a10dc94a3905b26158c783623d5e426cc6"
-      },
-      "latest_tag": "v3.1.4"
-    },
-    "otari98/quiver": {
-      "default_branch": "main",
-      "sha": "5fd5e208bb4bff191a1b03230af1d74178822a28",
-      "branches": {
-        "main": "5fd5e208bb4bff191a1b03230af1d74178822a28"
-      },
-      "latest_tag": "v3.1.3"
-    },
-    "gryzorz/quiver": {
-      "default_branch": "main",
-      "sha": "73e2c8cf562203107194f2e31667a85988ed0a41",
-      "branches": {
-        "main": "73e2c8cf562203107194f2e31667a85988ed0a41"
-      }
-    },
-    "lluistfc/quiver": {
-      "default_branch": "main",
-      "sha": "f12ecb171f7a8a4ea7af682bcd030b943f852122",
-      "branches": {
-        "main": "f12ecb171f7a8a4ea7af682bcd030b943f852122"
-      },
-      "latest_tag": "v3.1.1"
-    },
-    "qeynos/quiver": {
-      "default_branch": "main",
-      "sha": "e281abda6fce4db282683aa7f07b0781ab9c3bd4",
-      "branches": {
-        "main": "e281abda6fce4db282683aa7f07b0781ab9c3bd4"
-      },
-      "latest_tag": "v3.0.0"
-    },
-    "marcelinevq/quiver": {
-      "default_branch": "main",
-      "sha": "8d778d753e749ca4cd317ab80d2241cb24368372",
-      "branches": {
-        "main": "8d778d753e749ca4cd317ab80d2241cb24368372"
-      }
-    },
-    "ohforest/quiver": {
-      "default_branch": "main",
-      "sha": "8d778d753e749ca4cd317ab80d2241cb24368372",
-      "branches": {
-        "main": "8d778d753e749ca4cd317ab80d2241cb24368372"
-      },
-      "latest_tag": "v2.7.1"
-    },
-    "noeek/quiver": {
-      "default_branch": "main",
-      "sha": "6d153506f4f46cc4331e64674f7789626ea71a7a",
-      "branches": {
-        "main": "6d153506f4f46cc4331e64674f7789626ea71a7a"
-      }
-    },
-    "jan125/quiver": {
-      "default_branch": "main",
-      "sha": "143675cb4fbc2cf21d0a4c6452574de5aa2b7e7c",
-      "branches": {
-        "main": "143675cb4fbc2cf21d0a4c6452574de5aa2b7e7c"
-      }
-    },
-    "cache9527/quiver": {
-      "default_branch": "main",
-      "sha": "0043fb8a09da0d841e035ec769fc8b722a7fc1ca",
-      "branches": {
-        "main": "0043fb8a09da0d841e035ec769fc8b722a7fc1ca"
-      }
-    },
-    "srazdokunebil/quiver": {
-      "default_branch": "main",
-      "sha": "1c42f68b614d67560629fbd21d83c67dc5012067",
-      "branches": {
-        "main": "1c42f68b614d67560629fbd21d83c67dc5012067"
-      }
-    },
-    "road-block/ragetracker": {
-      "default_branch": "master",
-      "sha": "caede7e5c6acf6bc118e45323dd7996c46cc89e7",
-      "branches": {
-        "master": "caede7e5c6acf6bc118e45323dd7996c46cc89e7"
-      },
-      "latest_tag": "1.0.0m"
-    },
-    "eryzil-github/rais_autoshot": {
-      "default_branch": "master",
-      "sha": "b2aca3d80423e71d661afb232a6f46611b10a237",
-      "branches": {
-        "master": "b2aca3d80423e71d661afb232a6f46611b10a237"
-      }
-    },
-    "ganisen/rais_autoshot": {
-      "default_branch": "master",
-      "sha": "b2aca3d80423e71d661afb232a6f46611b10a237",
-      "branches": {
-        "master": "b2aca3d80423e71d661afb232a6f46611b10a237"
-      }
-    },
-    "0ldi/rangecolor": {
-      "default_branch": "master",
-      "sha": "86e303f1d97b0355010ed3a010bb7c611eb90112",
-      "branches": {
-        "master": "86e303f1d97b0355010ed3a010bb7c611eb90112"
-      }
-    },
-    "wiggen94/rangecolor": {
-      "default_branch": "master",
-      "sha": "52b22ed292c0675726bfa55a4bdcfd9c9c9aa7d4",
-      "branches": {
-        "master": "52b22ed292c0675726bfa55a4bdcfd9c9c9aa7d4"
-      }
-    },
-    "fiskehatt/rank14lossa": {
-      "default_branch": "master",
-      "sha": "b1bad3409f185fc96cb59ddd38e028f31490b7ba",
-      "branches": {
-        "master": "b1bad3409f185fc96cb59ddd38e028f31490b7ba"
-      }
-    },
-    "dragos-dijmarescu/rank14lossa": {
-      "default_branch": "master",
-      "sha": "b1bad3409f185fc96cb59ddd38e028f31490b7ba",
-      "branches": {
-        "master": "b1bad3409f185fc96cb59ddd38e028f31490b7ba"
-      }
-    },
-    "hippoom/rank14lossa": {
-      "default_branch": "master",
-      "sha": "289aacf0ee647692ad16a90666b676a9ebe1c442",
-      "branches": {
-        "master": "289aacf0ee647692ad16a90666b676a9ebe1c442"
-      }
-    },
-    "bretharte89/rank14lossa": {
-      "default_branch": "master",
-      "sha": "99992b57f29c74631e1dc901185b4657cb1cb876",
-      "branches": {
-        "master": "99992b57f29c74631e1dc901185b4657cb1cb876"
-      }
-    },
-    "zetone/reagentcounter": {
-      "default_branch": "master",
-      "sha": "a634c6e8e0091df2444d6b78b9c4e827d9766c95",
-      "branches": {
-        "master": "a634c6e8e0091df2444d6b78b9c4e827d9766c95"
-      }
-    },
-    "laytya/reciperadar-vanilla": {
-      "default_branch": "master",
-      "sha": "db200dae1f2d349e8f3fba83188e3950c73307af",
-      "branches": {
-        "master": "db200dae1f2d349e8f3fba83188e3950c73307af"
-      },
-      "latest_tag": "v1.15"
-    },
-    "refaim/reciperadar": {
-      "default_branch": "master",
-      "sha": "db200dae1f2d349e8f3fba83188e3950c73307af",
-      "branches": {
-        "master": "db200dae1f2d349e8f3fba83188e3950c73307af"
-      }
-    },
-    "markuruthunderhoof/reciperadar": {
-      "default_branch": "octowow",
-      "sha": "30103ceb8717976ec70fef23e8fd91c9b6545a21",
-      "branches": {
-        "octowow": "30103ceb8717976ec70fef23e8fd91c9b6545a21"
-      }
-    },
-    "sandworlds-mmo/sw-reciperadar": {
-      "default_branch": "master",
-      "sha": "db200dae1f2d349e8f3fba83188e3950c73307af",
-      "branches": {
-        "master": "db200dae1f2d349e8f3fba83188e3950c73307af"
-      }
-    },
-    "distrattos/reciperadar-vanilla": {
-      "default_branch": "master",
-      "sha": "db200dae1f2d349e8f3fba83188e3950c73307af",
-      "branches": {
-        "master": "db200dae1f2d349e8f3fba83188e3950c73307af"
-      }
-    },
-    "txuscolchonero/reciperadar-vanilla": {
-      "default_branch": "master",
-      "sha": "db200dae1f2d349e8f3fba83188e3950c73307af",
-      "branches": {
-        "master": "db200dae1f2d349e8f3fba83188e3950c73307af"
-      },
-      "latest_tag": "v1.15"
-    },
-    "satan666/reckcounter-fix": {
-      "default_branch": "master",
-      "sha": "f3d3714df928af06858090e0ea78fd3dec079d87",
-      "branches": {
-        "master": "f3d3714df928af06858090e0ea78fd3dec079d87"
-      }
-    },
-    "windowskar/reckcounter-fix": {
-      "default_branch": "master",
-      "sha": "758bd956d91e2dab7ea9eb70979445a1ffe51314",
-      "branches": {
-        "master": "758bd956d91e2dab7ea9eb70979445a1ffe51314"
-      },
-      "latest_tag": "Release"
-    },
-    "jsb/resourcecountactionbuttons": {
-      "default_branch": "master",
-      "sha": "aeaeb3aa940ba2cfb4a87b75b2b6f46b22b9ec14",
-      "branches": {
-        "master": "aeaeb3aa940ba2cfb4a87b75b2b6f46b22b9ec14"
-      }
-    },
-    "steelbash/restbar": {
-      "default_branch": "main",
-      "sha": "cd36a894369711bf86e20ad29a624f921922bcae",
-      "branches": {
-        "main": "cd36a894369711bf86e20ad29a624f921922bcae"
-      },
-      "latest_tag": "1.2.1"
-    },
-    "refaim/restbar": {
-      "default_branch": "main",
-      "sha": "b77a74f633f84f84fa8c43ce0a9d5d49b5f9560b",
-      "branches": {
-        "main": "b77a74f633f84f84fa8c43ce0a9d5d49b5f9560b"
-      }
-    },
-    "hazlema/rested": {
-      "default_branch": "master",
-      "sha": "8bcc360ddec4b3ca56a89d1cd445c5d19484d0b2",
-      "branches": {
-        "master": "8bcc360ddec4b3ca56a89d1cd445c5d19484d0b2"
-      }
-    },
-    "tyllyn/octo-rested": {
-      "default_branch": "master",
-      "sha": "cb65cf5b42133196f11f7474668b3171559b8fac",
-      "branches": {
-        "master": "cb65cf5b42133196f11f7474668b3171559b8fac"
-      }
-    },
-    "sandworlds-mmo/rested": {
-      "default_branch": "master",
-      "sha": "8bcc360ddec4b3ca56a89d1cd445c5d19484d0b2",
-      "branches": {
-        "master": "8bcc360ddec4b3ca56a89d1cd445c5d19484d0b2"
-      }
-    },
-    "thezephyrsong/rested": {
-      "default_branch": "master",
-      "sha": "be900d29fb1dbe3fbf53555174be33827f93edb1",
-      "branches": {
-        "master": "be900d29fb1dbe3fbf53555174be33827f93edb1"
-      }
-    },
-    "stokbaek/resurrectionannounce": {
-      "default_branch": "master",
-      "sha": "58a2c8a0d18ea42e4797e86b4bb89782a417c413",
-      "branches": {
-        "master": "58a2c8a0d18ea42e4797e86b4bb89782a417c413"
-      },
-      "latest_tag": "v1.1"
-    },
-    "ghornn/resurrectionannouncepartyfix": {
-      "default_branch": "master",
-      "sha": "7d104e177c9c0574e7b314ca8f1027e5f26fcf0f",
-      "branches": {
-        "master": "7d104e177c9c0574e7b314ca8f1027e5f26fcf0f"
-      }
-    },
-    "kemkerj3/unclenortresurrectionannounce": {
-      "default_branch": "master",
-      "sha": "fec26dd7d8823d31b658afce54bb546d84e1d968",
-      "branches": {
-        "master": "fec26dd7d8823d31b658afce54bb546d84e1d968"
-      }
-    },
-    "shirsig/retarget": {
-      "default_branch": "master",
-      "sha": "6ec740eb7b120898426b989a32e410a51c3e0c61",
-      "branches": {
-        "master": "6ec740eb7b120898426b989a32e410a51c3e0c61"
-      }
-    },
-    "otari98/retarget": {
-      "default_branch": "master",
-      "sha": "9c95d89112c96066113afe82ce0b7797c0746204",
-      "branches": {
-        "master": "9c95d89112c96066113afe82ce0b7797c0746204"
-      }
-    },
-    "jaraxxuss/retarget": {
-      "default_branch": "master",
-      "sha": "61bbc36cd10e668be7731d3db84510017b7e489e",
-      "branches": {
-        "master": "61bbc36cd10e668be7731d3db84510017b7e489e"
-      }
-    },
-    "einbaum/rezztimer": {
-      "default_branch": "master",
-      "sha": "b649787a3ec103fbc4d55b2b9d0b80d81bfc3d29",
-      "branches": {
-        "master": "b649787a3ec103fbc4d55b2b9d0b80d81bfc3d29"
-      },
-      "latest_tag": "1.0.0"
-    },
-    "marcelinevq/rightclickmodifier": {
-      "default_branch": "master",
-      "sha": "dc40936c0991230c8e92bc099b26c022510603a1",
-      "branches": {
-        "master": "dc40936c0991230c8e92bc099b26c022510603a1"
-      }
-    },
-    "megaevilz/rightclickmodifier": {
-      "default_branch": "master",
-      "sha": "dc40936c0991230c8e92bc099b26c022510603a1",
-      "branches": {
-        "master": "dc40936c0991230c8e92bc099b26c022510603a1"
-      }
-    },
-    "tec10101/rightclickmodifier-ascension": {
-      "default_branch": "master",
-      "sha": "dc40936c0991230c8e92bc099b26c022510603a1",
-      "branches": {
-        "master": "dc40936c0991230c8e92bc099b26c022510603a1"
-      }
-    },
-    "jsb/ringmenu": {
-      "default_branch": "master",
-      "sha": "23db580b0ddc04b8650afdf50179302fbb67128f",
-      "branches": {
-        "master": "23db580b0ddc04b8650afdf50179302fbb67128f"
-      },
-      "latest_tag": "v2.2.1"
-    },
-    "duke690/ringmenu": {
-      "default_branch": "master",
-      "sha": "23db580b0ddc04b8650afdf50179302fbb67128f",
-      "branches": {
-        "master": "23db580b0ddc04b8650afdf50179302fbb67128f"
-      }
-    },
-    "chad90b/ringmenu-vanilla112": {
-      "default_branch": "master",
-      "sha": "23db580b0ddc04b8650afdf50179302fbb67128f",
-      "branches": {
-        "master": "23db580b0ddc04b8650afdf50179302fbb67128f"
-      },
-      "latest_tag": "v2.2.1"
-    },
-    "ravenofseven/ringmenu": {
-      "default_branch": "master",
-      "sha": "23db580b0ddc04b8650afdf50179302fbb67128f",
-      "branches": {
-        "master": "23db580b0ddc04b8650afdf50179302fbb67128f"
-      }
-    },
-    "totemrecall1/ringmenu": {
-      "default_branch": "master",
-      "sha": "cfb9ba7f84a85252599aca7d314d27ff35700c13",
-      "branches": {
-        "master": "cfb9ba7f84a85252599aca7d314d27ff35700c13"
-      }
-    },
-    "spronkets/ringmenu-tbc": {
-      "default_branch": "master",
-      "sha": "6c0ab1161ecbd4715386ddc37e33bf7a034d2d44",
-      "branches": {
-        "master": "6c0ab1161ecbd4715386ddc37e33bf7a034d2d44"
-      },
-      "latest_tag": "v2.2.1"
-    },
-    "morkahja/roarguild": {
-      "default_branch": "main",
-      "sha": "1ba833dab3d546dc165cf9b17207b8c710eeba61",
-      "branches": {
-        "main": "1ba833dab3d546dc165cf9b17207b8c710eeba61"
-      }
-    },
-    "road-block/roguefocus": {
-      "default_branch": "master",
-      "sha": "1f0b166192dc8ace0cb42d321eb6b5289b141a49",
-      "branches": {
-        "master": "1f0b166192dc8ace0cb42d321eb6b5289b141a49"
-      },
-      "latest_tag": "1.04.11200"
-    },
-    "wierdthing/roguefocus": {
-      "default_branch": "master",
-      "sha": "3f77792a2ec64da38fcf32c290692bf6f7c15a47",
-      "branches": {
-        "master": "3f77792a2ec64da38fcf32c290692bf6f7c15a47"
-      }
-    },
-    "kangaroux/roguefocus": {
-      "default_branch": "master",
-      "sha": "469737c7679e5720fc842d037efce2ff4b2ce8cb",
-      "branches": {
-        "master": "469737c7679e5720fc842d037efce2ff4b2ce8cb"
-      }
-    },
-    "monteo/roguepack": {
-      "default_branch": "master",
-      "sha": "1a8d0dba7dd4799e6a1881559665b57b9089f562",
-      "branches": {
-        "master": "1a8d0dba7dd4799e6a1881559665b57b9089f562"
-      }
-    },
-    "geigerkind/roguerota": {
-      "default_branch": "master",
-      "sha": "270af53189c0b14ca5320366f2b50b775687c065",
-      "branches": {
-        "master": "270af53189c0b14ca5320366f2b50b775687c065"
-      },
-      "latest_tag": "b1"
-    },
-    "sc4r15/roguerota": {
-      "default_branch": "master",
-      "sha": "270af53189c0b14ca5320366f2b50b775687c065",
-      "branches": {
-        "master": "270af53189c0b14ca5320366f2b50b775687c065"
-      },
-      "latest_tag": "b1"
-    },
-    "parzydelkowiec3-hub/roguerota": {
-      "default_branch": "master",
-      "sha": "0538e5494074db3927bdb711065a6dae1083015c",
-      "branches": {
-        "master": "0538e5494074db3927bdb711065a6dae1083015c"
-      }
-    },
-    "pseja/roguetick": {
-      "default_branch": "main",
-      "sha": "586ae638e53a0ffc4e6b685030f6d946e4e47790",
-      "branches": {
-        "main": "586ae638e53a0ffc4e6b685030f6d946e4e47790"
-      }
-    },
-    "paenthy/roguetick": {
-      "default_branch": "main",
-      "sha": "586ae638e53a0ffc4e6b685030f6d946e4e47790",
-      "branches": {
-        "main": "586ae638e53a0ffc4e6b685030f6d946e4e47790"
-      }
-    },
-    "akzkak/rogueticker": {
-      "default_branch": "master",
-      "sha": "5110f54d89e043fc41fea8343a7e481ca4122d1f",
-      "branches": {
-        "master": "5110f54d89e043fc41fea8343a7e481ca4122d1f"
-      }
-    },
-    "paenthy/rogueticker": {
-      "default_branch": "master",
-      "sha": "5110f54d89e043fc41fea8343a7e481ca4122d1f",
-      "branches": {
-        "master": "5110f54d89e043fc41fea8343a7e481ca4122d1f"
-      }
-    },
-    "marcelinevq/roid-macros": {
-      "default_branch": "master",
-      "sha": "019afbcc018dc3765bc802b8c2fea2811f300689",
-      "branches": {
-        "master": "019afbcc018dc3765bc802b8c2fea2811f300689"
-      }
-    },
-    "pepopo978/roid-macros": {
-      "default_branch": "master",
-      "sha": "6d5db631481bed2a08acfcf24de29b4b6cdc5abf",
-      "branches": {
-        "master": "6d5db631481bed2a08acfcf24de29b4b6cdc5abf"
-      }
-    },
-    "al3xc1985/roid-macros": {
-      "default_branch": "master",
-      "sha": "019afbcc018dc3765bc802b8c2fea2811f300689",
-      "branches": {
-        "master": "019afbcc018dc3765bc802b8c2fea2811f300689"
-      }
-    },
-    "lythandrawow/lythroid-macros": {
-      "default_branch": "master",
-      "sha": "7f349499bb840a1ed6c47f52abccf23652c8e27c",
-      "branches": {
-        "master": "7f349499bb840a1ed6c47f52abccf23652c8e27c"
-      }
-    },
-    "peaap/roid-macros": {
-      "default_branch": "master",
-      "sha": "e29e991b00044b0dab130355a3087a7e0660b691",
-      "branches": {
-        "master": "e29e991b00044b0dab130355a3087a7e0660b691"
-      }
-    },
-    "violetrainbows/roid-macros": {
-      "default_branch": "master",
-      "sha": "3be5487a1198added98b90d4c40dce552547ad1b",
-      "branches": {
-        "master": "3be5487a1198added98b90d4c40dce552547ad1b"
-      }
-    },
-    "sohlk/roid-macros": {
-      "default_branch": "master",
-      "sha": "69032749d8782bd2dc1ee631aeef27969cc8ac61",
-      "branches": {
-        "master": "69032749d8782bd2dc1ee631aeef27969cc8ac61"
-      }
-    },
-    "jakekeeys/roid-macros": {
-      "default_branch": "master",
-      "sha": "43a442d52e3ccba6c4c2fa37329008d6b9d18082",
-      "branches": {
-        "master": "43a442d52e3ccba6c4c2fa37329008d6b9d18082"
-      }
-    },
-    "edgeofmagic/roid-macros": {
-      "default_branch": "master",
-      "sha": "7f1d3d80c6e7c9866a07e634dea44ebce05342e8",
-      "branches": {
-        "master": "7f1d3d80c6e7c9866a07e634dea44ebce05342e8"
-      }
-    },
-    "fenrirjk2/roid-macros": {
-      "default_branch": "master",
-      "sha": "3ab9f9827e1798d207d6875b25b4c210a9044ab5",
-      "branches": {
-        "master": "3ab9f9827e1798d207d6875b25b4c210a9044ab5"
-      }
-    },
-    "grymskvll/safeshift": {
-      "default_branch": "master",
-      "sha": "c5b4960c8629a4937e632aad8a36a23271bd93ad",
-      "branches": {
-        "master": "c5b4960c8629a4937e632aad8a36a23271bd93ad"
-      }
-    },
-    "determinedpanda/safeshift-twow": {
-      "default_branch": "main",
-      "sha": "8436ae757e4405e939fe22415cf925515c5a179a",
-      "branches": {
-        "main": "8436ae757e4405e939fe22415cf925515c5a179a"
-      }
-    },
-    "goffauxs/salad_cthun": {
-      "default_branch": "master",
-      "sha": "45dd2bc43da9aafa8bbbd88b9103db10d942655c",
-      "branches": {
-        "master": "45dd2bc43da9aafa8bbbd88b9103db10d942655c"
-      }
-    },
-    "arktos-wow/sod_salad": {
-      "default_branch": "master",
-      "sha": "39044b8541a4076d19f57f13f9f407ebf2df6e3d",
-      "branches": {
-        "master": "39044b8541a4076d19f57f13f9f407ebf2df6e3d"
-      }
-    },
-    "pendax/salad_cthun": {
-      "default_branch": "master",
-      "sha": "63f4fe574a761e324b1bab7a9e694505766c3c62",
-      "branches": {
-        "master": "63f4fe574a761e324b1bab7a9e694505766c3c62"
-      }
-    },
-    "terrub/samuel": {
-      "default_branch": "master",
-      "sha": "22e5869ca3fce7dd535443bbca575da609273579",
-      "branches": {
-        "master": "22e5869ca3fce7dd535443bbca575da609273579"
-      },
-      "latest_tag": "latest"
-    },
-    "knadra/samuel": {
-      "default_branch": "master",
-      "sha": "c9211a089a93dbdbf61e79eaaec602224c3f77b9",
-      "branches": {
-        "master": "c9211a089a93dbdbf61e79eaaec602224c3f77b9"
-      }
-    },
-    "ramodemir/samuel": {
-      "default_branch": "master",
-      "sha": "22e5869ca3fce7dd535443bbca575da609273579",
-      "branches": {
-        "master": "22e5869ca3fce7dd535443bbca575da609273579"
-      }
-    },
-    "fiskehatt/saysapped": {
-      "default_branch": "master",
-      "sha": "4ace0c9bb52dfd1694ff52f798f54345e8222cf4",
-      "branches": {
-        "master": "4ace0c9bb52dfd1694ff52f798f54345e8222cf4"
-      }
-    },
-    "fiskehatt/saysapped_extended": {
-      "default_branch": "master",
-      "sha": "3eec8d18c9ddfd1087ca75b72cc198de2bd92e12",
-      "branches": {
-        "master": "3eec8d18c9ddfd1087ca75b72cc198de2bd92e12"
-      }
-    },
-    "jhinzuo/another.screenresolutiondropdownfix": {
-      "default_branch": "main",
-      "sha": "5b7457c6c5df860e6ad6d7e900d8d9ae0a18f38e",
-      "branches": {
-        "main": "5b7457c6c5df860e6ad6d7e900d8d9ae0a18f38e"
-      }
-    },
-    "cryptokn1ght-dev/sealtracker": {
-      "default_branch": "main",
-      "sha": "bad8f173cdbc6b2b10b7984e009ca2d22437ca25",
-      "branches": {
-        "main": "bad8f173cdbc6b2b10b7984e009ca2d22437ca25"
-      }
-    },
-    "shagu/shaguactions": {
-      "default_branch": "master",
-      "sha": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8",
-      "branches": {
-        "master": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8"
-      }
-    },
-    "dbfblackbull/shaguactions": {
-      "default_branch": "master",
-      "sha": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8",
-      "branches": {
-        "master": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8"
-      }
-    },
-    "commandersouza/shaguactions": {
-      "default_branch": "master",
-      "sha": "e076014ad8043e1dc1edf0de5dff5fe49c24f4ac",
-      "branches": {
-        "master": "e076014ad8043e1dc1edf0de5dff5fe49c24f4ac"
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
       }
     },
     "amonra/shaguactions": {
@@ -6439,60 +724,11 @@
         "master": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8"
       }
     },
-    "dwbclz/shaguactions": {
-      "default_branch": "master",
-      "sha": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8",
-      "branches": {
-        "master": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8"
-      }
-    },
-    "jiangxt316/shaguactions": {
-      "default_branch": "master",
-      "sha": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8",
-      "branches": {
-        "master": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8"
-      }
-    },
-    "max-bruhn/shaguactions": {
-      "default_branch": "master",
-      "sha": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8",
-      "branches": {
-        "master": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8"
-      }
-    },
-    "shagu/shagubam": {
-      "default_branch": "master",
-      "sha": "5fd6bc33e1b0b4d1999a2470d651295163daeab2",
-      "branches": {
-        "master": "5fd6bc33e1b0b4d1999a2470d651295163daeab2"
-      }
-    },
     "amonra/shagubam": {
       "default_branch": "master",
       "sha": "5fd6bc33e1b0b4d1999a2470d651295163daeab2",
       "branches": {
         "master": "5fd6bc33e1b0b4d1999a2470d651295163daeab2"
-      }
-    },
-    "jiangxt316/shagubam": {
-      "default_branch": "master",
-      "sha": "5fd6bc33e1b0b4d1999a2470d651295163daeab2",
-      "branches": {
-        "master": "5fd6bc33e1b0b4d1999a2470d651295163daeab2"
-      }
-    },
-    "software-eugeneer/shagubam": {
-      "default_branch": "master",
-      "sha": "87b654a54e80befed9f4d8dc1be86cfd8cd7ee66",
-      "branches": {
-        "master": "87b654a54e80befed9f4d8dc1be86cfd8cd7ee66"
-      }
-    },
-    "shagu/shaguboat": {
-      "default_branch": "master",
-      "sha": "e2b3877a31cefdc36cf6fe46f4ef7a2f98dc228a",
-      "branches": {
-        "master": "e2b3877a31cefdc36cf6fe46f4ef7a2f98dc228a"
       }
     },
     "amonra/shaguboat": {
@@ -6502,32 +738,11 @@
         "master": "e2b3877a31cefdc36cf6fe46f4ef7a2f98dc228a"
       }
     },
-    "jiangxt316/shaguboat": {
+    "amonra/shagubop": {
       "default_branch": "master",
-      "sha": "e2b3877a31cefdc36cf6fe46f4ef7a2f98dc228a",
+      "sha": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9",
       "branches": {
-        "master": "e2b3877a31cefdc36cf6fe46f4ef7a2f98dc228a"
-      }
-    },
-    "shagu/shaguchat": {
-      "default_branch": "master",
-      "sha": "01c37853c5e714b218837d24932c316f68b2728f",
-      "branches": {
-        "master": "01c37853c5e714b218837d24932c316f68b2728f"
-      }
-    },
-    "macumbafeh/shaguchat": {
-      "default_branch": "master",
-      "sha": "01c37853c5e714b218837d24932c316f68b2728f",
-      "branches": {
-        "master": "01c37853c5e714b218837d24932c316f68b2728f"
-      }
-    },
-    "xian55/shaguchat": {
-      "default_branch": "master",
-      "sha": "01c37853c5e714b218837d24932c316f68b2728f",
-      "branches": {
-        "master": "01c37853c5e714b218837d24932c316f68b2728f"
+        "master": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9"
       }
     },
     "amonra/shaguchat": {
@@ -6537,48 +752,6 @@
         "master": "01c37853c5e714b218837d24932c316f68b2728f"
       }
     },
-    "dwbclz/shaguchat": {
-      "default_branch": "master",
-      "sha": "01c37853c5e714b218837d24932c316f68b2728f",
-      "branches": {
-        "master": "01c37853c5e714b218837d24932c316f68b2728f"
-      }
-    },
-    "evannnn1996/shaguchat": {
-      "default_branch": "master",
-      "sha": "01c37853c5e714b218837d24932c316f68b2728f",
-      "branches": {
-        "master": "01c37853c5e714b218837d24932c316f68b2728f"
-      }
-    },
-    "jiangxt316/shaguchat": {
-      "default_branch": "master",
-      "sha": "01c37853c5e714b218837d24932c316f68b2728f",
-      "branches": {
-        "master": "01c37853c5e714b218837d24932c316f68b2728f"
-      }
-    },
-    "shagu/shaguclock": {
-      "default_branch": "master",
-      "sha": "3ca9d1d41c9e7327d4c638dd19a65df15e8dbc68",
-      "branches": {
-        "master": "3ca9d1d41c9e7327d4c638dd19a65df15e8dbc68"
-      }
-    },
-    "shagu/shagucolor": {
-      "default_branch": "master",
-      "sha": "b4fd1b82b665c36ea6ef5879ec3707d34585bc62",
-      "branches": {
-        "master": "b4fd1b82b665c36ea6ef5879ec3707d34585bc62"
-      }
-    },
-    "shagu/shagucopy": {
-      "default_branch": "master",
-      "sha": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182",
-      "branches": {
-        "master": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182"
-      }
-    },
     "amonra/shagucopy": {
       "default_branch": "master",
       "sha": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182",
@@ -6586,53 +759,18 @@
         "master": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182"
       }
     },
-    "dwbclz/shagucopy": {
+    "amonra/shagudps": {
       "default_branch": "master",
-      "sha": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182",
+      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
       "branches": {
-        "master": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182"
+        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
       }
     },
-    "jiangxt316/shagucopy": {
+    "amonra/shagujunk": {
       "default_branch": "master",
-      "sha": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182",
+      "sha": "9a91065d8ef9078a9ea8b7d254e88605e8367567",
       "branches": {
-        "master": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182"
-      }
-    },
-    "shagu/shagudelgado": {
-      "default_branch": "master",
-      "sha": "cbe2dd666f1c0f388d5133412e6b151cb6abb4e7",
-      "branches": {
-        "master": "cbe2dd666f1c0f388d5133412e6b151cb6abb4e7"
-      }
-    },
-    "phytotoma/shagudelgado-3.3.5": {
-      "default_branch": "master",
-      "sha": "0e2e00de90dcabca30ae807d9fd44c41d521cb9b",
-      "branches": {
-        "master": "0e2e00de90dcabca30ae807d9fd44c41d521cb9b"
-      }
-    },
-    "shagu/shaguerror": {
-      "default_branch": "master",
-      "sha": "da847ea462dd6c3f8c009267ccf8eb9ef35b5916",
-      "branches": {
-        "master": "da847ea462dd6c3f8c009267ccf8eb9ef35b5916"
-      }
-    },
-    "shagu/shagukill": {
-      "default_branch": "master",
-      "sha": "498e2db84d2d666717d04538641add7ebca967cd",
-      "branches": {
-        "master": "498e2db84d2d666717d04538641add7ebca967cd"
-      }
-    },
-    "duzga/shagukill": {
-      "default_branch": "master",
-      "sha": "ea7777383aa43e3c87ef293b61d72a4c75d3a641",
-      "branches": {
-        "master": "ea7777383aa43e3c87ef293b61d72a4c75d3a641"
+        "master": "9a91065d8ef9078a9ea8b7d254e88605e8367567"
       }
     },
     "amonra/shagukill": {
@@ -6642,81 +780,11 @@
         "master": "498e2db84d2d666717d04538641add7ebca967cd"
       }
     },
-    "dwbclz/shagukill": {
-      "default_branch": "master",
-      "sha": "498e2db84d2d666717d04538641add7ebca967cd",
-      "branches": {
-        "master": "498e2db84d2d666717d04538641add7ebca967cd"
-      }
-    },
-    "jiangxt316/shagukill": {
-      "default_branch": "master",
-      "sha": "498e2db84d2d666717d04538641add7ebca967cd",
-      "branches": {
-        "master": "498e2db84d2d666717d04538641add7ebca967cd"
-      }
-    },
-    "whtmst/shagukill": {
-      "default_branch": "master",
-      "sha": "498e2db84d2d666717d04538641add7ebca967cd",
-      "branches": {
-        "master": "498e2db84d2d666717d04538641add7ebca967cd"
-      }
-    },
-    "shagu/shagumount": {
-      "default_branch": "master",
-      "sha": "e688d31e6f7792728d2e9adf5c33bc8d48f72e75",
-      "branches": {
-        "master": "e688d31e6f7792728d2e9adf5c33bc8d48f72e75"
-      }
-    },
     "amonra/shagumount": {
       "default_branch": "master",
       "sha": "e688d31e6f7792728d2e9adf5c33bc8d48f72e75",
       "branches": {
         "master": "e688d31e6f7792728d2e9adf5c33bc8d48f72e75"
-      }
-    },
-    "jiangxt316/shagumount": {
-      "default_branch": "master",
-      "sha": "e688d31e6f7792728d2e9adf5c33bc8d48f72e75",
-      "branches": {
-        "master": "e688d31e6f7792728d2e9adf5c33bc8d48f72e75"
-      }
-    },
-    "mcpewpew/shagumount": {
-      "default_branch": "master",
-      "sha": "845b98efd714abcb0f30265893ee7c217becfe91",
-      "branches": {
-        "master": "845b98efd714abcb0f30265893ee7c217becfe91"
-      }
-    },
-    "shagu/shagunotify": {
-      "default_branch": "master",
-      "sha": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49",
-      "branches": {
-        "master": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49"
-      }
-    },
-    "lihvar/shagunotify": {
-      "default_branch": "master",
-      "sha": "a95334e9a4accae5e6e28d6be7e0656ca28e291b",
-      "branches": {
-        "master": "a95334e9a4accae5e6e28d6be7e0656ca28e291b"
-      }
-    },
-    "ungweliant/shagunotify_ungweui": {
-      "default_branch": "master",
-      "sha": "1d46565e39d93db7df3c6f82e4840a4665c6daec",
-      "branches": {
-        "master": "1d46565e39d93db7df3c6f82e4840a4665c6daec"
-      }
-    },
-    "macumbafeh/shagunotify": {
-      "default_branch": "master",
-      "sha": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49",
-      "branches": {
-        "master": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49"
       }
     },
     "amonra/shagunotify": {
@@ -6726,46 +794,11 @@
         "master": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49"
       }
     },
-    "dwbclz/shagunotify": {
+    "amonra/shaguplates": {
       "default_branch": "master",
-      "sha": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49",
+      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
       "branches": {
-        "master": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49"
-      }
-    },
-    "jiangxt316/shagunotify": {
-      "default_branch": "master",
-      "sha": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49",
-      "branches": {
-        "master": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49"
-      }
-    },
-    "shagu/shaguscore": {
-      "default_branch": "master",
-      "sha": "b07d25e6a1fa30391d9dca0dd728e33a762c6711",
-      "branches": {
-        "master": "b07d25e6a1fa30391d9dca0dd728e33a762c6711"
-      }
-    },
-    "fhh2626/shaguscore-itemlevel": {
-      "default_branch": "master",
-      "sha": "11aa0ea1dcbef6c51534d2836741cd275d8c5eab",
-      "branches": {
-        "master": "11aa0ea1dcbef6c51534d2836741cd275d8c5eab"
-      }
-    },
-    "bombg/shaguscore": {
-      "default_branch": "master",
-      "sha": "2da0063f2f19c537d6b90b852cf8d0b6b1cb640d",
-      "branches": {
-        "master": "2da0063f2f19c537d6b90b852cf8d0b6b1cb640d"
-      }
-    },
-    "razzeee/shaguscore": {
-      "default_branch": "master",
-      "sha": "b07d25e6a1fa30391d9dca0dd728e33a762c6711",
-      "branches": {
-        "master": "b07d25e6a1fa30391d9dca0dd728e33a762c6711"
+        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
       }
     },
     "amonra/shaguscore": {
@@ -6775,67 +808,11 @@
         "master": "b07d25e6a1fa30391d9dca0dd728e33a762c6711"
       }
     },
-    "dwbclz/shaguscore": {
+    "amonra/shagutweaks-extras": {
       "default_branch": "master",
-      "sha": "b07d25e6a1fa30391d9dca0dd728e33a762c6711",
+      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
       "branches": {
-        "master": "b07d25e6a1fa30391d9dca0dd728e33a762c6711"
-      }
-    },
-    "jiangxt316/shaguscore": {
-      "default_branch": "master",
-      "sha": "b07d25e6a1fa30391d9dca0dd728e33a762c6711",
-      "branches": {
-        "master": "b07d25e6a1fa30391d9dca0dd728e33a762c6711"
-      }
-    },
-    "max-bruhn/shaguscore": {
-      "default_branch": "master",
-      "sha": "b07d25e6a1fa30391d9dca0dd728e33a762c6711",
-      "branches": {
-        "master": "b07d25e6a1fa30391d9dca0dd728e33a762c6711"
-      }
-    },
-    "chad90b/shaguscore": {
-      "default_branch": "master",
-      "sha": "70eb78e85917a1d1d41fd44e39feea5842d23037",
-      "branches": {
-        "master": "70eb78e85917a1d1d41fd44e39feea5842d23037"
-      }
-    },
-    "shagu/shagustance": {
-      "default_branch": "master",
-      "sha": "26cde9d5049018b9b8de745177a79c972f9f78f8",
-      "branches": {
-        "master": "26cde9d5049018b9b8de745177a79c972f9f78f8"
-      }
-    },
-    "shagu/shagutooltips": {
-      "default_branch": "master",
-      "sha": "85abb17f4181b514ef6848e380aafd0616bad12e",
-      "branches": {
-        "master": "85abb17f4181b514ef6848e380aafd0616bad12e"
-      }
-    },
-    "gashole/shagutweaks-druidmanabar": {
-      "default_branch": "main",
-      "sha": "9a661f54515f1c953417ab46a66c181be25e3352",
-      "branches": {
-        "main": "9a661f54515f1c953417ab46a66c181be25e3352"
-      }
-    },
-    "tokensworth/shagutweaks-mods": {
-      "default_branch": "main",
-      "sha": "b782e1e17fcfd68ec77f9ca96df797a6a977d2e8",
-      "branches": {
-        "main": "b782e1e17fcfd68ec77f9ca96df797a6a977d2e8"
-      }
-    },
-    "crimsonhollow/shagutweaks-more-mods": {
-      "default_branch": "main",
-      "sha": "c1bad7fda3b20fd75b8538570216423121517ada",
-      "branches": {
-        "main": "c1bad7fda3b20fd75b8538570216423121517ada"
+        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
       }
     },
     "amonra/shagutweaks-more-mods": {
@@ -6845,186 +822,11 @@
         "main": "c1bad7fda3b20fd75b8538570216423121517ada"
       }
     },
-    "shagu/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
-      "branches": {
-        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
-      }
-    },
-    "paokkerkir/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "4af510e3dce9d5e615bff34ccdd390719f6e428a",
-      "branches": {
-        "master": "4af510e3dce9d5e615bff34ccdd390719f6e428a"
-      }
-    },
-    "brutaliccus/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "b6e7840bf804b22c985350ce3d541857fe127843",
-      "branches": {
-        "master": "b6e7840bf804b22c985350ce3d541857fe127843"
-      }
-    },
-    "nidski-wow/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "d9d071390632054912b058e7400c21d4c77801ef",
-      "branches": {
-        "master": "d9d071390632054912b058e7400c21d4c77801ef"
-      }
-    },
-    "deceius/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "a34adec84b31462d63818c4570d274915a7e1dac",
-      "branches": {
-        "master": "a34adec84b31462d63818c4570d274915a7e1dac"
-      }
-    },
-    "xinleibird/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "117727d849cb94bd46078c47f40aa9bc064bbb19",
-      "branches": {
-        "master": "117727d849cb94bd46078c47f40aa9bc064bbb19"
-      }
-    },
-    "patlamontagne/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "f5af91f962906ca353e3978b88fbb7263589d7bc",
-      "branches": {
-        "master": "f5af91f962906ca353e3978b88fbb7263589d7bc"
-      }
-    },
-    "akurutin/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
-      "branches": {
-        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
-      }
-    },
-    "amonra/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
-      "branches": {
-        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
-      }
-    },
-    "dwbclz/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
-      "branches": {
-        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
-      }
-    },
-    "jiangxt316/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
-      "branches": {
-        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
-      }
-    },
-    "panzier32564-cmd/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
-      "branches": {
-        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
-      }
-    },
-    "ruvaro-ahol/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
-      "branches": {
-        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
-      }
-    },
-    "shigemunekurogane/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
-      "branches": {
-        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
-      }
-    },
-    "yani9o/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
-      "branches": {
-        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
-      }
-    },
-    "dbfblackbull/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "cf669abb5e32a857dab0c9d78b0d9ed833ccce19",
-      "branches": {
-        "master": "cf669abb5e32a857dab0c9d78b0d9ed833ccce19"
-      }
-    },
-    "paenthy/shagutweaks-extras": {
-      "default_branch": "master",
-      "sha": "99b30f48d423afedfc94f0d031854a3e4174a352",
-      "branches": {
-        "master": "99b30f48d423afedfc94f0d031854a3e4174a352"
-      }
-    },
-    "shagu/shaguvalue": {
-      "default_branch": "master",
-      "sha": "debbde88b68a941b13a614612a7aa867cadbe542",
-      "branches": {
-        "master": "debbde88b68a941b13a614612a7aa867cadbe542"
-      }
-    },
     "amonra/shaguvalue": {
       "default_branch": "master",
       "sha": "debbde88b68a941b13a614612a7aa867cadbe542",
       "branches": {
         "master": "debbde88b68a941b13a614612a7aa867cadbe542"
-      }
-    },
-    "dimadze1337/shaguvalue": {
-      "default_branch": "master",
-      "sha": "debbde88b68a941b13a614612a7aa867cadbe542",
-      "branches": {
-        "master": "debbde88b68a941b13a614612a7aa867cadbe542"
-      }
-    },
-    "dwbclz/shaguvalue": {
-      "default_branch": "master",
-      "sha": "debbde88b68a941b13a614612a7aa867cadbe542",
-      "branches": {
-        "master": "debbde88b68a941b13a614612a7aa867cadbe542"
-      }
-    },
-    "jiangxt316/shaguvalue": {
-      "default_branch": "master",
-      "sha": "debbde88b68a941b13a614612a7aa867cadbe542",
-      "branches": {
-        "master": "debbde88b68a941b13a614612a7aa867cadbe542"
-      }
-    },
-    "macumbafeh/shaguvalue": {
-      "default_branch": "master",
-      "sha": "debbde88b68a941b13a614612a7aa867cadbe542",
-      "branches": {
-        "master": "debbde88b68a941b13a614612a7aa867cadbe542"
-      }
-    },
-    "max-bruhn/shaguvalue": {
-      "default_branch": "master",
-      "sha": "debbde88b68a941b13a614612a7aa867cadbe542",
-      "branches": {
-        "master": "debbde88b68a941b13a614612a7aa867cadbe542"
-      }
-    },
-    "shagu/shaguwidget": {
-      "default_branch": "master",
-      "sha": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0",
-      "branches": {
-        "master": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0"
-      }
-    },
-    "macumbafeh/shaguwidget": {
-      "default_branch": "master",
-      "sha": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0",
-      "branches": {
-        "master": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0"
       }
     },
     "amonra/shaguwidget": {
@@ -7034,67 +836,131 @@
         "master": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0"
       }
     },
-    "dingleshu/shaguwidget": {
+    "amonra/succ-bag": {
       "default_branch": "master",
-      "sha": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0",
+      "sha": "8e0b52194d91f14bf90a457c1778509eb86db8a3",
       "branches": {
-        "master": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0"
+        "master": "8e0b52194d91f14bf90a457c1778509eb86db8a3"
       }
     },
-    "dwbclz/shaguwidget": {
+    "amonra/turtlemail": {
       "default_branch": "master",
-      "sha": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0",
+      "sha": "a4884f70ef3aac805a25956750bb92106a5c8cf3",
       "branches": {
-        "master": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0"
+        "master": "a4884f70ef3aac805a25956750bb92106a5c8cf3"
       }
     },
-    "jiangxt316/shaguwidget": {
-      "default_branch": "master",
-      "sha": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0",
-      "branches": {
-        "master": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0"
-      }
-    },
-    "bfcatalin/shaguwidget": {
-      "default_branch": "master",
-      "sha": "5bb1899d6cc2f455b905c54f7a7160864a97c719",
-      "branches": {
-        "master": "5bb1899d6cc2f455b905c54f7a7160864a97c719"
-      }
-    },
-    "wouterbink/shamanfix": {
-      "default_branch": "master",
-      "sha": "bb5931afb798f4820b36e8b0efdbbc2fe5c6d654",
-      "branches": {
-        "master": "bb5931afb798f4820b36e8b0efdbbc2fe5c6d654"
-      }
-    },
-    "dogmax/shardcap": {
+    "amonra/xiaomount": {
       "default_branch": "main",
-      "sha": "20dd94969c42f3baa4bd5133ca841e8cc58ed932",
+      "sha": "2342d9e5a92d27f5fb128c345c28cc080a313146",
       "branches": {
-        "main": "20dd94969c42f3baa4bd5133ca841e8cc58ed932"
+        "main": "2342d9e5a92d27f5fb128c345c28cc080a313146"
       }
     },
-    "voxan-dev/shardcap": {
-      "default_branch": "main",
-      "sha": "17579924332f0f5ef6ae2519160ccf941389fb3a",
+    "amstiel/chatbar": {
+      "default_branch": "master",
+      "sha": "ab3106bdfbd33bb871ceac1848e70f2d71e73f32",
       "branches": {
-        "main": "17579924332f0f5ef6ae2519160ccf941389fb3a"
+        "master": "ab3106bdfbd33bb871ceac1848e70f2d71e73f32"
       }
     },
-    "akzkak/shardcapplus": {
-      "default_branch": "main",
-      "sha": "d352a79783f8e6d1a99ac122e7226de4e345b677",
+    "andresuarezschou/wiiiui": {
+      "default_branch": "master",
+      "sha": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600",
       "branches": {
-        "main": "d352a79783f8e6d1a99ac122e7226de4e345b677"
+        "master": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600"
       }
     },
-    "tr00dudu/shieldbuddy": {
-      "default_branch": "main",
-      "sha": "091c2b3061ada43555b9c668b891488eea4b3167",
+    "andrgita/outfitter": {
+      "default_branch": "master",
+      "sha": "9e8d2c6101280c995118f2195374ffbd8dbcf283",
       "branches": {
-        "main": "091c2b3061ada43555b9c668b891488eea4b3167"
+        "master": "9e8d2c6101280c995118f2195374ffbd8dbcf283"
+      }
+    },
+    "andrgita/pizzaslices": {
+      "default_branch": "master",
+      "sha": "16349ed21935b8e3207c549d44b7f34272f78310",
+      "branches": {
+        "master": "16349ed21935b8e3207c549d44b7f34272f78310"
+      }
+    },
+    "andrgita/rabuffs": {
+      "default_branch": "master",
+      "sha": "a201330411959166b6e2646f38c2f6950b4b195b",
+      "branches": {
+        "master": "a201330411959166b6e2646f38c2f6950b4b195b"
+      }
+    },
+    "andrgita/simpleshareepgp": {
+      "default_branch": "master",
+      "sha": "c045e7250b953b497dc97aad0038e366d4e6c2ab",
+      "branches": {
+        "master": "c045e7250b953b497dc97aad0038e366d4e6c2ab"
+      },
+      "latest_tag": "v2.7"
+    },
+    "angrysathan/sellvalue": {
+      "default_branch": "master",
+      "sha": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e",
+      "branches": {
+        "master": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e"
+      }
+    },
+    "anzz1/freebagslots": {
+      "default_branch": "master",
+      "sha": "4833907cba903a48442ae7c246ccc2d9036a76e4",
+      "branches": {
+        "master": "4833907cba903a48442ae7c246ccc2d9036a76e4"
+      }
+    },
+    "anzz1/sellvalue": {
+      "default_branch": "master",
+      "sha": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e",
+      "branches": {
+        "master": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e"
+      }
+    },
+    "apgm82/decursive": {
+      "default_branch": "superwow",
+      "sha": "953237c7d35d102b23a083b15cc2f32d8ba079d6",
+      "branches": {
+        "superwow": "953237c7d35d102b23a083b15cc2f32d8ba079d6"
+      }
+    },
+    "apgm82/healbot-classic-es-fix": {
+      "default_branch": "master",
+      "sha": "9d7d4961716a3faaef8d6d6c5cb39a7449ee48f4",
+      "branches": {
+        "master": "9d7d4961716a3faaef8d6d6c5cb39a7449ee48f4"
+      }
+    },
+    "apostroll/cooline": {
+      "default_branch": "master",
+      "sha": "1c9cbe7cbc4b6c17626e18858159b23819cf245a",
+      "branches": {
+        "master": "1c9cbe7cbc4b6c17626e18858159b23819cf245a"
+      }
+    },
+    "arcitec/soloraidtargeticons": {
+      "default_branch": "master",
+      "sha": "8b961e36dc3d9f239837b5912597ab0334a7c7b8",
+      "branches": {
+        "master": "8b961e36dc3d9f239837b5912597ab0334a7c7b8"
+      }
+    },
+    "arektor/turtlehonorspyenhanced": {
+      "default_branch": "master",
+      "sha": "354b88eea4c59236e37ade08e4d3d57122c8f0f3",
+      "branches": {
+        "master": "354b88eea4c59236e37ade08e4d3d57122c8f0f3"
+      }
+    },
+    "arimbaud-x/lazyscript": {
+      "default_branch": "superlazyscript",
+      "sha": "2f84c274793f4fcd62831b4a5b2a8ca1e4a6508e",
+      "branches": {
+        "superlazyscript": "2f84c274793f4fcd62831b4a5b2a8ca1e4a6508e"
       }
     },
     "arizonacan723/shieldbuddy": {
@@ -7104,39 +970,429 @@
         "main": "091c2b3061ada43555b9c668b891488eea4b3167"
       }
     },
-    "bugranger/shieldbuddy": {
+    "arktos-wow/sod_salad": {
+      "default_branch": "master",
+      "sha": "39044b8541a4076d19f57f13f9f407ebf2df6e3d",
+      "branches": {
+        "master": "39044b8541a4076d19f57f13f9f407ebf2df6e3d"
+      }
+    },
+    "arma-software/t-restedxp-window": {
       "default_branch": "main",
-      "sha": "091c2b3061ada43555b9c668b891488eea4b3167",
+      "sha": "f2ed3c9175f76337a6f72c0f0d5e2a124401ea76",
       "branches": {
-        "main": "091c2b3061ada43555b9c668b891488eea4b3167"
+        "main": "f2ed3c9175f76337a6f72c0f0d5e2a124401ea76"
       }
     },
-    "shikawalepaladin/shikaswap": {
+    "arthur-helias/bettercharacterpanel": {
       "default_branch": "main",
-      "sha": "fb28ae9bceac50fc75a7d70b732c1692d1fe0f86",
+      "sha": "c81f8b7146fc34927f43331b469d08ce5556b78d",
       "branches": {
-        "main": "fb28ae9bceac50fc75a7d70b732c1692d1fe0f86"
+        "main": "c81f8b7146fc34927f43331b469d08ce5556b78d"
       }
     },
-    "cdmichaelb/silverdragon": {
+    "arthur-helias/instancejournal": {
       "default_branch": "master",
-      "sha": "ab6a890bd91b2d946fae440a2f220062d51df606",
+      "sha": "b58ebe0ffd9bd7bc1c18d0a7d009795d1c2a942c",
       "branches": {
-        "master": "ab6a890bd91b2d946fae440a2f220062d51df606"
+        "master": "b58ebe0ffd9bd7bc1c18d0a7d009795d1c2a942c"
       }
     },
-    "roagosh/silverdragon": {
+    "arthur-helias/pfui-locationplus": {
       "default_branch": "master",
-      "sha": "ab6a890bd91b2d946fae440a2f220062d51df606",
+      "sha": "3f861f343bee8616c8ad80691cd349395af6fcc9",
       "branches": {
-        "master": "ab6a890bd91b2d946fae440a2f220062d51df606"
+        "master": "3f861f343bee8616c8ad80691cd349395af6fcc9"
       }
     },
-    "goldenpipes/silverdragon": {
+    "arthur-helias/pfui-moredatatexts": {
       "default_branch": "master",
-      "sha": "d8eaf9fddbe529d2135dff0914196bd844c39c87",
+      "sha": "565d6f3b5d9c37e9892f21dc88e1c9f0940f573b",
       "branches": {
-        "master": "d8eaf9fddbe529d2135dff0914196bd844c39c87"
+        "master": "565d6f3b5d9c37e9892f21dc88e1c9f0940f573b"
+      }
+    },
+    "arthur-helias/shagudps": {
+      "default_branch": "master",
+      "sha": "45b270500f2228d012b03fc5130d8961e862be69",
+      "branches": {
+        "master": "45b270500f2228d012b03fc5130d8961e862be69"
+      }
+    },
+    "arthur-helias/zoneslevel": {
+      "default_branch": "master",
+      "sha": "985652b77532fe09dd3a1044bb736f92d7cfefd1",
+      "branches": {
+        "master": "985652b77532fe09dd3a1044bb736f92d7cfefd1"
+      }
+    },
+    "artificialowl/chroniclecompanion": {
+      "default_branch": "main",
+      "sha": "0aa90950cd198c55de5025501a22826411716523",
+      "branches": {
+        "main": "0aa90950cd198c55de5025501a22826411716523"
+      }
+    },
+    "asbakdave/minimapbuttonbag-turtlewow": {
+      "default_branch": "master",
+      "sha": "f60670877557999ff400c03f298292b9e0e7fdbd",
+      "branches": {
+        "master": "f60670877557999ff400c03f298292b9e0e7fdbd"
+      },
+      "latest_tag": "v0.508"
+    },
+    "asdaaf/mb-ca-icons": {
+      "default_branch": "master",
+      "sha": "8f4c0fcf61ac2305d60b2f8e8b1366a993e7b5b2",
+      "branches": {
+        "master": "8f4c0fcf61ac2305d60b2f8e8b1366a993e7b5b2"
+      }
+    },
+    "ashigaru/atlasloot": {
+      "default_branch": "master",
+      "sha": "1b0d4971bac9b71adf72111b1943d25e59f6e02a",
+      "branches": {
+        "master": "1b0d4971bac9b71adf72111b1943d25e59f6e02a"
+      }
+    },
+    "aspanj/yaht-turtlewowsteady": {
+      "default_branch": "master",
+      "sha": "c117bca876492358f4620a2a76fdcb801a55188c",
+      "branches": {
+        "master": "c117bca876492358f4620a2a76fdcb801a55188c"
+      }
+    },
+    "assassingbg/vanilla-wow-addons": {
+      "default_branch": "master",
+      "sha": "8f6feb94325135c090a891e5d81f0f760c4371e8",
+      "branches": {
+        "master": "8f6feb94325135c090a891e5d81f0f760c4371e8"
+      }
+    },
+    "asyncwithsky/adf": {
+      "default_branch": "master",
+      "sha": "5ea2d7a869ee4d415c8ea4fdb13552425c6bda1b",
+      "branches": {
+        "master": "5ea2d7a869ee4d415c8ea4fdb13552425c6bda1b"
+      }
+    },
+    "asyncwithsky/chatlootbidder": {
+      "default_branch": "master",
+      "sha": "065c1e2b8a676ba230b6441abea7dccc0ffa1a31",
+      "branches": {
+        "master": "065c1e2b8a676ba230b6441abea7dccc0ffa1a31"
+      }
+    },
+    "asyncwithsky/masterlootremind": {
+      "default_branch": "master",
+      "sha": "f5377589b98a336d2380a4a930a50416ba7e7f9d",
+      "branches": {
+        "master": "f5377589b98a336d2380a4a930a50416ba7e7f9d"
+      }
+    },
+    "asyncwithsky/notchatlootbidder": {
+      "default_branch": "master",
+      "sha": "8b85120c5111dc55f65ed9fe1799bb96fab6ceb3",
+      "branches": {
+        "master": "8b85120c5111dc55f65ed9fe1799bb96fab6ceb3"
+      }
+    },
+    "asyncwithsky/xckmasterlootadvanced": {
+      "default_branch": "Classic",
+      "sha": "a6870300ad35603276738f13a0f3495dd891d8d1",
+      "branches": {
+        "Classic": "a6870300ad35603276738f13a0f3495dd891d8d1"
+      }
+    },
+    "athenegenesis/vanilla_manyqtitemtooltips": {
+      "default_branch": "master",
+      "sha": "4571462e87ecc91d7eb1d711ff17c27e5c9ffcb8",
+      "branches": {
+        "master": "4571462e87ecc91d7eb1d711ff17c27e5c9ffcb8"
+      },
+      "latest_tag": "v1.0"
+    },
+    "atreyyo/autodot": {
+      "default_branch": "master",
+      "sha": "707dae14bcba632c6ee41b046d54e1a26d313f19",
+      "branches": {
+        "master": "707dae14bcba632c6ee41b046d54e1a26d313f19"
+      }
+    },
+    "atreyyo/iwin": {
+      "default_branch": "master",
+      "sha": "ee65d68f44c45c26783f707deb22be965ff71bd3",
+      "branches": {
+        "master": "ee65d68f44c45c26783f707deb22be965ff71bd3"
+      }
+    },
+    "atreyyo/rat": {
+      "default_branch": "master",
+      "sha": "0c3add0173307a955f245f2aec52832b21862a22",
+      "branches": {
+        "master": "0c3add0173307a955f245f2aec52832b21862a22"
+      }
+    },
+    "atreyyo/tankassignments": {
+      "default_branch": "master",
+      "sha": "d465f021627ce56ca857cb825a8d0cd664493e20",
+      "branches": {
+        "master": "d465f021627ce56ca857cb825a8d0cd664493e20"
+      }
+    },
+    "attero/punschrulle": {
+      "default_branch": "master",
+      "sha": "92c6fe367a31ba5b1c5a841ea4dc2caf5cc8e354",
+      "branches": {
+        "master": "92c6fe367a31ba5b1c5a841ea4dc2caf5cc8e354"
+      }
+    },
+    "aubreykun/bmloot": {
+      "default_branch": "master",
+      "sha": "3fee37cdc301bfac11a7f231b5a2401eecbf4eee",
+      "branches": {
+        "master": "3fee37cdc301bfac11a7f231b5a2401eecbf4eee"
+      }
+    },
+    "autignem/lazyweirdo": {
+      "default_branch": "master",
+      "sha": "713b621d6e6bdd9b73f4f3ebaa87d3650e7ead97",
+      "branches": {
+        "master": "713b621d6e6bdd9b73f4f3ebaa87d3650e7ead97"
+      }
+    },
+    "avery1337/turtlepetsearch": {
+      "default_branch": "main",
+      "sha": "f56a670e0080f8af2c5cf363c6cf8b4580c4e528",
+      "branches": {
+        "main": "f56a670e0080f8af2c5cf363c6cf8b4580c4e528"
+      }
+    },
+    "avirar/mendeleev": {
+      "default_branch": "main",
+      "sha": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a",
+      "branches": {
+        "main": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a"
+      }
+    },
+    "avirar/sortbags-vanilla": {
+      "default_branch": "master",
+      "sha": "f3233852a858ccce7b7b1f95e7cd534049d5d79a",
+      "branches": {
+        "master": "f3233852a858ccce7b7b1f95e7cd534049d5d79a"
+      }
+    },
+    "avvatar/lockport": {
+      "default_branch": "main",
+      "sha": "3b2d049a2b593f189522d2c9b70711ed48b32819",
+      "branches": {
+        "main": "3b2d049a2b593f189522d2c9b70711ed48b32819"
+      }
+    },
+    "azgaardian/crusader": {
+      "default_branch": "main",
+      "sha": "41511322589daa959e8d36632b7abd7393109906",
+      "branches": {
+        "main": "41511322589daa959e8d36632b7abd7393109906"
+      }
+    },
+    "azgaardian/totemus": {
+      "default_branch": "main",
+      "sha": "83dbcbd1cc7a25494bb56b21eaf2f9551c4b5d76",
+      "branches": {
+        "main": "83dbcbd1cc7a25494bb56b21eaf2f9551c4b5d76"
+      }
+    },
+    "azuredrak0/lootblare": {
+      "default_branch": "master",
+      "sha": "3289c64e668b7e24cef6be22615dfbfe203aa951",
+      "branches": {
+        "master": "3289c64e668b7e24cef6be22615dfbfe203aa951"
+      }
+    },
+    "azuredrak0/raidmemberexport": {
+      "default_branch": "main",
+      "sha": "3dd211673a47e0e03102f4461318d7477abaab40",
+      "branches": {
+        "main": "3dd211673a47e0e03102f4461318d7477abaab40"
+      }
+    },
+    "azzc0/consumesmanager": {
+      "default_branch": "main",
+      "sha": "7a8a179c81ea2a3923eeabf0a9b4b37388c23aee",
+      "branches": {
+        "main": "7a8a179c81ea2a3923eeabf0a9b4b37388c23aee"
+      }
+    },
+    "azzc0/smartbuff": {
+      "default_branch": "main",
+      "sha": "f5c828b55cf96206fd1d195e86b651103391114c",
+      "branches": {
+        "main": "f5c828b55cf96206fd1d195e86b651103391114c"
+      }
+    },
+    "bagan95/fadeframeui": {
+      "default_branch": "main",
+      "sha": "cbc475155f193b6553fdd4963e51e432e13e8c70",
+      "branches": {
+        "main": "cbc475155f193b6553fdd4963e51e432e13e8c70"
+      },
+      "latest_tag": "v1.2.0"
+    },
+    "bagaze/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "f43019aba2c7816d02a76265cfc827ddc566d064",
+      "branches": {
+        "master": "f43019aba2c7816d02a76265cfc827ddc566d064"
+      }
+    },
+    "bahamutxd/automasterlooter": {
+      "default_branch": "master",
+      "sha": "f2d18ce595159702d4a067477278e6fa73e7c5c3",
+      "branches": {
+        "master": "f2d18ce595159702d4a067477278e6fa73e7c5c3"
+      }
+    },
+    "bahamutxd/cooline": {
+      "default_branch": "master",
+      "sha": "a48c6e8a20f22d4f204faa17b4dc753cc9651e2b",
+      "branches": {
+        "master": "a48c6e8a20f22d4f204faa17b4dc753cc9651e2b"
+      }
+    },
+    "bahamutxd/masterlootbyclass": {
+      "default_branch": "master",
+      "sha": "5744a57a95880f0604229aeab79b7c511731a8b7",
+      "branches": {
+        "master": "5744a57a95880f0604229aeab79b7c511731a8b7"
+      }
+    },
+    "bahamutxd/masterlootremind": {
+      "default_branch": "master",
+      "sha": "9da60e47196e167c76f23b3ad03ad3fa6812a90c",
+      "branches": {
+        "master": "9da60e47196e167c76f23b3ad03ad3fa6812a90c"
+      }
+    },
+    "bahamutxd/outfitter": {
+      "default_branch": "master",
+      "sha": "5adc5b553e4fe18c564e734fbd7880cf28753601",
+      "branches": {
+        "master": "5adc5b553e4fe18c564e734fbd7880cf28753601"
+      }
+    },
+    "bahamutxd/pfui-autoinvite": {
+      "default_branch": "main",
+      "sha": "e67988f1f28478c2df1163e3b8a2a1b50656ad0a",
+      "branches": {
+        "main": "e67988f1f28478c2df1163e3b8a2a1b50656ad0a"
+      }
+    },
+    "balakethelock/automasterlooter": {
+      "default_branch": "master",
+      "sha": "5d2b0cf849120ff7bd4835c1593c4a2e28a843ab",
+      "branches": {
+        "master": "5d2b0cf849120ff7bd4835c1593c4a2e28a843ab"
+      }
+    },
+    "balakethelock/bananabar": {
+      "default_branch": "master",
+      "sha": "d1f000b43d7e5e42f1b249b0a280ccf66aa3fb22",
+      "branches": {
+        "master": "d1f000b43d7e5e42f1b249b0a280ccf66aa3fb22"
+      }
+    },
+    "balakethelock/itemsplit": {
+      "default_branch": "master",
+      "sha": "51a435e531ec6822af83ef5960e608a77b608572",
+      "branches": {
+        "master": "51a435e531ec6822af83ef5960e608a77b608572"
+      }
+    },
+    "balakethelock/pfquest": {
+      "default_branch": "main",
+      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
+      "branches": {
+        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
+      }
+    },
+    "balakethelock/superapi": {
+      "default_branch": "master",
+      "sha": "901322dc88890a2ea10610b8228fb43c9c2a3610",
+      "branches": {
+        "master": "901322dc88890a2ea10610b8228fb43c9c2a3610"
+      }
+    },
+    "balakethelock/superapi_castlib": {
+      "default_branch": "master",
+      "sha": "4a354bf11fe9c150328301b3db4fcc4de9379170",
+      "branches": {
+        "master": "4a354bf11fe9c150328301b3db4fcc4de9379170"
+      }
+    },
+    "balakethelock/superwow": {
+      "default_branch": "master",
+      "sha": "60c05fa1bed338f50092ee73894ee4e3b81b5a65",
+      "branches": {
+        "master": "60c05fa1bed338f50092ee73894ee4e3b81b5a65"
+      },
+      "latest_tag": "Release",
+      "display_version": "v2.2"
+    },
+    "balakethelock/tankhelper": {
+      "default_branch": "master",
+      "sha": "8a35b584943445dcfa24a9ae29f4272340fb7f95",
+      "branches": {
+        "master": "8a35b584943445dcfa24a9ae29f4272340fb7f95"
+      }
+    },
+    "balkirrium/outfitter": {
+      "default_branch": "master",
+      "sha": "8ab8cf5ba9cdfee9ff0256bc5457e806d12225f7",
+      "branches": {
+        "master": "8ab8cf5ba9cdfee9ff0256bc5457e806d12225f7"
+      }
+    },
+    "bang1726528/tattler": {
+      "default_branch": "master",
+      "sha": "d8dc4bbf8c332ebd93a853e35be37528d14f1817",
+      "branches": {
+        "master": "d8dc4bbf8c332ebd93a853e35be37528d14f1817"
+      }
+    },
+    "bapiop/iwinenhanced": {
+      "default_branch": "main",
+      "sha": "f7c58df2d84efd2354a42a285383bdc87e71459e",
+      "branches": {
+        "main": "f7c58df2d84efd2354a42a285383bdc87e71459e"
+      }
+    },
+    "bear-lb/iwin": {
+      "default_branch": "master",
+      "sha": "e06bb939d976319445f8598e1e3dc43f901bd28f",
+      "branches": {
+        "master": "e06bb939d976319445f8598e1e3dc43f901bd28f"
+      }
+    },
+    "beardedrasta/noscursor": {
+      "default_branch": "main",
+      "sha": "fb59ba7dcc739b45ba7aaaa231a5ebe6536510a1",
+      "branches": {
+        "main": "fb59ba7dcc739b45ba7aaaa231a5ebe6536510a1"
+      }
+    },
+    "beardedrasta/shagudps": {
+      "default_branch": "master",
+      "sha": "8450a27230b05b3d3cc7a31bab51ab147e50e8ac",
+      "branches": {
+        "master": "8450a27230b05b3d3cc7a31bab51ab147e50e8ac"
+      }
+    },
+    "beardedrasta/simplebars": {
+      "default_branch": "main",
+      "sha": "fc0bb212cb23a8c976d84a08dbe8a29cab55a856",
+      "branches": {
+        "main": "fc0bb212cb23a8c976d84a08dbe8a29cab55a856"
       }
     },
     "beardedrasta/simplelvl": {
@@ -7153,305 +1409,428 @@
         "master": "f343c35853c54c824224c3b14ca18786bc4a2183"
       }
     },
-    "neguszek/sleepypeon": {
-      "default_branch": "main",
-      "sha": "979da6c7e3f6f70c37d1778dcbb00f462d7d4165",
-      "branches": {
-        "main": "979da6c7e3f6f70c37d1778dcbb00f462d7d4165"
-      }
-    },
-    "denniswg/smallerrollframes": {
+    "bennylavaa/pfquest-turtle": {
       "default_branch": "master",
-      "sha": "27f8954f45eb15e671e350f4aa348366623eba23",
+      "sha": "cd20d143a193b12d5c550246005085474cf17dcd",
       "branches": {
-        "master": "27f8954f45eb15e671e350f4aa348366623eba23"
-      }
-    },
-    "hitbutton/sniper": {
-      "default_branch": "master",
-      "sha": "05494e1b2a29d7c9a148b806c8a7bb8ae9215a14",
-      "branches": {
-        "master": "05494e1b2a29d7c9a148b806c8a7bb8ae9215a14"
-      }
-    },
-    "vakos1/snowkoban": {
-      "default_branch": "main",
-      "sha": "1236a4c68e3cf5e0e58f003bec0621cb910591cf",
-      "branches": {
-        "main": "1236a4c68e3cf5e0e58f003bec0621cb910591cf"
-      }
-    },
-    "einbaum/sp_overpower": {
-      "default_branch": "master",
-      "sha": "9e09e73604140a65a5c5cc141377c2310b7e90a6",
-      "branches": {
-        "master": "9e09e73604140a65a5c5cc141377c2310b7e90a6"
+        "master": "cd20d143a193b12d5c550246005085474cf17dcd"
       },
-      "latest_tag": "3.0.0"
+      "latest_tag": "pfQuest-turtle-v1.0.2"
     },
-    "otari98/sp_overpower": {
+    "bergador/charactermap": {
       "default_branch": "master",
-      "sha": "b35fded98ffcc86822c36421bc41ceda06e9eec3",
+      "sha": "3f4194d5b438cee3ea48bf6fe84871951fb6ca31",
       "branches": {
-        "master": "b35fded98ffcc86822c36421bc41ceda06e9eec3"
+        "master": "3f4194d5b438cee3ea48bf6fe84871951fb6ca31"
       }
     },
-    "nanatot/sp_overpower": {
+    "bergador/insigniataken": {
       "default_branch": "master",
-      "sha": "48cb43aee09bb10becfaa3e460185e7ab6d7f1d7",
+      "sha": "d0958f91a5246cc970cd350e40b62d380962db51",
       "branches": {
-        "master": "48cb43aee09bb10becfaa3e460185e7ab6d7f1d7"
+        "master": "d0958f91a5246cc970cd350e40b62d380962db51"
       }
     },
-    "tiffanyplus/sp_overpower": {
+    "bergador/ktmemeaddon": {
       "default_branch": "master",
-      "sha": "3136f7cfc9a7674b49b9a17f0eccda74c887ae5b",
+      "sha": "8c50d875e4089f0720abfadcf575cf18089254be",
       "branches": {
-        "master": "3136f7cfc9a7674b49b9a17f0eccda74c887ae5b"
+        "master": "8c50d875e4089f0720abfadcf575cf18089254be"
+      }
+    },
+    "bergador/ktp3shacklecounter": {
+      "default_branch": "master",
+      "sha": "eb7efedfdcb181f29d69561de1e2d997e873cc09",
+      "branches": {
+        "master": "eb7efedfdcb181f29d69561de1e2d997e873cc09"
+      }
+    },
+    "bergador/worldbuffsoundalert": {
+      "default_branch": "master",
+      "sha": "4058df754baae525cd6531622dc34dd10e89c0b5",
+      "branches": {
+        "master": "4058df754baae525cd6531622dc34dd10e89c0b5"
+      }
+    },
+    "bestoriop/autobar": {
+      "default_branch": "octo",
+      "sha": "867064ee5553b4f42dceb887a6bffb049f886279",
+      "branches": {
+        "octo": "867064ee5553b4f42dceb887a6bffb049f886279"
+      }
+    },
+    "bestoriop/aux-addon": {
+      "default_branch": "master",
+      "sha": "3d735190b3be8d4bbc17b7145edbb27a185641a2",
+      "branches": {
+        "master": "3d735190b3be8d4bbc17b7145edbb27a185641a2"
+      }
+    },
+    "bestoriop/difficultbulletinboard": {
+      "default_branch": "master",
+      "sha": "6dbeacec52cbd38dbc6d943e7da317fd0548daf6",
+      "branches": {
+        "master": "6dbeacec52cbd38dbc6d943e7da317fd0548daf6"
+      }
+    },
+    "bestoriop/itemsofpower": {
+      "default_branch": "turtle",
+      "sha": "46a0f66dfbfd788712ef15d00f14d3f2362bfa34",
+      "branches": {
+        "turtle": "46a0f66dfbfd788712ef15d00f14d3f2362bfa34"
+      }
+    },
+    "bestoriop/questprogressshare": {
+      "default_branch": "main",
+      "sha": "c96de984adc175a8e293e402837af256e9a31abf",
+      "branches": {
+        "main": "c96de984adc175a8e293e402837af256e9a31abf"
+      }
+    },
+    "bfcatalin/shaguwidget": {
+      "default_branch": "master",
+      "sha": "5bb1899d6cc2f455b905c54f7a7160864a97c719",
+      "branches": {
+        "master": "5bb1899d6cc2f455b905c54f7a7160864a97c719"
+      }
+    },
+    "bigmoonz/lazyspell": {
+      "default_branch": "master",
+      "sha": "99b1a92c0e9587ac8d52f48cc1a098901421a077",
+      "branches": {
+        "master": "99b1a92c0e9587ac8d52f48cc1a098901421a077"
+      }
+    },
+    "bingete/lfghelper": {
+      "default_branch": "main",
+      "sha": "3ab8561286cd7215431043c2e3608e614585a1b6",
+      "branches": {
+        "main": "3ab8561286cd7215431043c2e3608e614585a1b6"
+      }
+    },
+    "birdayz/fubar_buffleecherfu": {
+      "default_branch": "master",
+      "sha": "d694ab83b71692609b0cf50855f5fd65fbe7078e",
+      "branches": {
+        "master": "d694ab83b71692609b0cf50855f5fd65fbe7078e"
+      }
+    },
+    "blackhaste/lazyres": {
+      "default_branch": "master",
+      "sha": "ffed45c8d6912aef7cb8e2531745928edce54af9",
+      "branches": {
+        "master": "ffed45c8d6912aef7cb8e2531745928edce54af9"
+      }
+    },
+    "blackhobbit/necrosis-twow": {
+      "default_branch": "main",
+      "sha": "b7eb990c0a92affc543d5e549026ab938a150911",
+      "branches": {
+        "main": "b7eb990c0a92affc543d5e549026ab938a150911"
+      }
+    },
+    "blehz-be/flyout": {
+      "default_branch": "main",
+      "sha": "f13633a7adc6169e9b5112b68322252b1e623740",
+      "branches": {
+        "main": "f13633a7adc6169e9b5112b68322252b1e623740"
+      }
+    },
+    "blehz-be/magnify": {
+      "default_branch": "main",
+      "sha": "3ff15a844a5ade917c6ac63489a9dc375b1411b2",
+      "branches": {
+        "main": "3ff15a844a5ade917c6ac63489a9dc375b1411b2"
+      }
+    },
+    "blehz-be/mastertradeskills": {
+      "default_branch": "master",
+      "sha": "18535fe277dcda131789e3be5d2b8d8c6950a5e4",
+      "branches": {
+        "master": "18535fe277dcda131789e3be5d2b8d8c6950a5e4"
+      }
+    },
+    "blehz-be/missingtradeskillslist": {
+      "default_branch": "master",
+      "sha": "dca6269945e67226ee7874957188f056d5b50b1b",
+      "branches": {
+        "master": "dca6269945e67226ee7874957188f056d5b50b1b"
+      }
+    },
+    "blehz-be/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "f9873f69b656c9cb717febbb536beee51b7f910f",
+      "branches": {
+        "main": "f9873f69b656c9cb717febbb536beee51b7f910f"
+      }
+    },
+    "blehz-be/sortbags-vanilla": {
+      "default_branch": "master",
+      "sha": "8f7bf57d91a2935600cd5857b29237dcdf9718cf",
+      "branches": {
+        "master": "8f7bf57d91a2935600cd5857b29237dcdf9718cf"
+      }
+    },
+    "blehz-be/vanillaguidereloaded": {
+      "default_branch": "master",
+      "sha": "e80f1dfb76609d75ad493cb21514dd7798b07f79",
+      "branches": {
+        "master": "e80f1dfb76609d75ad493cb21514dd7798b07f79"
+      }
+    },
+    "blomma/bc_trackingmenu": {
+      "default_branch": "master",
+      "sha": "0d462546337f620454635bdbc7dfbbdbc51d8636",
+      "branches": {
+        "master": "0d462546337f620454635bdbc7dfbbdbc51d8636"
+      }
+    },
+    "bludmoon/bartender2-read-instructions": {
+      "default_branch": "master",
+      "sha": "1eec247ecaf755916ece74009b367c5f7219f0c4",
+      "branches": {
+        "master": "1eec247ecaf755916ece74009b367c5f7219f0c4"
+      }
+    },
+    "blueager2/tourguideturtle": {
+      "default_branch": "master",
+      "sha": "83235bec8fc1a75ea90cdd3cc6387d3991b93927",
+      "branches": {
+        "master": "83235bec8fc1a75ea90cdd3cc6387d3991b93927"
       },
-      "latest_tag": "3.0.0"
+      "latest_tag": "1.1.3-beta"
     },
-    "aggromemnon/sp_revenge": {
+    "bluewhale1337/pfquest": {
       "default_branch": "main",
-      "sha": "e19426df9bc586cefd2cc39ae61cfea549b6fd59",
+      "sha": "cd45867716f2269faa4cfb8fc6b69fde0723d60c",
       "branches": {
-        "main": "e19426df9bc586cefd2cc39ae61cfea549b6fd59"
+        "main": "cd45867716f2269faa4cfb8fc6b69fde0723d60c"
       }
     },
-    "ciphuk/sp_revenge": {
-      "default_branch": "main",
-      "sha": "e19426df9bc586cefd2cc39ae61cfea549b6fd59",
-      "branches": {
-        "main": "e19426df9bc586cefd2cc39ae61cfea549b6fd59"
-      }
-    },
-    "oleksii-pavlikovskii-eleks-com/sp_revenge": {
-      "default_branch": "main",
-      "sha": "e19426df9bc586cefd2cc39ae61cfea549b6fd59",
-      "branches": {
-        "main": "e19426df9bc586cefd2cc39ae61cfea549b6fd59"
-      }
-    },
-    "laytya/spamthrottle": {
+    "bmclare19/nugenergy": {
       "default_branch": "master",
-      "sha": "14a08db9aa8c0d53fef03dff14345c7005c029a7",
+      "sha": "7f40e648383cbd8ab94f340a53210ce24428738c",
       "branches": {
-        "master": "14a08db9aa8c0d53fef03dff14345c7005c029a7"
+        "master": "7f40e648383cbd8ab94f340a53210ce24428738c"
       },
-      "latest_tag": "1.17"
+      "latest_tag": "10.0.0"
     },
-    "shikulja/spamthrottle": {
-      "default_branch": "master",
-      "sha": "9e2a2520150a021a0295ea12eaff2d4369eded6a",
+    "bombg/pfui-bettertotems": {
+      "default_branch": "main",
+      "sha": "4bcb23338570476c97db89590a70d102b0438b09",
       "branches": {
-        "master": "9e2a2520150a021a0295ea12eaff2d4369eded6a"
+        "main": "4bcb23338570476c97db89590a70d102b0438b09"
       }
     },
-    "daribon/spartanui_spincam": {
+    "bombg/shaguscore": {
       "default_branch": "master",
-      "sha": "16fa426a517745aa5c267cb8de91c0f695f787f2",
+      "sha": "2da0063f2f19c537d6b90b852cf8d0b6b1cb640d",
       "branches": {
-        "master": "16fa426a517745aa5c267cb8de91c0f695f787f2"
+        "master": "2da0063f2f19c537d6b90b852cf8d0b6b1cb640d"
       }
     },
-    "tomek7667/speed-o-meter": {
+    "bradleeharr/mail": {
       "default_branch": "master",
-      "sha": "95eb9f99a9cabf73d57870bed0b897cdf0b36cf7",
+      "sha": "59c04a41ea4110cd098cc6dddb6799be6edb5892",
       "branches": {
-        "master": "95eb9f99a9cabf73d57870bed0b897cdf0b36cf7"
+        "master": "59c04a41ea4110cd098cc6dddb6799be6edb5892"
       }
     },
-    "brqje/spellalert": {
-      "default_branch": "master",
-      "sha": "aef5feec2b24a46c04a84596d9a494e4c7af4a5c",
+    "bratmage/turtlerp": {
+      "default_branch": "main",
+      "sha": "395756d1355e37b4a8babf3531484f733d13ecdc",
       "branches": {
-        "master": "aef5feec2b24a46c04a84596d9a494e4c7af4a5c"
-      }
-    },
-    "yutsuku/stealtoverlay": {
-      "default_branch": "master",
-      "sha": "5a8405d6083adeca04883461465e0e9128790615",
-      "branches": {
-        "master": "5a8405d6083adeca04883461465e0e9128790615"
+        "main": "395756d1355e37b4a8babf3531484f733d13ecdc"
       },
-      "latest_tag": "1.1"
+      "latest_tag": "2.0.3"
     },
-    "7aske/stealthoverlay": {
-      "default_branch": "master",
-      "sha": "8640ab06f92ea35d68cf78d5cc904a1b631c20e4",
-      "branches": {
-        "master": "8640ab06f92ea35d68cf78d5cc904a1b631c20e4"
-      }
-    },
-    "cyaohiri/stealthoverlay": {
-      "default_branch": "master",
-      "sha": "ff164bbcbda66770051e3304f15f3c46b3c91a6e",
-      "branches": {
-        "master": "ff164bbcbda66770051e3304f15f3c46b3c91a6e"
-      }
-    },
-    "geigerkind/stopwatch": {
-      "default_branch": "master",
-      "sha": "d267430f855f4e9ff616d28564a7218628eacf5d",
-      "branches": {
-        "master": "d267430f855f4e9ff616d28564a7218628eacf5d"
-      },
-      "latest_tag": "b1"
-    },
-    "tinukedaya/stopwatch": {
-      "default_branch": "master",
-      "sha": "d267430f855f4e9ff616d28564a7218628eacf5d",
-      "branches": {
-        "master": "d267430f855f4e9ff616d28564a7218628eacf5d"
-      },
-      "latest_tag": "b1"
-    },
-    "checkem/succ-ecb": {
-      "default_branch": "master",
-      "sha": "e6e753c85f90f6de34093fe4dc2e8c7053dbb864",
-      "branches": {
-        "master": "e6e753c85f90f6de34093fe4dc2e8c7053dbb864"
-      }
-    },
-    "ravenofseven/succ-ecb": {
-      "default_branch": "master",
-      "sha": "0bafc3cfa1dfdbbf32405707e2e2cfb526252da8",
-      "branches": {
-        "master": "0bafc3cfa1dfdbbf32405707e2e2cfb526252da8"
-      }
-    },
-    "0ldi/summonsmonitor": {
-      "default_branch": "master",
-      "sha": "06c8f377bab24fd59f094a01674f1aaa7376aea0",
-      "branches": {
-        "master": "06c8f377bab24fd59f094a01674f1aaa7376aea0"
-      }
-    },
-    "melbaa/sunderarmor": {
-      "default_branch": "master",
-      "sha": "dc5dff076f131d24f61e1fe31b12c03085c88c3e",
-      "branches": {
-        "master": "dc5dff076f131d24f61e1fe31b12c03085c88c3e"
-      }
-    },
-    "gutterrotisaseriousissue-cyber/sunderarmor": {
-      "default_branch": "master",
-      "sha": "7b6a0743ad0d7381269b531191981c04457c807d",
-      "branches": {
-        "master": "7b6a0743ad0d7381269b531191981c04457c807d"
-      }
-    },
-    "lanrutcon/sunofthenight": {
-      "default_branch": "master",
-      "sha": "35fa987754f7912d6465681bcac8c6dc15f12c9c",
-      "branches": {
-        "master": "35fa987754f7912d6465681bcac8c6dc15f12c9c"
-      },
-      "latest_tag": "v1.1"
-    },
-    "refaim/superignore": {
-      "default_branch": "master",
-      "sha": "da02d908e753d717a52714d2d54907709f997d50",
-      "branches": {
-        "master": "da02d908e753d717a52714d2d54907709f997d50"
-      }
-    },
-    "otari98/superignore": {
-      "default_branch": "master",
-      "sha": "495527c3a6a979bc66438312fe98100da30fbd53",
-      "branches": {
-        "master": "495527c3a6a979bc66438312fe98100da30fbd53"
-      }
-    },
-    "whtmst/superignore": {
-      "default_branch": "master",
-      "sha": "495527c3a6a979bc66438312fe98100da30fbd53",
-      "branches": {
-        "master": "495527c3a6a979bc66438312fe98100da30fbd53"
-      }
-    },
-    "vakos1/superinspect": {
+    "bretharte89/casthistorytracker": {
       "default_branch": "main",
-      "sha": "3fc7e1dcd44d5bf8772ca89e5af6b643672c1a7c",
+      "sha": "5de5cd4b40018c53cd2ee3291a077303b5969f28",
       "branches": {
-        "main": "3fc7e1dcd44d5bf8772ca89e5af6b643672c1a7c"
+        "main": "5de5cd4b40018c53cd2ee3291a077303b5969f28"
       }
     },
-    "whtmst/superinspect": {
+    "bretharte89/consoleexperienceclassic": {
       "default_branch": "main",
-      "sha": "3fc7e1dcd44d5bf8772ca89e5af6b643672c1a7c",
+      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
       "branches": {
-        "main": "3fc7e1dcd44d5bf8772ca89e5af6b643672c1a7c"
+        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
       }
     },
-    "xorann/svt": {
+    "bretharte89/cooldowntracker": {
+      "default_branch": "main",
+      "sha": "36caab96f68d7b4477cab536089d6e8ad51e9d2d",
+      "branches": {
+        "main": "36caab96f68d7b4477cab536089d6e8ad51e9d2d"
+      }
+    },
+    "bretharte89/cthunwarner": {
       "default_branch": "master",
-      "sha": "578170b325e3a6e7e3fb805f07521c73f8a9c636",
+      "sha": "70f5129730bb96834abab7678ec7e51c402fbbc8",
       "branches": {
-        "master": "578170b325e3a6e7e3fb805f07521c73f8a9c636"
+        "master": "70f5129730bb96834abab7678ec7e51c402fbbc8"
       }
     },
-    "melbaa/swapondeath": {
+    "bretharte89/cursive": {
       "default_branch": "master",
-      "sha": "7cb4dae14c14ae4a9f4887d23d9e9f255f3123f1",
+      "sha": "e8d46dff3de8ae14fca72c68766862e32892c6c1",
       "branches": {
-        "master": "7cb4dae14c14ae4a9f4887d23d9e9f255f3123f1"
+        "master": "e8d46dff3de8ae14fca72c68766862e32892c6c1"
       }
     },
-    "gabrielecimolino/swapper": {
+    "bretharte89/deathlog_vanilla": {
+      "default_branch": "main",
+      "sha": "81e28be99cd026f17d79fa97693899128136095e",
+      "branches": {
+        "main": "81e28be99cd026f17d79fa97693899128136095e"
+      }
+    },
+    "bretharte89/dragonflightui-reforged": {
+      "default_branch": "main",
+      "sha": "0f97b722bdc2f0c5fd31b5ee55ffd91d1bc8c26b",
+      "branches": {
+        "main": "0f97b722bdc2f0c5fd31b5ee55ffd91d1bc8c26b"
+      }
+    },
+    "bretharte89/flighttracker": {
+      "default_branch": "main",
+      "sha": "a28d3bdfe6c6e03da70657ef412ff4a423e59824",
+      "branches": {
+        "main": "a28d3bdfe6c6e03da70657ef412ff4a423e59824"
+      }
+    },
+    "bretharte89/fullsack": {
       "default_branch": "master",
-      "sha": "d6b707fbfede36cd9e781ce54a1b07ff55fb9759",
+      "sha": "fc3b7f5a5f14539334d09bc8a99b5894b78d9c47",
       "branches": {
-        "master": "d6b707fbfede36cd9e781ce54a1b07ff55fb9759"
+        "master": "fc3b7f5a5f14539334d09bc8a99b5894b78d9c47"
       }
     },
-    "cubenicke/swapper": {
+    "bretharte89/guda": {
+      "default_branch": "main",
+      "sha": "f1618b71bddf816bac82d1a0be67bc1417e8ba20",
+      "branches": {
+        "main": "f1618b71bddf816bac82d1a0be67bc1417e8ba20"
+      }
+    },
+    "bretharte89/gudaplates": {
+      "default_branch": "main",
+      "sha": "e5204a4e8035257bbdb66234eab0494231443d5c",
+      "branches": {
+        "main": "e5204a4e8035257bbdb66234eab0494231443d5c"
+      }
+    },
+    "bretharte89/healersmate": {
+      "default_branch": "main",
+      "sha": "533636c4f63317d0cca7b576e315dddea27c8201",
+      "branches": {
+        "main": "533636c4f63317d0cca7b576e315dddea27c8201"
+      }
+    },
+    "bretharte89/immersion": {
+      "default_branch": "main",
+      "sha": "e87aa4b025da9b810866f64f769af1fb48e3ffe6",
+      "branches": {
+        "main": "e87aa4b025da9b810866f64f769af1fb48e3ffe6"
+      }
+    },
+    "bretharte89/instancejournal": {
       "default_branch": "master",
-      "sha": "f17ef7a478aa8c3b68a48ba856a7adc0561a9bbc",
+      "sha": "77eade63939ecab01c32f2983913fbf801b7b8c2",
       "branches": {
-        "master": "f17ef7a478aa8c3b68a48ba856a7adc0561a9bbc"
+        "master": "77eade63939ecab01c32f2983913fbf801b7b8c2"
       }
     },
-    "whtmst/t-oom": {
-      "default_branch": "main",
-      "sha": "3b4d7c1b2529bde2f447f9d1ce63a3ff7384eaa4",
-      "branches": {
-        "main": "3b4d7c1b2529bde2f447f9d1ce63a3ff7384eaa4"
-      }
-    },
-    "missdyrella/t-oom-dyrella": {
-      "default_branch": "main",
-      "sha": "98d3118af6aacac22ea3469ce9e510b2ea9a5f23",
-      "branches": {
-        "main": "98d3118af6aacac22ea3469ce9e510b2ea9a5f23"
-      }
-    },
-    "compudefierro/t-oom": {
-      "default_branch": "main",
-      "sha": "5aa952f4a33a0201d420431b8b56db9161869286",
-      "branches": {
-        "main": "5aa952f4a33a0201d420431b8b56db9161869286"
-      }
-    },
-    "whtmst/t-restedxp": {
-      "default_branch": "main",
-      "sha": "5eaf92fdd9f437751e0e405c34b235fc0f5b962d",
-      "branches": {
-        "main": "5eaf92fdd9f437751e0e405c34b235fc0f5b962d"
-      }
-    },
-    "arma-software/t-restedxp-window": {
-      "default_branch": "main",
-      "sha": "f2ed3c9175f76337a6f72c0f0d5e2a124401ea76",
-      "branches": {
-        "main": "f2ed3c9175f76337a6f72c0f0d5e2a124401ea76"
-      }
-    },
-    "pepopo978/talentsaver": {
+    "bretharte89/instancetimers": {
       "default_branch": "master",
-      "sha": "af400696c16e0e0959f6d31861579142db96be86",
+      "sha": "5d4e5535c92aeed47e06e7ee143263931401d96c",
       "branches": {
-        "master": "af400696c16e0e0959f6d31861579142db96be86"
+        "master": "5d4e5535c92aeed47e06e7ee143263931401d96c"
+      }
+    },
+    "bretharte89/lilsparkysworkshop-vanilla": {
+      "default_branch": "master",
+      "sha": "326db62006d5281b749bb0b3587fd0b977575581",
+      "branches": {
+        "master": "326db62006d5281b749bb0b3587fd0b977575581"
+      }
+    },
+    "bretharte89/lootblare": {
+      "default_branch": "master",
+      "sha": "eccea47172a2d600aa73001008cc3c1f34b221da",
+      "branches": {
+        "master": "eccea47172a2d600aa73001008cc3c1f34b221da"
+      }
+    },
+    "bretharte89/messagebox": {
+      "default_branch": "main",
+      "sha": "eede932b062a764b7ff1b548106e2d95a9925737",
+      "branches": {
+        "main": "eede932b062a764b7ff1b548106e2d95a9925737"
+      }
+    },
+    "bretharte89/modernfocusframe": {
+      "default_branch": "main",
+      "sha": "6c6631b174e1a4450c32af801cd5a1f278f6e630",
+      "branches": {
+        "main": "6c6631b174e1a4450c32af801cd5a1f278f6e630"
+      }
+    },
+    "bretharte89/modernmapmarkers": {
+      "default_branch": "main",
+      "sha": "5311be6a24979d4119ed59e9f48f90beb41ecfb4",
+      "branches": {
+        "main": "5311be6a24979d4119ed59e9f48f90beb41ecfb4"
+      }
+    },
+    "bretharte89/modernspellalert": {
+      "default_branch": "main",
+      "sha": "97486297904a360c0e0fddb4fcbc6ada731a476c",
+      "branches": {
+        "main": "97486297904a360c0e0fddb4fcbc6ada731a476c"
+      }
+    },
+    "bretharte89/puppeteer": {
+      "default_branch": "main",
+      "sha": "aa732a6c44f0dbba3c0803bc70243bf0fdb23060",
+      "branches": {
+        "main": "aa732a6c44f0dbba3c0803bc70243bf0fdb23060"
+      }
+    },
+    "bretharte89/raidcalendar": {
+      "default_branch": "main",
+      "sha": "0e822dce563bd05886759e9d20cd53592305f5c1",
+      "branches": {
+        "main": "0e822dce563bd05886759e9d20cd53592305f5c1"
+      }
+    },
+    "bretharte89/rank14lossa": {
+      "default_branch": "master",
+      "sha": "99992b57f29c74631e1dc901185b4657cb1cb876",
+      "branches": {
+        "master": "99992b57f29c74631e1dc901185b4657cb1cb876"
+      }
+    },
+    "bretharte89/roll-for-vanilla": {
+      "default_branch": "master",
+      "sha": "05b964006ec4b9dd35decc0581fd84ddf78cb343",
+      "branches": {
+        "master": "05b964006ec4b9dd35decc0581fd84ddf78cb343"
+      }
+    },
+    "bretharte89/selffound": {
+      "default_branch": "main",
+      "sha": "fadf4c12dd9d9653c76cd9f6773d0e90cdb0c729",
+      "branches": {
+        "main": "fadf4c12dd9d9653c76cd9f6773d0e90cdb0c729"
+      }
+    },
+    "bretharte89/tactica": {
+      "default_branch": "main",
+      "sha": "f85e7fb0ded1a9178f207d3940c153e6e06f5e48",
+      "branches": {
+        "main": "f85e7fb0ded1a9178f207d3940c153e6e06f5e48"
       }
     },
     "bretharte89/talentsaver": {
@@ -7461,131 +1840,11 @@
         "master": "af400696c16e0e0959f6d31861579142db96be86"
       }
     },
-    "balakethelock/tankhelper": {
-      "default_branch": "master",
-      "sha": "8a35b584943445dcfa24a9ae29f4272340fb7f95",
-      "branches": {
-        "master": "8a35b584943445dcfa24a9ae29f4272340fb7f95"
-      }
-    },
-    "otari98/tankhelper": {
-      "default_branch": "master",
-      "sha": "2176bd21652c35a0c5bcd92b7797ad8e1f0e25ca",
-      "branches": {
-        "master": "2176bd21652c35a0c5bcd92b7797ad8e1f0e25ca"
-      }
-    },
-    "melbaa/tankhelper": {
-      "default_branch": "master",
-      "sha": "9431b5cc6fbb8770e984871c021f6ce3eb3a1ed9",
-      "branches": {
-        "master": "9431b5cc6fbb8770e984871c021f6ce3eb3a1ed9"
-      }
-    },
-    "gashole/timemanager": {
-      "default_branch": "master",
-      "sha": "4a2bd0af61745cf3d5f01166b470e33982759c56",
-      "branches": {
-        "master": "4a2bd0af61745cf3d5f01166b470e33982759c56"
-      }
-    },
-    "xinleibird/timemanager": {
-      "default_branch": "master",
-      "sha": "3ed3f1279de1b473f1c72022af8271d16c40c139",
-      "branches": {
-        "master": "3ed3f1279de1b473f1c72022af8271d16c40c139"
-      }
-    },
-    "0ldi/timers": {
-      "default_branch": "master",
-      "sha": "8c5645ad517589600049aacfbb1748297e372629",
-      "branches": {
-        "master": "8c5645ad517589600049aacfbb1748297e372629"
-      }
-    },
-    "jrc13245/timetokill": {
-      "default_branch": "master",
-      "sha": "e9ee2e5520535c19674ed88d63fbd68aa7fa0d56",
-      "branches": {
-        "master": "e9ee2e5520535c19674ed88d63fbd68aa7fa0d56"
-      }
-    },
     "bretharte89/timetokill": {
       "default_branch": "master",
       "sha": "e9ee2e5520535c19674ed88d63fbd68aa7fa0d56",
       "branches": {
         "master": "e9ee2e5520535c19674ed88d63fbd68aa7fa0d56"
-      }
-    },
-    "jejkas/timetracker": {
-      "default_branch": "master",
-      "sha": "ad3f897521aa7cfea62bf0f69da439e441ddf71d",
-      "branches": {
-        "master": "ad3f897521aa7cfea62bf0f69da439e441ddf71d"
-      }
-    },
-    "einbaum/tinytip": {
-      "default_branch": "master",
-      "sha": "c4f4947afc7d907033010ec05d46be14d28ed87b",
-      "branches": {
-        "master": "c4f4947afc7d907033010ec05d46be14d28ed87b"
-      }
-    },
-    "isitlove/titanguild": {
-      "default_branch": "master",
-      "sha": "fc5a45134a1cc796444a9776cf2fa5768201f424",
-      "branches": {
-        "master": "fc5a45134a1cc796444a9776cf2fa5768201f424"
-      },
-      "latest_tag": "2.20"
-    },
-    "daribon/titanwowradio": {
-      "default_branch": "master",
-      "sha": "d54df521e8bcfeacdaeba7bfab990f034129c949",
-      "branches": {
-        "master": "d54df521e8bcfeacdaeba7bfab990f034129c949"
-      }
-    },
-    "sica42/titlerotator": {
-      "default_branch": "main",
-      "sha": "37247bb3903227ad87a745c725178c14bde37f6b",
-      "branches": {
-        "main": "37247bb3903227ad87a745c725178c14bde37f6b"
-      }
-    },
-    "otari98/tmog": {
-      "default_branch": "master",
-      "sha": "870da4a34d803607e62f271a003b797fc6cbcf8b",
-      "branches": {
-        "master": "870da4a34d803607e62f271a003b797fc6cbcf8b"
-      }
-    },
-    "refaim/tne-fivesec": {
-      "default_branch": "master",
-      "sha": "ba7edc3fb5b03cad24ebca9d71d63792e451d3b8",
-      "branches": {
-        "master": "ba7edc3fb5b03cad24ebca9d71d63792e451d3b8"
-      }
-    },
-    "monteo/tne_nightfall": {
-      "default_branch": "main",
-      "sha": "c7bbcdfd7a15946513a1e2457ec69225faad1430",
-      "branches": {
-        "main": "c7bbcdfd7a15946513a1e2457ec69225faad1430"
-      }
-    },
-    "maxcodk/togglegather-by-svarrog": {
-      "default_branch": "main",
-      "sha": "2cccdd58b4acdec885df92c465e6dcd845337641",
-      "branches": {
-        "main": "2cccdd58b4acdec885df92c465e6dcd845337641"
-      }
-    },
-    "therealfayz/totemnesia": {
-      "default_branch": "main",
-      "sha": "13a14ee37e95482f6369d12f358f425cfe502bca",
-      "branches": {
-        "main": "13a14ee37e95482f6369d12f358f425cfe502bca"
       }
     },
     "bretharte89/totemnesia": {
@@ -7595,164 +1854,746 @@
         "main": "13a14ee37e95482f6369d12f358f425cfe502bca"
       }
     },
-    "gregdeichler/totemtimers": {
-      "default_branch": "main",
-      "sha": "eeb49f807d3a18f805cf2e7514efd29ff3f23805",
+    "brightlee1983/shagutweaks": {
+      "default_branch": "master",
+      "sha": "5014a47bac39e25c3caee512b940298436049f9b",
       "branches": {
-        "main": "eeb49f807d3a18f805cf2e7514efd29ff3f23805"
+        "master": "5014a47bac39e25c3caee512b940298436049f9b"
       }
     },
-    "mouzu/totemtimers-enhanced": {
+    "brndd/vanilla-tweaks": {
       "default_branch": "master",
-      "sha": "a4107a83a4f557bced0c00d592a79e8e1abc475b",
+      "sha": "fbbe31add71b23602d981d70f1a58520fc349b47",
       "branches": {
-        "master": "a4107a83a4f557bced0c00d592a79e8e1abc475b"
+        "master": "fbbe31add71b23602d981d70f1a58520fc349b47"
       },
-      "latest_tag": "1.3"
+      "latest_tag": "v1.6.0"
     },
-    "mdmcclel/totemtimers-enhanced": {
+    "brotalnia/blizzplates": {
       "default_branch": "master",
-      "sha": "dd1702bcd16f697473b4e74aec7824638c01e2ee",
+      "sha": "8aa50c0fe0d50aabeab39472abebb3f5f241672b",
       "branches": {
-        "master": "dd1702bcd16f697473b4e74aec7824638c01e2ee"
+        "master": "8aa50c0fe0d50aabeab39472abebb3f5f241672b"
+      }
+    },
+    "brqje/enginventory": {
+      "default_branch": "master",
+      "sha": "10b1471b51bc3472f4a05a9bb7553646d61b47fe",
+      "branches": {
+        "master": "10b1471b51bc3472f4a05a9bb7553646d61b47fe"
+      }
+    },
+    "brqje/spellalert": {
+      "default_branch": "master",
+      "sha": "aef5feec2b24a46c04a84596d9a494e4c7af4a5c",
+      "branches": {
+        "master": "aef5feec2b24a46c04a84596d9a494e4c7af4a5c"
+      }
+    },
+    "bruceanhuifs/wiiiui": {
+      "default_branch": "master",
+      "sha": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600",
+      "branches": {
+        "master": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600"
+      }
+    },
+    "brues-code/auctionator": {
+      "default_branch": "main",
+      "sha": "b321b95287f300167a85fad636b2bf0ff3380ee8",
+      "branches": {
+        "main": "b321b95287f300167a85fad636b2bf0ff3380ee8"
       },
-      "latest_tag": "1.3"
+      "latest_tag": "v1.0.5"
     },
-    "dbfblackbull/totemtimers-enhanced": {
-      "default_branch": "master",
-      "sha": "99337e1cc9506665d38bda8b02b627845897015c",
+    "brues-code/auctionquerythrottle": {
+      "default_branch": "main",
+      "sha": "27ce3633dfc94714e070dab67cf56f85e1146287",
       "branches": {
-        "master": "99337e1cc9506665d38bda8b02b627845897015c"
-      }
-    },
-    "nocarea/totemtimers-enhanced-totemic-recall": {
-      "default_branch": "master",
-      "sha": "383d05cb08dc32258b568222470204ba80da23f0",
-      "branches": {
-        "master": "383d05cb08dc32258b568222470204ba80da23f0"
-      }
-    },
-    "hlado/totemtimers-enhanced": {
-      "default_branch": "master",
-      "sha": "e6a10d7f5feeaa55304453e0321e9b031ec72d7b",
-      "branches": {
-        "master": "e6a10d7f5feeaa55304453e0321e9b031ec72d7b"
-      }
-    },
-    "dragosdijmarescu/totemtimers-enhanced": {
-      "default_branch": "master",
-      "sha": "a4107a83a4f557bced0c00d592a79e8e1abc475b",
-      "branches": {
-        "master": "a4107a83a4f557bced0c00d592a79e8e1abc475b"
+        "main": "27ce3633dfc94714e070dab67cf56f85e1146287"
       },
-      "latest_tag": "1.3"
+      "latest_tag": "v1.2.0"
     },
-    "manaril/totemtimers-enhanced": {
+    "brues-code/classicapi": {
       "default_branch": "master",
-      "sha": "dc0f87507671c02200a83b9a46efcce118eca944",
+      "sha": "fdbe66b05740bc34cef3d93754ac409f6abaa5bb",
       "branches": {
-        "master": "dc0f87507671c02200a83b9a46efcce118eca944"
-      }
-    },
-    "azgaardian/totemus": {
-      "default_branch": "main",
-      "sha": "83dbcbd1cc7a25494bb56b21eaf2f9551c4b5d76",
-      "branches": {
-        "main": "83dbcbd1cc7a25494bb56b21eaf2f9551c4b5d76"
-      }
-    },
-    "dogmax/toxictagger": {
-      "default_branch": "master",
-      "sha": "f2b751d9216b9a10b050aa529dd92fc4aad3376a",
-      "branches": {
-        "master": "f2b751d9216b9a10b050aa529dd92fc4aad3376a"
-      }
-    },
-    "liijin/trailblazer": {
-      "default_branch": "main",
-      "sha": "6e448a724eb35381ec63f10576bf013f1251387c",
-      "branches": {
-        "main": "6e448a724eb35381ec63f10576bf013f1251387c"
-      }
-    },
-    "jrc13245/trinketmenu": {
-      "default_branch": "master",
-      "sha": "ad2a196ae8c9dc87c78cbe28e9d13853a89f678f",
-      "branches": {
-        "master": "ad2a196ae8c9dc87c78cbe28e9d13853a89f678f"
-      }
-    },
-    "neimad-mp/turtlecount": {
-      "default_branch": "main",
-      "sha": "f13d103f056431b5073f0ffe40ace550f61f4076",
-      "branches": {
-        "main": "f13d103f056431b5073f0ffe40ace550f61f4076"
-      }
-    },
-    "francisegan/turtledebug": {
-      "default_branch": "main",
-      "sha": "0a98d2aadecd0ab6c7ba498fd2dca844dc3ddc82",
-      "branches": {
-        "main": "0a98d2aadecd0ab6c7ba498fd2dca844dc3ddc82"
-      }
-    },
-    "trangoul/turtlemenagerie": {
-      "default_branch": "main",
-      "sha": "025952539801894d37bc5cc899315a87aa9e769d",
-      "branches": {
-        "main": "025952539801894d37bc5cc899315a87aa9e769d"
+        "master": "fdbe66b05740bc34cef3d93754ac409f6abaa5bb"
       },
-      "latest_tag": "v2.3.1"
+      "latest_tag": "v1.13.3"
     },
-    "kameleonuk/turtlemenagerie": {
+    "brues-code/nampower": {
       "default_branch": "main",
-      "sha": "2c4fe1181595aafd66fef445f2be4706014319ec",
+      "sha": "2c7f51cd436e9b0ce88271e84ce5a77c19f2c23b",
       "branches": {
-        "main": "2c4fe1181595aafd66fef445f2be4706014319ec"
-      }
-    },
-    "diginfotek/turtlemenagerie": {
-      "default_branch": "main",
-      "sha": "23ccfde1737c5832bfd7170a711d1faf179e5235",
-      "branches": {
-        "main": "23ccfde1737c5832bfd7170a711d1faf179e5235"
-      }
-    },
-    "avery1337/turtlepetsearch": {
-      "default_branch": "main",
-      "sha": "f56a670e0080f8af2c5cf363c6cf8b4580c4e528",
-      "branches": {
-        "main": "f56a670e0080f8af2c5cf363c6cf8b4580c4e528"
-      }
-    },
-    "francisegan/turtlerestedxp": {
-      "default_branch": "main",
-      "sha": "a125622f7391cb6e39be953306a7b58ed7fd8c60",
-      "branches": {
-        "main": "a125622f7391cb6e39be953306a7b58ed7fd8c60"
-      }
-    },
-    "ravenofseven/turtlerestedxp": {
-      "default_branch": "main",
-      "sha": "a125622f7391cb6e39be953306a7b58ed7fd8c60",
-      "branches": {
-        "main": "a125622f7391cb6e39be953306a7b58ed7fd8c60"
-      }
-    },
-    "picardebooks/turtletranslator": {
-      "default_branch": "main",
-      "sha": "d246dbbca5f94195b646e39e2a509eb0eba92fb3",
-      "branches": {
-        "main": "d246dbbca5f94195b646e39e2a509eb0eba92fb3"
-      }
-    },
-    "mitjafelicijan/turtletweaks": {
-      "default_branch": "master",
-      "sha": "91ee7f608a6b35085e8b0be8d6d136210daf3b33",
-      "branches": {
-        "master": "91ee7f608a6b35085e8b0be8d6d136210daf3b33"
+        "main": "2c7f51cd436e9b0ce88271e84ce5a77c19f2c23b"
       },
-      "latest_tag": "v0.7"
+      "latest_tag": "v4.6.1"
+    },
+    "brues-code/pfquest": {
+      "default_branch": "main",
+      "sha": "f5ff7f3ed220027a2cf9c8aaa4fd6fc037211b3d",
+      "branches": {
+        "main": "f5ff7f3ed220027a2cf9c8aaa4fd6fc037211b3d"
+      }
+    },
+    "brues-code/pfui": {
+      "default_branch": "master",
+      "sha": "5815b9e81e1567d7bcb768338876764d30ed5bee",
+      "branches": {
+        "master": "5815b9e81e1567d7bcb768338876764d30ed5bee"
+      },
+      "latest_tag": "v9.0.23"
+    },
+    "brues-code/supercleveroidmacros": {
+      "default_branch": "main",
+      "sha": "61bab6c734e646f67a9252bca57841059c5cdb0e",
+      "branches": {
+        "main": "61bab6c734e646f67a9252bca57841059c5cdb0e"
+      },
+      "latest_tag": "v3.1.10"
+    },
+    "brues-code/unitxp_sp3": {
+      "default_branch": "main",
+      "sha": "cedbf4b59776567db954ce38f681af1cbb9f0e1c",
+      "branches": {
+        "main": "cedbf4b59776567db954ce38f681af1cbb9f0e1c"
+      },
+      "latest_tag": "v90"
+    },
+    "brunt/buffalert": {
+      "default_branch": "main",
+      "sha": "7bb6f3526f9d39aa6a35eec4bfc2c4b08465f7b7",
+      "branches": {
+        "main": "7bb6f3526f9d39aa6a35eec4bfc2c4b08465f7b7"
+      }
+    },
+    "brutaliccus/ichalaunch": {
+      "default_branch": "master",
+      "sha": "5c502023d0ecd077c868f1cde7118e1001601178",
+      "branches": {
+        "master": "5c502023d0ecd077c868f1cde7118e1001601178"
+      },
+      "latest_tag": "v1.6.4"
+    },
+    "brutaliccus/moveanything": {
+      "default_branch": "main",
+      "sha": "d63834dcda25ed2bfb510e4196560299d0488f46",
+      "branches": {
+        "main": "d63834dcda25ed2bfb510e4196560299d0488f46"
+      }
+    },
+    "brutaliccus/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "b6e7840bf804b22c985350ce3d541857fe127843",
+      "branches": {
+        "master": "b6e7840bf804b22c985350ce3d541857fe127843"
+      }
+    },
+    "bugranger/shieldbuddy": {
+      "default_branch": "main",
+      "sha": "091c2b3061ada43555b9c668b891488eea4b3167",
+      "branches": {
+        "main": "091c2b3061ada43555b9c668b891488eea4b3167"
+      }
+    },
+    "buhfur/nolfg": {
+      "default_branch": "master",
+      "sha": "d437689a057cd27027e0528767adc7d7cdbf5776",
+      "branches": {
+        "master": "d437689a057cd27027e0528767adc7d7cdbf5776"
+      }
+    },
+    "buzzkill54/atlasquest": {
+      "default_branch": "master",
+      "sha": "dc9c364566ca173a75a1fd15adc5d35f4c8f3e00",
+      "branches": {
+        "master": "dc9c364566ca173a75a1fd15adc5d35f4c8f3e00"
+      }
+    },
+    "bycfm2/atlas-cfm": {
+      "default_branch": "main",
+      "sha": "07218cc2e6a43a00f37444abebbee20b71f4e944",
+      "branches": {
+        "main": "07218cc2e6a43a00f37444abebbee20b71f4e944"
+      }
+    },
+    "bycfm2/enemyframes": {
+      "default_branch": "master",
+      "sha": "4ae5fd621e7f2207c97b8d42a4d94df3158efeb0",
+      "branches": {
+        "master": "4ae5fd621e7f2207c97b8d42a4d94df3158efeb0"
+      }
+    },
+    "bycfm2/fonzappraiser": {
+      "default_branch": "main",
+      "sha": "924a5521532e0cbac8f90f7f4aac5fe855cc9072",
+      "branches": {
+        "main": "924a5521532e0cbac8f90f7f4aac5fe855cc9072"
+      }
+    },
+    "c4rcer/atlas-cfm": {
+      "default_branch": "main",
+      "sha": "9a9936a1923fd503ba8abda375371e747a2a2cff",
+      "branches": {
+        "main": "9a9936a1923fd503ba8abda375371e747a2a2cff"
+      }
+    },
+    "cabro/clog": {
+      "default_branch": "master",
+      "sha": "e9fd281f7947bfeffe96decca152446e64b34ec8",
+      "branches": {
+        "master": "e9fd281f7947bfeffe96decca152446e64b34ec8"
+      }
+    },
+    "cache9527/enemyframes": {
+      "default_branch": "master",
+      "sha": "0ac29c1dde801593ada2a0c84800ed8ac9380906",
+      "branches": {
+        "master": "0ac29c1dde801593ada2a0c84800ed8ac9380906"
+      }
+    },
+    "cache9527/lazyscript": {
+      "default_branch": "master",
+      "sha": "041ce6efafb4ea8cc599a81200693051e8f52ed9",
+      "branches": {
+        "master": "041ce6efafb4ea8cc599a81200693051e8f52ed9"
+      }
+    },
+    "cache9527/losecontrol-old": {
+      "default_branch": "master",
+      "sha": "5b228020d0f73231df1bdc31ffcfbd84b504878a",
+      "branches": {
+        "master": "5b228020d0f73231df1bdc31ffcfbd84b504878a"
+      }
+    },
+    "cache9527/quiver": {
+      "default_branch": "main",
+      "sha": "0043fb8a09da0d841e035ec769fc8b722a7fc1ca",
+      "branches": {
+        "main": "0043fb8a09da0d841e035ec769fc8b722a7fc1ca"
+      }
+    },
+    "caestielle/beardleysdiabloorbsvanilla": {
+      "default_branch": "master",
+      "sha": "b66186fe9f5de999034bd78f307e50cb8a6a3152",
+      "branches": {
+        "master": "b66186fe9f5de999034bd78f307e50cb8a6a3152"
+      }
+    },
+    "callumhoughton18/vanillastoryline": {
+      "default_branch": "master",
+      "sha": "259e712611e3cc81881d776eed527dc82725d8e0",
+      "branches": {
+        "master": "259e712611e3cc81881d776eed527dc82725d8e0"
+      }
+    },
+    "cama-dev/turtlebeastiary": {
+      "default_branch": "main",
+      "sha": "6def1c555106db9d181b4820edd53f7a4ea3561f",
+      "branches": {
+        "main": "6def1c555106db9d181b4820edd53f7a4ea3561f"
+      }
+    },
+    "caracioly/critei": {
+      "default_branch": "main",
+      "sha": "eeee679dc03d47502477e10a9fa0fced04ee9895",
+      "branches": {
+        "main": "eeee679dc03d47502477e10a9fa0fced04ee9895"
+      },
+      "latest_tag": "v1.2.2"
+    },
+    "carnvanbeck/turtlerp": {
+      "default_branch": "main",
+      "sha": "6a908cbb9c30ceaf42c7bafedcf739733f908e9f",
+      "branches": {
+        "main": "6a908cbb9c30ceaf42c7bafedcf739733f908e9f"
+      }
+    },
+    "carolluparu/gryllsbongos": {
+      "default_branch": "main",
+      "sha": "485e3840c5975e0da1fed4070a0eb71e0f429e85",
+      "branches": {
+        "main": "485e3840c5975e0da1fed4070a0eb71e0f429e85"
+      }
+    },
+    "carravan/lateral": {
+      "default_branch": "main",
+      "sha": "2f36500c9c3c5804cd790f37785b343f424818a1",
+      "branches": {
+        "main": "2f36500c9c3c5804cd790f37785b343f424818a1"
+      }
+    },
+    "caspervk/tactica": {
+      "default_branch": "main",
+      "sha": "54475a88c11f286733e0418dee3030a1797cf78d",
+      "branches": {
+        "main": "54475a88c11f286733e0418dee3030a1797cf78d"
+      }
+    },
+    "cdmichaelb/questprogressshare": {
+      "default_branch": "main",
+      "sha": "50261dd1cf7ac85c746b4693a763353c90dd10c7",
+      "branches": {
+        "main": "50261dd1cf7ac85c746b4693a763353c90dd10c7"
+      }
+    },
+    "cdmichaelb/silverdragon": {
+      "default_branch": "master",
+      "sha": "ab6a890bd91b2d946fae440a2f220062d51df606",
+      "branches": {
+        "master": "ab6a890bd91b2d946fae440a2f220062d51df606"
+      }
+    },
+    "cdnievas/fastbinding": {
+      "default_branch": "main",
+      "sha": "ee17faa82f4aa2faa1fade7d4219d23eee3520f3",
+      "branches": {
+        "main": "ee17faa82f4aa2faa1fade7d4219d23eee3520f3"
+      },
+      "latest_tag": "v1.1.1"
+    },
+    "celguar/characterprofiler": {
+      "default_branch": "master",
+      "sha": "8501d6991302d177776ace5f5843cd24b6308974",
+      "branches": {
+        "master": "8501d6991302d177776ace5f5843cd24b6308974"
+      },
+      "latest_tag": "1.0"
+    },
+    "celguar/wiiiui": {
+      "default_branch": "master",
+      "sha": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600",
+      "branches": {
+        "master": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600"
+      }
+    },
+    "cephel/dankscore": {
+      "default_branch": "master",
+      "sha": "9c38910c9c6d66417c7e44762857b6781b0d38fe",
+      "branches": {
+        "master": "9c38910c9c6d66417c7e44762857b6781b0d38fe"
+      }
+    },
+    "cephel/webdkp_elysium": {
+      "default_branch": "master",
+      "sha": "2e709d87e71517e147fe830c4753fa66fc551ea0",
+      "branches": {
+        "master": "2e709d87e71517e147fe830c4753fa66fc551ea0"
+      }
+    },
+    "cernie/catdruiddps": {
+      "default_branch": "master",
+      "sha": "3eeecbad23a584f265a17f559b7319d54d089d57",
+      "branches": {
+        "master": "3eeecbad23a584f265a17f559b7319d54d089d57"
+      }
+    },
+    "cernie/cernieswonderfulfunctions": {
+      "default_branch": "master",
+      "sha": "c89ecbe4789323ee6396a60fee15447708f22759",
+      "branches": {
+        "master": "c89ecbe4789323ee6396a60fee15447708f22759"
+      }
+    },
+    "cernie/druidconsumable": {
+      "default_branch": "master",
+      "sha": "7138b6f1919e2d3e8ea9a3011d2ef277dddcb14f",
+      "branches": {
+        "master": "7138b6f1919e2d3e8ea9a3011d2ef277dddcb14f"
+      }
+    },
+    "cernie/pummeler": {
+      "default_branch": "master",
+      "sha": "5094843163426678e129316910672515af58ee72",
+      "branches": {
+        "master": "5094843163426678e129316910672515af58ee72"
+      }
+    },
+    "cernie/warriortank": {
+      "default_branch": "master",
+      "sha": "0e1dfdb342b6e5c3e38e63d487eb9270c4be580c",
+      "branches": {
+        "master": "0e1dfdb342b6e5c3e38e63d487eb9270c4be580c"
+      }
+    },
+    "chad90b/cleanup-vanilla": {
+      "default_branch": "master",
+      "sha": "4c83ecb84f376979a0ac6b4747a0bed467cb9b90",
+      "branches": {
+        "master": "4c83ecb84f376979a0ac6b4747a0bed467cb9b90"
+      }
+    },
+    "chad90b/codex": {
+      "default_branch": "main",
+      "sha": "dff918ab8a2c742982fa12df865d6224cf7d4a4f",
+      "branches": {
+        "main": "dff918ab8a2c742982fa12df865d6224cf7d4a4f"
+      }
+    },
+    "chad90b/hardcoredeath": {
+      "default_branch": "main",
+      "sha": "342ab3eb9468a4f342c75702960909bf9cb5bc8f",
+      "branches": {
+        "main": "342ab3eb9468a4f342c75702960909bf9cb5bc8f"
+      }
+    },
+    "chad90b/lilsparkysworkshop-vanilla": {
+      "default_branch": "master",
+      "sha": "b20712697cd5ece1a4553f113d7ffcb4569a9055",
+      "branches": {
+        "master": "b20712697cd5ece1a4553f113d7ffcb4569a9055"
+      }
+    },
+    "chad90b/mastertradeskills": {
+      "default_branch": "master",
+      "sha": "bb780c85a6855d1cb5af63df0f68bf5ff9e642e1",
+      "branches": {
+        "master": "bb780c85a6855d1cb5af63df0f68bf5ff9e642e1"
+      }
+    },
+    "chad90b/minimapbuttonframe-vanilla": {
+      "default_branch": "master",
+      "sha": "0923f9e4128c6fcdc97df448c7665ca71bca2a18",
+      "branches": {
+        "master": "0923f9e4128c6fcdc97df448c7665ca71bca2a18"
+      },
+      "latest_tag": "1.12"
+    },
+    "chad90b/missingcrafts": {
+      "default_branch": "master",
+      "sha": "e702ce7d781d68c2ead5f8223e59689edb8cfc91",
+      "branches": {
+        "master": "e702ce7d781d68c2ead5f8223e59689edb8cfc91"
+      }
+    },
+    "chad90b/missingtradeskillslist": {
+      "default_branch": "master",
+      "sha": "d40172f3d2e61d8541f35c01460e4f0b595a470e",
+      "branches": {
+        "master": "d40172f3d2e61d8541f35c01460e4f0b595a470e"
+      }
+    },
+    "chad90b/niagara": {
+      "default_branch": "master",
+      "sha": "9c09951be42a8a7152a2c67eebc42077618eb39d",
+      "branches": {
+        "master": "9c09951be42a8a7152a2c67eebc42077618eb39d"
+      }
+    },
+    "chad90b/pfquest-icons": {
+      "default_branch": "master",
+      "sha": "399eaa6391aa816f91c989dfe5a96a69b884457b",
+      "branches": {
+        "master": "399eaa6391aa816f91c989dfe5a96a69b884457b"
+      }
+    },
+    "chad90b/questframefixer": {
+      "default_branch": "master",
+      "sha": "3cce407a9acd8a035507c6022f47109320509031",
+      "branches": {
+        "master": "3cce407a9acd8a035507c6022f47109320509031"
+      }
+    },
+    "chad90b/reagentdata": {
+      "default_branch": "master",
+      "sha": "c10ad1e2a9044dfa2f6c21fe4917fad42e2365c3",
+      "branches": {
+        "master": "c10ad1e2a9044dfa2f6c21fe4917fad42e2365c3"
+      }
+    },
+    "chad90b/ringmenu-vanilla112": {
+      "default_branch": "master",
+      "sha": "23db580b0ddc04b8650afdf50179302fbb67128f",
+      "branches": {
+        "master": "23db580b0ddc04b8650afdf50179302fbb67128f"
+      },
+      "latest_tag": "v2.2.1"
+    },
+    "chad90b/shaguscore": {
+      "default_branch": "master",
+      "sha": "70eb78e85917a1d1d41fd44e39feea5842d23037",
+      "branches": {
+        "master": "70eb78e85917a1d1d41fd44e39feea5842d23037"
+      }
+    },
+    "chad90b/soloraidtargeticons": {
+      "default_branch": "master",
+      "sha": "8f4312c96d7b61e0a34278617633c6d183ee9f5a",
+      "branches": {
+        "master": "8f4312c96d7b61e0a34278617633c6d183ee9f5a"
+      }
+    },
+    "chad90b/sortbags-vanilla": {
+      "default_branch": "master",
+      "sha": "1b59767ca41749e70d72f2991c27054beebcdfcd",
+      "branches": {
+        "master": "1b59767ca41749e70d72f2991c27054beebcdfcd"
+      }
+    },
+    "chad90b/tradeskillsdata": {
+      "default_branch": "master",
+      "sha": "9cc02127ae479ed39689f9e3a82eeadb5db81caa",
+      "branches": {
+        "master": "9cc02127ae479ed39689f9e3a82eeadb5db81caa"
+      }
+    },
+    "chad90b/trainerskills": {
+      "default_branch": "master",
+      "sha": "20468df1622b9edd3b6ea6c8bfd61fdf641c3598",
+      "branches": {
+        "master": "20468df1622b9edd3b6ea6c8bfd61fdf641c3598"
+      }
+    },
+    "chad90b/unicodefont": {
+      "default_branch": "master",
+      "sha": "f19092f3bf49b5303f9bba16f45d51397b610c0a",
+      "branches": {
+        "master": "f19092f3bf49b5303f9bba16f45d51397b610c0a"
+      }
+    },
+    "checkem/succ-ecb": {
+      "default_branch": "master",
+      "sha": "e6e753c85f90f6de34093fe4dc2e8c7053dbb864",
+      "branches": {
+        "master": "e6e753c85f90f6de34093fe4dc2e8c7053dbb864"
+      }
+    },
+    "checkem/succ-ui": {
+      "default_branch": "master",
+      "sha": "11679eac1b16814e1ef3c41a0baffe872c7f698b",
+      "branches": {
+        "master": "11679eac1b16814e1ef3c41a0baffe872c7f698b"
+      },
+      "latest_tag": "0.2"
+    },
+    "choogerdev/chaux-addon": {
+      "default_branch": "master",
+      "sha": "caebf5833c931f35d22a27def58cf9e8855e6ba5",
+      "branches": {
+        "master": "caebf5833c931f35d22a27def58cf9e8855e6ba5"
+      }
+    },
+    "chrisbigart/bitescookbook": {
+      "default_branch": "master",
+      "sha": "371a84e3cdf2ae22c73755ff559b822be3051528",
+      "branches": {
+        "master": "371a84e3cdf2ae22c73755ff559b822be3051528"
+      }
+    },
+    "christiancook/roll-for-vanilla": {
+      "default_branch": "master",
+      "sha": "268f7a78b4e43f7ee3c40272360262775e6a2b11",
+      "branches": {
+        "master": "268f7a78b4e43f7ee3c40272360262775e6a2b11"
+      }
+    },
+    "cinecom/brainwasherpro": {
+      "default_branch": "main",
+      "sha": "ec02c4ea74ebc59791873943bd57fdd1179c9cc7",
+      "branches": {
+        "main": "ec02c4ea74ebc59791873943bd57fdd1179c9cc7"
+      }
+    },
+    "cinecom/consumesmanager": {
+      "default_branch": "main",
+      "sha": "9662595123519609bad09ff49061ca969a5249e8",
+      "branches": {
+        "main": "9662595123519609bad09ff49061ca969a5249e8"
+      }
+    },
+    "cinecom/easypoisons": {
+      "default_branch": "main",
+      "sha": "7c79f964118995c4cd7874704f561488cb02e2ce",
+      "branches": {
+        "main": "7c79f964118995c4cd7874704f561488cb02e2ce"
+      }
+    },
+    "cinecom/shootyepgp": {
+      "default_branch": "master",
+      "sha": "aae250f73a0c745fd448ce179030b8458a1a2feb",
+      "branches": {
+        "master": "aae250f73a0c745fd448ce179030b8458a1a2feb"
+      }
+    },
+    "cinos03/bankraider": {
+      "default_branch": "main",
+      "sha": "7de9a083e653593daa9285be7aa24650d9726aca",
+      "branches": {
+        "main": "7de9a083e653593daa9285be7aa24650d9726aca"
+      }
+    },
+    "cinos03/bijoucounter": {
+      "default_branch": "main",
+      "sha": "f6ce02e7b66566912b00de739f2f042ab0914323",
+      "branches": {
+        "main": "f6ce02e7b66566912b00de739f2f042ab0914323"
+      }
+    },
+    "cinos03/surpriseme-1.12": {
+      "default_branch": "main",
+      "sha": "5be9b5eaeb3b01a2862d1ac21873000b84d8a46a",
+      "branches": {
+        "main": "5be9b5eaeb3b01a2862d1ac21873000b84d8a46a"
+      }
+    },
+    "ciphuk/sp_revenge": {
+      "default_branch": "main",
+      "sha": "e19426df9bc586cefd2cc39ae61cfea549b6fd59",
+      "branches": {
+        "main": "e19426df9bc586cefd2cc39ae61cfea549b6fd59"
+      }
+    },
+    "cliencer/pfextend": {
+      "default_branch": "main",
+      "sha": "6a8e03142901771fca71fefe8df5c2aa41f6105d",
+      "branches": {
+        "main": "6a8e03142901771fca71fefe8df5c2aa41f6105d"
+      },
+      "latest_tag": "1.0.6"
+    },
+    "clungo/turtlepvp": {
+      "default_branch": "main",
+      "sha": "bd3f5ed3004c2aabf21bdb6825667ccbabd31883",
+      "branches": {
+        "main": "bd3f5ed3004c2aabf21bdb6825667ccbabd31883"
+      }
+    },
+    "codeshard/architotem": {
+      "default_branch": "master",
+      "sha": "b2aa56ca6ba10b52bcf3cdb7eb91c43f3a822abc",
+      "branches": {
+        "master": "b2aa56ca6ba10b52bcf3cdb7eb91c43f3a822abc"
+      },
+      "latest_tag": "v1.6.3"
+    },
+    "commanderkeen34/modernmapmarkersenhanced": {
+      "default_branch": "main",
+      "sha": "67ae4ab6b9ff711537c46b0365f14a53938c669a",
+      "branches": {
+        "main": "67ae4ab6b9ff711537c46b0365f14a53938c669a"
+      }
+    },
+    "commandersouza/cursive": {
+      "default_branch": "master",
+      "sha": "3bb9fff354fedb136d6cae46e22e81514d0e2e61",
+      "branches": {
+        "master": "3bb9fff354fedb136d6cae46e22e81514d0e2e61"
+      }
+    },
+    "commandersouza/magehud": {
+      "default_branch": "main",
+      "sha": "bbe97d933fb43811beb3010e57d6751137042d52",
+      "branches": {
+        "main": "bbe97d933fb43811beb3010e57d6751137042d52"
+      }
+    },
+    "commandersouza/pfui-autoinvite": {
+      "default_branch": "main",
+      "sha": "e67988f1f28478c2df1163e3b8a2a1b50656ad0a",
+      "branches": {
+        "main": "e67988f1f28478c2df1163e3b8a2a1b50656ad0a"
+      }
+    },
+    "commandersouza/raidsummon": {
+      "default_branch": "master",
+      "sha": "d8d58be6bfaeb570f9ab89c7513014e9181542fb",
+      "branches": {
+        "master": "d8d58be6bfaeb570f9ab89c7513014e9181542fb"
+      }
+    },
+    "commandersouza/shaguactions": {
+      "default_branch": "master",
+      "sha": "e076014ad8043e1dc1edf0de5dff5fe49c24f4ac",
+      "branches": {
+        "master": "e076014ad8043e1dc1edf0de5dff5fe49c24f4ac"
+      }
+    },
+    "commandersouza/shagudps": {
+      "default_branch": "master",
+      "sha": "a1f3e071b9bf0437ee60530bf19a0dcfd96b939c",
+      "branches": {
+        "master": "a1f3e071b9bf0437ee60530bf19a0dcfd96b939c"
+      }
+    },
+    "compudefierro/t-oom": {
+      "default_branch": "main",
+      "sha": "5aa952f4a33a0201d420431b8b56db9161869286",
+      "branches": {
+        "main": "5aa952f4a33a0201d420431b8b56db9161869286"
+      }
+    },
+    "computerequipmentgroup/bubbles": {
+      "default_branch": "main",
+      "sha": "d6e07f8b958ade654fa5e02be6f63ae22e7f634f",
+      "branches": {
+        "main": "d6e07f8b958ade654fa5e02be6f63ae22e7f634f"
+      },
+      "latest_tag": "1.2"
+    },
+    "conquistadorestwow/gfw_huntershelper": {
+      "default_branch": "master",
+      "sha": "306a625f1b97e80013aae9887de8ba8d278e96ae",
+      "branches": {
+        "master": "306a625f1b97e80013aae9887de8ba8d278e96ae"
+      }
+    },
+    "conquistadorestwow/missingcrafts": {
+      "default_branch": "master",
+      "sha": "e702ce7d781d68c2ead5f8223e59689edb8cfc91",
+      "branches": {
+        "master": "e702ce7d781d68c2ead5f8223e59689edb8cfc91"
+      }
+    },
+    "convay89/aux-addon": {
+      "default_branch": "master",
+      "sha": "62bef57950810a989ac741c5e5f58257f2c780b9",
+      "branches": {
+        "master": "62bef57950810a989ac741c5e5f58257f2c780b9"
+      }
+    },
+    "copypasteonly/pfquest": {
+      "default_branch": "main",
+      "sha": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9",
+      "branches": {
+        "main": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9"
+      },
+      "latest_tag": "8.0.0"
+    },
+    "coryo/rdx": {
+      "default_branch": "master",
+      "sha": "d413628bbca92b0da93a7872523e5a30bc5aaee5",
+      "branches": {
+        "master": "d413628bbca92b0da93a7872523e5a30bc5aaee5"
+      }
+    },
+    "coryo/rosterfilter": {
+      "default_branch": "master",
+      "sha": "a9ddd62e7ef70b890737d2d3583d1fb7db4052f0",
+      "branches": {
+        "master": "a9ddd62e7ef70b890737d2d3583d1fb7db4052f0"
+      },
+      "latest_tag": "v2.4"
+    },
+    "cosminpop/hendrishift": {
+      "default_branch": "master",
+      "sha": "22b05db2ee66e4555cce2263fc8854687a66134f",
+      "branches": {
+        "master": "22b05db2ee66e4555cce2263fc8854687a66134f"
+      }
+    },
+    "cosminpop/lootres": {
+      "default_branch": "master",
+      "sha": "f757716d8cebc6f75ff8a4de33d91b3207e07191",
+      "branches": {
+        "master": "f757716d8cebc6f75ff8a4de33d91b3207e07191"
+      }
+    },
+    "cosminpop/twassignments": {
+      "default_branch": "master",
+      "sha": "e4533a9809ec30fa1b27f0821130f08d237a5b14",
+      "branches": {
+        "master": "e4533a9809ec30fa1b27f0821130f08d237a5b14"
+      }
     },
     "cosminpop/twbluedragon": {
       "default_branch": "master",
@@ -7761,33 +2602,13 @@
         "master": "f9d691bde37a1e9bd90826d7fbbe7b9804cdf77f"
       }
     },
-    "phobos-programmer/twbuypoisons": {
+    "cosminpop/twlc2c": {
       "default_branch": "master",
-      "sha": "e69c62e0a8285b6bc63894900a6ccfb2af10996f",
+      "sha": "ced533890980f8e7170c191c27d3aca2363905f0",
       "branches": {
-        "master": "e69c62e0a8285b6bc63894900a6ccfb2af10996f"
-      }
-    },
-    "sica42/twbuypoisons": {
-      "default_branch": "master",
-      "sha": "4aba9ed37164030c084a968670303cd767cb1314",
-      "branches": {
-        "master": "4aba9ed37164030c084a968670303cd767cb1314"
-      }
-    },
-    "thenuclei/twbuypoisonsjin": {
-      "default_branch": "master",
-      "sha": "19414909316521e6f57b94e0fe2d6b4ba071b7b8",
-      "branches": {
-        "master": "19414909316521e6f57b94e0fe2d6b4ba071b7b8"
-      }
-    },
-    "wierdthing/twbuypoisons": {
-      "default_branch": "master",
-      "sha": "194fa10b8216c73a795ab393a71b815bd464989f",
-      "branches": {
-        "master": "194fa10b8216c73a795ab393a71b815bd464989f"
-      }
+        "master": "ced533890980f8e7170c191c27d3aca2363905f0"
+      },
+      "latest_tag": "v1.1.1-beta.1"
     },
     "cosminpop/twowenwilson": {
       "default_branch": "master",
@@ -7810,123 +2631,163 @@
         "master": "ab3f92bc9b557fc337174bae9d04f24d29fee89d"
       }
     },
-    "yamayaml/twtrans": {
+    "cosminpop/twthreat": {
+      "default_branch": "master",
+      "sha": "07b97382a7f72f0c8d65f20e47a50b843b073ebf",
+      "branches": {
+        "master": "07b97382a7f72f0c8d65f20e47a50b843b073ebf"
+      }
+    },
+    "cr45hcode/healbot-returtled": {
+      "default_branch": "master",
+      "sha": "6c78b6801556e52be829548b1305b2f4a53141e2",
+      "branches": {
+        "master": "6c78b6801556e52be829548b1305b2f4a53141e2"
+      }
+    },
+    "crackedmustache/bearcastbar_castbartoggle": {
+      "default_branch": "master",
+      "sha": "5e19c5b201effacc21f5ac1faa39c286772037ff",
+      "branches": {
+        "master": "5e19c5b201effacc21f5ac1faa39c286772037ff"
+      },
+      "latest_tag": "v1.0"
+    },
+    "crackion/mobstats": {
+      "default_branch": "master",
+      "sha": "3ff6580763b2726dd97cd6383a5842428830250c",
+      "branches": {
+        "master": "3ff6580763b2726dd97cd6383a5842428830250c"
+      }
+    },
+    "cralor/tomtomvanilla": {
+      "default_branch": "master",
+      "sha": "075a6840535da89526c6469e7eb27a1863f9dba1",
+      "branches": {
+        "master": "075a6840535da89526c6469e7eb27a1863f9dba1"
+      },
+      "latest_tag": "1.0.1-beta"
+    },
+    "cralor/tourguide_professions": {
+      "default_branch": "master",
+      "sha": "c5ed92c003f625b1c84d37dfa724b7ef298e21c0",
+      "branches": {
+        "master": "c5ed92c003f625b1c84d37dfa724b7ef298e21c0"
+      },
+      "latest_tag": "1.0.2-beta"
+    },
+    "cralor/tourguidevanilla": {
+      "default_branch": "master",
+      "sha": "bc94ceaf497d6b524a2f2dced3ef1fededa1bfa1",
+      "branches": {
+        "master": "bc94ceaf497d6b524a2f2dced3ef1fededa1bfa1"
+      },
+      "latest_tag": "1.1.3-beta"
+    },
+    "cregham/mobstolevel": {
+      "default_branch": "master",
+      "sha": "6a9466ca9b775e08a957bde72aa6d8189a983131",
+      "branches": {
+        "master": "6a9466ca9b775e08a957bde72aa6d8189a983131"
+      }
+    },
+    "cregham/partyplus": {
       "default_branch": "main",
-      "sha": "1bcef7f3f2631cf3a13bbf63cd91da14a7b6f06c",
+      "sha": "81027ce5b13da8ad81dd312dabcbba0f444babf6",
       "branches": {
-        "main": "1bcef7f3f2631cf3a13bbf63cd91da14a7b6f06c"
+        "main": "81027ce5b13da8ad81dd312dabcbba0f444babf6"
       }
     },
-    "raphaelantoniocampos/twtrans": {
+    "creohex/lockassignment": {
       "default_branch": "main",
-      "sha": "1bcef7f3f2631cf3a13bbf63cd91da14a7b6f06c",
+      "sha": "c82e4b47c969736fb83cfd0ce56d451ad4ecab0e",
       "branches": {
-        "main": "1bcef7f3f2631cf3a13bbf63cd91da14a7b6f06c"
+        "main": "c82e4b47c969736fb83cfd0ce56d451ad4ecab0e"
       }
     },
-    "yutsuku/uitweaks": {
+    "creohex/raidorganizer": {
       "default_branch": "master",
-      "sha": "4c5dbd523e787ef66efa3f482e2adb38a82f367d",
+      "sha": "67c743e2ea844ae4f2ca086f0b33b253bbd182b5",
       "branches": {
-        "master": "4c5dbd523e787ef66efa3f482e2adb38a82f367d"
+        "master": "67c743e2ea844ae4f2ca086f0b33b253bbd182b5"
       }
     },
-    "jrc13245/ultimamacros": {
+    "crimsonhollow/shagutweaks-more-mods": {
       "default_branch": "main",
-      "sha": "67d908144a85b5d4ceed84491e6e80fa034a5d9e",
+      "sha": "c1bad7fda3b20fd75b8538570216423121517ada",
       "branches": {
-        "main": "67d908144a85b5d4ceed84491e6e80fa034a5d9e"
+        "main": "c1bad7fda3b20fd75b8538570216423121517ada"
       }
     },
-    "daribon/unicodefont": {
-      "default_branch": "master",
-      "sha": "f19092f3bf49b5303f9bba16f45d51397b610c0a",
+    "cryptokn1ght-dev/chatmonitor": {
+      "default_branch": "main",
+      "sha": "2095edc3e5a10c8065304dbb567914424b8d9bf5",
       "branches": {
-        "master": "f19092f3bf49b5303f9bba16f45d51397b610c0a"
+        "main": "2095edc3e5a10c8065304dbb567914424b8d9bf5"
       }
     },
-    "macumbafeh/unicodefont": {
-      "default_branch": "master",
-      "sha": "f19092f3bf49b5303f9bba16f45d51397b610c0a",
+    "cryptokn1ght-dev/sealtracker": {
+      "default_branch": "main",
+      "sha": "bad8f173cdbc6b2b10b7984e009ca2d22437ca25",
       "branches": {
-        "master": "f19092f3bf49b5303f9bba16f45d51397b610c0a"
+        "main": "bad8f173cdbc6b2b10b7984e009ca2d22437ca25"
       }
     },
-    "ratkosrb/unicodefont": {
+    "cryptopsy30/mobstats-bleedimmune": {
       "default_branch": "master",
-      "sha": "fd408c8656078afbd72f4f8911ef197e1c934a75",
+      "sha": "bbfd39f2200637d1a2a7a5d52e324e78623d9720",
       "branches": {
-        "master": "fd408c8656078afbd72f4f8911ef197e1c934a75"
+        "master": "bbfd39f2200637d1a2a7a5d52e324e78623d9720"
       }
     },
-    "hippoom/unicodefont": {
+    "cubenicke/efcreport": {
       "default_branch": "master",
-      "sha": "d05916b18d02f6bd34eddeaa7fc0d87033b9c911",
+      "sha": "a4ae1f56c2e3fbfd34b2804d59a0e0b214d4b5d4",
       "branches": {
-        "master": "d05916b18d02f6bd34eddeaa7fc0d87033b9c911"
+        "master": "a4ae1f56c2e3fbfd34b2804d59a0e0b214d4b5d4"
       }
     },
-    "fondlez/unicodefont": {
+    "cubenicke/fury": {
       "default_branch": "master",
-      "sha": "f19092f3bf49b5303f9bba16f45d51397b610c0a",
+      "sha": "e832d00beebe52c32989f8621e4eaf05730ecd7e",
       "branches": {
-        "master": "f19092f3bf49b5303f9bba16f45d51397b610c0a"
+        "master": "e832d00beebe52c32989f8621e4eaf05730ecd7e"
+      },
+      "latest_tag": "fury_1_15"
+    },
+    "cubenicke/mule": {
+      "default_branch": "master",
+      "sha": "c90acd5139ae8a5bff7d4a04d7024d4071fb5bc0",
+      "branches": {
+        "master": "c90acd5139ae8a5bff7d4a04d7024d4071fb5bc0"
       }
     },
-    "chad90b/unicodefont": {
+    "cubenicke/swapper": {
       "default_branch": "master",
-      "sha": "f19092f3bf49b5303f9bba16f45d51397b610c0a",
+      "sha": "f17ef7a478aa8c3b68a48ba856a7adc0561a9bbc",
       "branches": {
-        "master": "f19092f3bf49b5303f9bba16f45d51397b610c0a"
+        "master": "f17ef7a478aa8c3b68a48ba856a7adc0561a9bbc"
       }
     },
-    "nishizhumagu/unicodefont": {
-      "default_branch": "master",
-      "sha": "f19092f3bf49b5303f9bba16f45d51397b610c0a",
+    "cutiepoka/cleveroidmacros": {
+      "default_branch": "main",
+      "sha": "9456c483dd21a77028aa6afc5952e8ef190426bf",
       "branches": {
-        "master": "f19092f3bf49b5303f9bba16f45d51397b610c0a"
+        "main": "9456c483dd21a77028aa6afc5952e8ef190426bf"
       }
     },
-    "marcelinevq/vamper": {
+    "cw60/tradeskillsdata": {
       "default_branch": "master",
-      "sha": "2306cc10e8d3ea86d04e4fbca3fe4fb1ad76e2d1",
+      "sha": "9cc02127ae479ed39689f9e3a82eeadb5db81caa",
       "branches": {
-        "master": "2306cc10e8d3ea86d04e4fbca3fe4fb1ad76e2d1"
+        "master": "9cc02127ae479ed39689f9e3a82eeadb5db81caa"
       }
     },
-    "whtmst/t-vamp": {
+    "cw60/tradeskillsdata-turtle": {
       "default_branch": "master",
-      "sha": "63727b656e13aaad818fd7dee77002a261684416",
+      "sha": "81b9653cdb21ad26839a849e9548aa57f4d0a6ed",
       "branches": {
-        "master": "63727b656e13aaad818fd7dee77002a261684416"
-      }
-    },
-    "hixio-mh/vanillagraphicboost": {
-      "default_branch": "master",
-      "sha": "0b19da75d19cdb0754171a2167bc533f1337ec01",
-      "branches": {
-        "master": "0b19da75d19cdb0754171a2167bc533f1337ec01"
-      }
-    },
-    "refaim/vanillagraphicboost": {
-      "default_branch": "master",
-      "sha": "0fc8a161e8bbfd84c4afebe9c0013e46c9ba9e5e",
-      "branches": {
-        "master": "0fc8a161e8bbfd84c4afebe9c0013e46c9ba9e5e"
-      }
-    },
-    "shikulja/vanillagraphicboost": {
-      "default_branch": "master",
-      "sha": "bfc1ea885909b4ca7688fbd5223fe13b89feccd9",
-      "branches": {
-        "master": "bfc1ea885909b4ca7688fbd5223fe13b89feccd9"
-      }
-    },
-    "macumbafeh/vanillagraphicboost": {
-      "default_branch": "master",
-      "sha": "082405f1d4e9081b2adf110596b67e44c4fd4bd6",
-      "branches": {
-        "master": "082405f1d4e9081b2adf110596b67e44c4fd4bd6"
+        "master": "81b9653cdb21ad26839a849e9548aa57f4d0a6ed"
       }
     },
     "cw60/vanillagraphicboost": {
@@ -7936,6 +2797,521 @@
         "master": "b6ce2454619dba6646ebd300fe8e26ad4891e581"
       }
     },
+    "cyaohiri/autoshot": {
+      "default_branch": "master",
+      "sha": "62e93212072fae64dad4525c161376d523c39e69",
+      "branches": {
+        "master": "62e93212072fae64dad4525c161376d523c39e69"
+      }
+    },
+    "cyaohiri/censusplusturtle": {
+      "default_branch": "main",
+      "sha": "6dae25fad5fcf038083ded230c380cc56b142d3a",
+      "branches": {
+        "main": "6dae25fad5fcf038083ded230c380cc56b142d3a"
+      }
+    },
+    "cyaohiri/chattimestamps": {
+      "default_branch": "master",
+      "sha": "eace4ae20f20102f0c4794b1da35ecf6d4b57854",
+      "branches": {
+        "master": "eace4ae20f20102f0c4794b1da35ecf6d4b57854"
+      }
+    },
+    "cyaohiri/itemidtooltip": {
+      "default_branch": "main",
+      "sha": "f25c97e799ebd66d3e5e4318f4b513f3561c385d",
+      "branches": {
+        "main": "f25c97e799ebd66d3e5e4318f4b513f3561c385d"
+      }
+    },
+    "cyaohiri/stealthoverlay": {
+      "default_branch": "master",
+      "sha": "ff164bbcbda66770051e3304f15f3c46b3c91a6e",
+      "branches": {
+        "master": "ff164bbcbda66770051e3304f15f3c46b3c91a6e"
+      }
+    },
+    "cyaohiri/triviabot-turtlewow": {
+      "default_branch": "master",
+      "sha": "e11b168dd15d3d0eac358bf2f7c7a75c68dcd63b",
+      "branches": {
+        "master": "e11b168dd15d3d0eac358bf2f7c7a75c68dcd63b"
+      }
+    },
+    "cybula-real/pfui-weakicons-turtle": {
+      "default_branch": "master",
+      "sha": "274a9153fe738ff1e2b1f6628cffcce39e83925a",
+      "branches": {
+        "master": "274a9153fe738ff1e2b1f6628cffcce39e83925a"
+      }
+    },
+    "cysthen/comix": {
+      "default_branch": "main",
+      "sha": "0c1fb1c38260babf4194a4342f1f954ecce37a95",
+      "branches": {
+        "main": "0c1fb1c38260babf4194a4342f1f954ecce37a95"
+      }
+    },
+    "daemonp/tankplates": {
+      "default_branch": "master",
+      "sha": "e2f9ba304f4ec82ae76fbd46cc935b433cadc782",
+      "branches": {
+        "master": "e2f9ba304f4ec82ae76fbd46cc935b433cadc782"
+      },
+      "latest_tag": "v1.4.2"
+    },
+    "damagepyhun/turtlechatcolors": {
+      "default_branch": "main",
+      "sha": "3360599bccf37e0d7965cddb9c91c85009d931dd",
+      "branches": {
+        "main": "3360599bccf37e0d7965cddb9c91c85009d931dd"
+      }
+    },
+    "danieladolfsson/clevermacro": {
+      "default_branch": "master",
+      "sha": "7b85b4c4e59cfea121e5460dfc19e0dde8c89472",
+      "branches": {
+        "master": "7b85b4c4e59cfea121e5460dfc19e0dde8c89472"
+      },
+      "latest_tag": "v1.4"
+    },
+    "daniilsokolyuk/ripmap": {
+      "default_branch": "master",
+      "sha": "0f864a5e25de22ee7f5dd66ee740434a12d07bba",
+      "branches": {
+        "master": "0f864a5e25de22ee7f5dd66ee740434a12d07bba"
+      }
+    },
+    "dankirichenko/adf": {
+      "default_branch": "master",
+      "sha": "1f294c31c11f45823afc2702e6e8abeeb4996c26",
+      "branches": {
+        "master": "1f294c31c11f45823afc2702e6e8abeeb4996c26"
+      }
+    },
+    "dannychan94/cooline": {
+      "default_branch": "master",
+      "sha": "0596db4d3c05a26d68199c3651a37dc8eb550000",
+      "branches": {
+        "master": "0596db4d3c05a26d68199c3651a37dc8eb550000"
+      }
+    },
+    "daomatys/chatbar": {
+      "default_branch": "master",
+      "sha": "dab207f1e96748705115ffed1c2536b1a34a9575",
+      "branches": {
+        "master": "dab207f1e96748705115ffed1c2536b1a34a9575"
+      }
+    },
+    "daribon/questtranslator": {
+      "default_branch": "master",
+      "sha": "151667024e19be5640440596e1b41f984eaa9677",
+      "branches": {
+        "master": "151667024e19be5640440596e1b41f984eaa9677"
+      }
+    },
+    "daribon/spartanui_spincam": {
+      "default_branch": "master",
+      "sha": "16fa426a517745aa5c267cb8de91c0f695f787f2",
+      "branches": {
+        "master": "16fa426a517745aa5c267cb8de91c0f695f787f2"
+      }
+    },
+    "daribon/titanwowradio": {
+      "default_branch": "master",
+      "sha": "d54df521e8bcfeacdaeba7bfab990f034129c949",
+      "branches": {
+        "master": "d54df521e8bcfeacdaeba7bfab990f034129c949"
+      }
+    },
+    "daribon/unicodefont": {
+      "default_branch": "master",
+      "sha": "f19092f3bf49b5303f9bba16f45d51397b610c0a",
+      "branches": {
+        "master": "f19092f3bf49b5303f9bba16f45d51397b610c0a"
+      }
+    },
+    "daribon/wrugs": {
+      "default_branch": "master",
+      "sha": "608e64dcbd79d4f8dd2823a4fb9a9b789150a0ea",
+      "branches": {
+        "master": "608e64dcbd79d4f8dd2823a4fb9a9b789150a0ea"
+      }
+    },
+    "darkovian/missingtradeskillslist-libcrafts": {
+      "default_branch": "master",
+      "sha": "545095062c5609e2cdb9d853faeb17c0c9dfc34d",
+      "branches": {
+        "master": "545095062c5609e2cdb9d853faeb17c0c9dfc34d"
+      }
+    },
+    "dauls/rinse-v-": {
+      "default_branch": "master",
+      "sha": "2bc316755635266dffc3f4975dff88a9a06035af",
+      "branches": {
+        "master": "2bc316755635266dffc3f4975dff88a9a06035af"
+      }
+    },
+    "dauls/smartrestore": {
+      "default_branch": "main",
+      "sha": "ce7ccc9ba7bc18a52ab9fc85d1e85fbe2a78bc93",
+      "branches": {
+        "main": "ce7ccc9ba7bc18a52ab9fc85d1e85fbe2a78bc93"
+      },
+      "latest_tag": "v3.4.1"
+    },
+    "davidbecht/autolock": {
+      "default_branch": "main",
+      "sha": "4b1f63a28c3e1e335fcc046efc3682fa8adf3cff",
+      "branches": {
+        "main": "4b1f63a28c3e1e335fcc046efc3682fa8adf3cff"
+      }
+    },
+    "dayfiree/autospellranker": {
+      "default_branch": "main",
+      "sha": "625e2088a50f2df30314b740356a06f875e13600",
+      "branches": {
+        "main": "625e2088a50f2df30314b740356a06f875e13600"
+      }
+    },
+    "dbfblackbull/bitescookbook": {
+      "default_branch": "master",
+      "sha": "36c919110a87bcadbc331f657bc962da00c3ef92",
+      "branches": {
+        "master": "36c919110a87bcadbc331f657bc962da00c3ef92"
+      }
+    },
+    "dbfblackbull/debufftimers": {
+      "default_branch": "master",
+      "sha": "99880e7cb950b90adfb5c094fbc30012ba3bdc6d",
+      "branches": {
+        "master": "99880e7cb950b90adfb5c094fbc30012ba3bdc6d"
+      }
+    },
+    "dbfblackbull/sellvalue": {
+      "default_branch": "master",
+      "sha": "64c61ce1729dc3d9d573c03bef16e94ad36ad7dc",
+      "branches": {
+        "master": "64c61ce1729dc3d9d573c03bef16e94ad36ad7dc"
+      }
+    },
+    "dbfblackbull/shaguactions": {
+      "default_branch": "master",
+      "sha": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8",
+      "branches": {
+        "master": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8"
+      }
+    },
+    "dbfblackbull/shagutweaks": {
+      "default_branch": "master",
+      "sha": "ae86e6657055a7933a89e6426aae2c0b99a6046c",
+      "branches": {
+        "master": "ae86e6657055a7933a89e6426aae2c0b99a6046c"
+      }
+    },
+    "dbfblackbull/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "cf669abb5e32a857dab0c9d78b0d9ed833ccce19",
+      "branches": {
+        "master": "cf669abb5e32a857dab0c9d78b0d9ed833ccce19"
+      }
+    },
+    "dbfblackbull/totemtimers-enhanced": {
+      "default_branch": "master",
+      "sha": "99337e1cc9506665d38bda8b02b627845897015c",
+      "branches": {
+        "master": "99337e1cc9506665d38bda8b02b627845897015c"
+      }
+    },
+    "dbfblackbull/trainerskills": {
+      "default_branch": "master",
+      "sha": "cfae8cbcb64a265ab0cc9b1cf07151cb37eb6d65",
+      "branches": {
+        "master": "cfae8cbcb64a265ab0cc9b1cf07151cb37eb6d65"
+      }
+    },
+    "dbtdsilva/nugenergy": {
+      "default_branch": "vanilla",
+      "sha": "96370aecaefe7ff9fdc8a28029562a169fc81ffa",
+      "branches": {
+        "vanilla": "96370aecaefe7ff9fdc8a28029562a169fc81ffa"
+      },
+      "latest_tag": "11.0.1"
+    },
+    "dbulatovicx32/shagudps": {
+      "default_branch": "master",
+      "sha": "9510167d9a3a59fb06a154c653af68bbf83b582a",
+      "branches": {
+        "master": "9510167d9a3a59fb06a154c653af68bbf83b582a"
+      }
+    },
+    "dcv-2142/rabuffs": {
+      "default_branch": "master",
+      "sha": "6000d7140b8ea486094cbce85de68b079443f00f",
+      "branches": {
+        "master": "6000d7140b8ea486094cbce85de68b079443f00f"
+      }
+    },
+    "dcv-2142/shagudps": {
+      "default_branch": "master",
+      "sha": "ddfa91c265a6fc441fbbb7fba5ed09193e12380f",
+      "branches": {
+        "master": "ddfa91c265a6fc441fbbb7fba5ed09193e12380f"
+      }
+    },
+    "deceius/attackbar": {
+      "default_branch": "master",
+      "sha": "f0e6a588cb31484300aea9e864aa7b843233f9ed",
+      "branches": {
+        "master": "f0e6a588cb31484300aea9e864aa7b843233f9ed"
+      }
+    },
+    "deceius/doiteauras": {
+      "default_branch": "main",
+      "sha": "15c444ea0214b5399020c0515bad9e8cef4a6593",
+      "branches": {
+        "main": "15c444ea0214b5399020c0515bad9e8cef4a6593"
+      }
+    },
+    "deceius/minimapbuttonbag": {
+      "default_branch": "master",
+      "sha": "b2bd0c5277552b7a2ed36bbb18cc3f7bad7e2885",
+      "branches": {
+        "master": "b2bd0c5277552b7a2ed36bbb18cc3f7bad7e2885"
+      },
+      "latest_tag": "v0.508"
+    },
+    "deceius/shagudps": {
+      "default_branch": "master",
+      "sha": "88b3aab0afc175a211130d895cedd7e7fae28b4a",
+      "branches": {
+        "master": "88b3aab0afc175a211130d895cedd7e7fae28b4a"
+      }
+    },
+    "deceius/shagutweaks": {
+      "default_branch": "master",
+      "sha": "1ee005adeadc311618695c16cfac9de9f51c2288",
+      "branches": {
+        "master": "1ee005adeadc311618695c16cfac9de9f51c2288"
+      }
+    },
+    "deceius/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "a34adec84b31462d63818c4570d274915a7e1dac",
+      "branches": {
+        "master": "a34adec84b31462d63818c4570d274915a7e1dac"
+      }
+    },
+    "deffar/fishingvolume": {
+      "default_branch": "main",
+      "sha": "3f7dbd522844a994f945748b5dd1f1f2aef3f3cd",
+      "branches": {
+        "main": "3f7dbd522844a994f945748b5dd1f1f2aef3f3cd"
+      }
+    },
+    "denisisk/bettercharacterstats-octowow": {
+      "default_branch": "main",
+      "sha": "3a7177253e07e5e564289a0a81c96597177879cd",
+      "branches": {
+        "main": "3a7177253e07e5e564289a0a81c96597177879cd"
+      }
+    },
+    "denniswg/betteralign": {
+      "default_branch": "master",
+      "sha": "b1ef86016dd0dee96e60870649f77b0a27a7b95e",
+      "branches": {
+        "master": "b1ef86016dd0dee96e60870649f77b0a27a7b95e"
+      },
+      "latest_tag": "1.0.0"
+    },
+    "denniswg/quickbind": {
+      "default_branch": "master",
+      "sha": "91e414ec9460db9a9ba4acb391a455b8ac814b3d",
+      "branches": {
+        "master": "91e414ec9460db9a9ba4acb391a455b8ac814b3d"
+      }
+    },
+    "denniswg/smallerrollframes": {
+      "default_branch": "master",
+      "sha": "27f8954f45eb15e671e350f4aa348366623eba23",
+      "branches": {
+        "master": "27f8954f45eb15e671e350f4aa348366623eba23"
+      }
+    },
+    "desocode/quiver": {
+      "default_branch": "yaht-feel",
+      "sha": "3e80ae9a8913249aaa8457e128e9746a8768d5e1",
+      "branches": {
+        "yaht-feel": "3e80ae9a8913249aaa8457e128e9746a8768d5e1"
+      },
+      "latest_tag": "v3.1.4-twow.1"
+    },
+    "determinedpanda/difficultbulletinboard": {
+      "default_branch": "master",
+      "sha": "6eb7629c36b3e767be1febb468ee24b30da7ff33",
+      "branches": {
+        "master": "6eb7629c36b3e767be1febb468ee24b30da7ff33"
+      },
+      "latest_tag": "V3.00"
+    },
+    "determinedpanda/safeshift-twow": {
+      "default_branch": "main",
+      "sha": "8436ae757e4405e939fe22415cf925515c5a179a",
+      "branches": {
+        "main": "8436ae757e4405e939fe22415cf925515c5a179a"
+      }
+    },
+    "diamondbond/enemyframes": {
+      "default_branch": "master",
+      "sha": "e02a66d0af5af1573bb895e9e2a75f50d7b38c08",
+      "branches": {
+        "master": "e02a66d0af5af1573bb895e9e2a75f50d7b38c08"
+      }
+    },
+    "diff3/ghost": {
+      "default_branch": "master",
+      "sha": "fd2bbd44fdf7205f92d42548c4a2a7e6f1c4eb2f",
+      "branches": {
+        "master": "fd2bbd44fdf7205f92d42548c4a2a7e6f1c4eb2f"
+      },
+      "latest_tag": "3745561"
+    },
+    "diginfotek/outfitter": {
+      "default_branch": "master",
+      "sha": "eac031d8a2ee37cbf31a55dfa9382da78f79ef60",
+      "branches": {
+        "master": "eac031d8a2ee37cbf31a55dfa9382da78f79ef60"
+      }
+    },
+    "diginfotek/simpleactionsets": {
+      "default_branch": "master",
+      "sha": "0a11689e189d0a2d7f5988d7cc477ab922027f5c",
+      "branches": {
+        "master": "0a11689e189d0a2d7f5988d7cc477ab922027f5c"
+      }
+    },
+    "diginfotek/turtlemenagerie": {
+      "default_branch": "main",
+      "sha": "23ccfde1737c5832bfd7170a711d1faf179e5235",
+      "branches": {
+        "main": "23ccfde1737c5832bfd7170a711d1faf179e5235"
+      }
+    },
+    "dimadze1337/shaguvalue": {
+      "default_branch": "master",
+      "sha": "debbde88b68a941b13a614612a7aa867cadbe542",
+      "branches": {
+        "master": "debbde88b68a941b13a614612a7aa867cadbe542"
+      }
+    },
+    "dingleshu/shaguwidget": {
+      "default_branch": "master",
+      "sha": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0",
+      "branches": {
+        "master": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0"
+      }
+    },
+    "dingleshu/turtlehcfilter": {
+      "default_branch": "main",
+      "sha": "f096c926e69c2c08a8c8afdde74f70c1863c4cfc",
+      "branches": {
+        "main": "f096c926e69c2c08a8c8afdde74f70c1863c4cfc"
+      }
+    },
+    "dirty-git/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "48cd30bff231add81b7d892b4fc1c9d40912c57e",
+      "branches": {
+        "main": "48cd30bff231add81b7d892b4fc1c9d40912c57e"
+      }
+    },
+    "distrattos/mendeleev": {
+      "default_branch": "main",
+      "sha": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a",
+      "branches": {
+        "main": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a"
+      }
+    },
+    "distrattos/reciperadar-vanilla": {
+      "default_branch": "master",
+      "sha": "db200dae1f2d349e8f3fba83188e3950c73307af",
+      "branches": {
+        "master": "db200dae1f2d349e8f3fba83188e3950c73307af"
+      }
+    },
+    "distrattos/shagujunk": {
+      "default_branch": "master",
+      "sha": "49e0b66b6d52fb4e085e2c11ff7fcb469cb52d8b",
+      "branches": {
+        "master": "49e0b66b6d52fb4e085e2c11ff7fcb469cb52d8b"
+      }
+    },
+    "distrattos/wowluavanilla": {
+      "default_branch": "master",
+      "sha": "be006cbbcd6fbf5dcaf769dd300168389225604b",
+      "branches": {
+        "master": "be006cbbcd6fbf5dcaf769dd300168389225604b"
+      }
+    },
+    "djramsey01/raidorganizer": {
+      "default_branch": "master",
+      "sha": "efca3a7567a20f72152c933d924d54e7ac5cdda3",
+      "branches": {
+        "master": "efca3a7567a20f72152c933d924d54e7ac5cdda3"
+      },
+      "latest_tag": "v0.9.920"
+    },
+    "dnkrse/turtlehonorspyenhanced": {
+      "default_branch": "master",
+      "sha": "0ced057f763eb1097a9d96297f530d4c613cfa97",
+      "branches": {
+        "master": "0ced057f763eb1097a9d96297f530d4c613cfa97"
+      }
+    },
+    "dogmax/damagemeters": {
+      "default_branch": "main",
+      "sha": "4b42534ff9c80b128d5830985c812ea08e77e267",
+      "branches": {
+        "main": "4b42534ff9c80b128d5830985c812ea08e77e267"
+      }
+    },
+    "dogmax/moduicombattextstandalone": {
+      "default_branch": "main",
+      "sha": "0a92ff158429c04d55404e3350225618c9f56dee",
+      "branches": {
+        "main": "0a92ff158429c04d55404e3350225618c9f56dee"
+      }
+    },
+    "dogmax/shardcap": {
+      "default_branch": "main",
+      "sha": "20dd94969c42f3baa4bd5133ca841e8cc58ed932",
+      "branches": {
+        "main": "20dd94969c42f3baa4bd5133ca841e8cc58ed932"
+      }
+    },
+    "dogmax/toxictagger": {
+      "default_branch": "master",
+      "sha": "f2b751d9216b9a10b050aa529dd92fc4aad3376a",
+      "branches": {
+        "master": "f2b751d9216b9a10b050aa529dd92fc4aad3376a"
+      }
+    },
+    "doitsujin/dxvk": {
+      "default_branch": "master",
+      "sha": "d7ac2580aa274a14a500e74edbe4ec6aae250e4a",
+      "branches": {
+        "master": "d7ac2580aa274a14a500e74edbe4ec6aae250e4a"
+      },
+      "latest_tag": "v3.1"
+    },
+    "donneyluck/wiiiui": {
+      "default_branch": "master",
+      "sha": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600",
+      "branches": {
+        "master": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600"
+      }
+    },
     "donutsdelivery/vanillaguide-plus": {
       "default_branch": "main",
       "sha": "f0a9fb6330c46fe175043f1afc64627fbdb4d3b2",
@@ -7943,63 +3319,1030 @@
         "main": "f0a9fb6330c46fe175043f1afc64627fbdb4d3b2"
       }
     },
-    "nostalgiageek/vanillaguide-plus": {
-      "default_branch": "main",
-      "sha": "104c357e70111433318e11c9f5943ac6b8bd8a43",
-      "branches": {
-        "main": "104c357e70111433318e11c9f5943ac6b8bd8a43"
-      }
-    },
-    "theunprofessionalgamer/vanillaguide": {
-      "default_branch": "main",
-      "sha": "3c839a71607ad6957a5766333ab3e844edf7db40",
-      "branches": {
-        "main": "3c839a71607ad6957a5766333ab3e844edf7db40"
-      }
-    },
-    "jeromem/vanillaguidereloaded": {
+    "doorknob6/inspector": {
       "default_branch": "master",
-      "sha": "9309495f06cde851461f71d068f7f29c0014db9c",
+      "sha": "3298d70752b60475ad611242a7030c0bbacb02df",
       "branches": {
-        "master": "9309495f06cde851461f71d068f7f29c0014db9c"
+        "master": "3298d70752b60475ad611242a7030c0bbacb02df"
+      }
+    },
+    "doorknob6/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "4cba1b4e07a70b0c3a53122016c25cd9745bec7a",
+      "branches": {
+        "master": "4cba1b4e07a70b0c3a53122016c25cd9745bec7a"
+      }
+    },
+    "dragos-dijmarescu/rank14lossa": {
+      "default_branch": "master",
+      "sha": "b1bad3409f185fc96cb59ddd38e028f31490b7ba",
+      "branches": {
+        "master": "b1bad3409f185fc96cb59ddd38e028f31490b7ba"
+      }
+    },
+    "dragosdijmarescu/totemtimers-enhanced": {
+      "default_branch": "master",
+      "sha": "a4107a83a4f557bced0c00d592a79e8e1abc475b",
+      "branches": {
+        "master": "a4107a83a4f557bced0c00d592a79e8e1abc475b"
       },
-      "latest_tag": "v2.0.3"
+      "latest_tag": "1.3"
     },
-    "blehz-be/vanillaguidereloaded": {
-      "default_branch": "master",
-      "sha": "e80f1dfb76609d75ad493cb21514dd7798b07f79",
+    "draiscor/fishswap": {
+      "default_branch": "main",
+      "sha": "d502d96cf1037785649476807df4a6bc79c26d15",
       "branches": {
-        "master": "e80f1dfb76609d75ad493cb21514dd7798b07f79"
-      }
-    },
-    "kxseven/vanillaratingbuster": {
-      "default_branch": "master",
-      "sha": "d1c4df6a3a2f59e5a0c794f600090bfe55078818",
-      "branches": {
-        "master": "d1c4df6a3a2f59e5a0c794f600090bfe55078818"
+        "main": "d502d96cf1037785649476807df4a6bc79c26d15"
       },
-      "latest_tag": "0.13"
+      "latest_tag": "v1.1"
     },
-    "thezephyrsong/vanillaratingbuster": {
+    "drakensangs/modernmapmarkers-vanilla": {
       "default_branch": "master",
-      "sha": "4843891d684f63193b734e4d5c508498848f313d",
+      "sha": "ccb00b4bf87e57f47dbdb60964ddfbfc9edd8984",
       "branches": {
-        "master": "4843891d684f63193b734e4d5c508498848f313d"
+        "master": "ccb00b4bf87e57f47dbdb60964ddfbfc9edd8984"
+      },
+      "latest_tag": "1.65"
+    },
+    "dreaming-possum/recap": {
+      "default_branch": "master",
+      "sha": "c20ddb525c45e98be6cd7e6418e7ed3a19f272bf",
+      "branches": {
+        "master": "c20ddb525c45e98be6cd7e6418e7ed3a19f272bf"
       }
     },
-    "otari98/vf_warrioraddon": {
+    "drepetsky/cursive": {
       "default_branch": "master",
-      "sha": "fa9a2932ebf1ea10900a70323d5aa53eb565decd",
+      "sha": "f321bb678b757a3a619d5466b8a0906ec8f91234",
       "branches": {
-        "master": "fa9a2932ebf1ea10900a70323d5aa53eb565decd"
+        "master": "f321bb678b757a3a619d5466b8a0906ec8f91234"
       }
     },
-    "krautchanpro/vf_tankaddon": {
+    "drepetsky/enginventory": {
       "default_branch": "master",
-      "sha": "b39c7bee4a7750c578b0dc0eaadebef0dbd6e75b",
+      "sha": "a3f0355d2b52c09ac9d5b30d61e762d7ab70c35a",
       "branches": {
-        "master": "b39c7bee4a7750c578b0dc0eaadebef0dbd6e75b"
+        "master": "a3f0355d2b52c09ac9d5b30d61e762d7ab70c35a"
       }
+    },
+    "drepetsky/shootyepgp": {
+      "default_branch": "master",
+      "sha": "64826eac4ace616ad9a2b0d56594fa384fc791ea",
+      "branches": {
+        "master": "64826eac4ace616ad9a2b0d56594fa384fc791ea"
+      }
+    },
+    "dromida/monkeyspeed": {
+      "default_branch": "main",
+      "sha": "f2e45caf16b40e24e971b0bda81d466f381ab5c1",
+      "branches": {
+        "main": "f2e45caf16b40e24e971b0bda81d466f381ab5c1"
+      }
+    },
+    "dsidirop/aux-addon": {
+      "default_branch": "master",
+      "sha": "dd859a84468b8ea555ef9d14bb360b303573aec3",
+      "branches": {
+        "master": "dd859a84468b8ea555ef9d14bb360b303573aec3"
+      }
+    },
+    "dsidirop/buffblock": {
+      "default_branch": "master",
+      "sha": "1a46f7c46981718356d8e2138a666caef65cff35",
+      "branches": {
+        "master": "1a46f7c46981718356d8e2138a666caef65cff35"
+      }
+    },
+    "dsidirop/cernieswonderfulfunctions": {
+      "default_branch": "master",
+      "sha": "da7a16caa7e1b567f749e18f4b470b7155f461f8",
+      "branches": {
+        "master": "da7a16caa7e1b567f749e18f4b470b7155f461f8"
+      },
+      "latest_tag": "v01.10.01.00"
+    },
+    "dsidirop/mousehighlightcircle": {
+      "default_branch": "main",
+      "sha": "95c3b2e0c53fe98f13d8b005b59955fd7f1fc381",
+      "branches": {
+        "main": "95c3b2e0c53fe98f13d8b005b59955fd7f1fc381"
+      },
+      "latest_tag": "v02.00.00.00"
+    },
+    "dsidirop/outfitter": {
+      "default_branch": "master",
+      "sha": "e6827a55d07a4a06b9df9e879ed6c0862badec79",
+      "branches": {
+        "master": "e6827a55d07a4a06b9df9e879ed6c0862badec79"
+      }
+    },
+    "dsidirop/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "0bb7c903060339c08979d24a713c9f6fa2744ca1",
+      "branches": {
+        "master": "0bb7c903060339c08979d24a713c9f6fa2744ca1"
+      }
+    },
+    "dsidirop/simpleraidtargeticons": {
+      "default_branch": "master",
+      "sha": "6432ff69ed55a0e761bb54856840c4f27a6b79f3",
+      "branches": {
+        "master": "6432ff69ed55a0e761bb54856840c4f27a6b79f3"
+      }
+    },
+    "dsidirop/smarthealer": {
+      "default_branch": "master",
+      "sha": "fe83d70a9dc8dec8642573c70e900ee374b794ad",
+      "branches": {
+        "master": "fe83d70a9dc8dec8642573c70e900ee374b794ad"
+      },
+      "latest_tag": "v001.02.01.00"
+    },
+    "dsidirop/turtlemail": {
+      "default_branch": "master",
+      "sha": "010332eb25382cb3dbba2a573c8a808e9dee9d0a",
+      "branches": {
+        "master": "010332eb25382cb3dbba2a573c8a808e9dee9d0a"
+      }
+    },
+    "dudusandsten/hotbotpanel": {
+      "default_branch": "master",
+      "sha": "37bfac2799975c6d9902a4f7b252cc1c7abb8836",
+      "branches": {
+        "master": "37bfac2799975c6d9902a4f7b252cc1c7abb8836"
+      },
+      "latest_tag": "1"
+    },
+    "dudusandsten/nbr": {
+      "default_branch": "master",
+      "sha": "074e06d2191380deec3758a10da3cf54b36c2eb5",
+      "branches": {
+        "master": "074e06d2191380deec3758a10da3cf54b36c2eb5"
+      }
+    },
+    "duke690/ringmenu": {
+      "default_branch": "master",
+      "sha": "23db580b0ddc04b8650afdf50179302fbb67128f",
+      "branches": {
+        "master": "23db580b0ddc04b8650afdf50179302fbb67128f"
+      }
+    },
+    "dusk-92/deathlog_vanilla": {
+      "default_branch": "main",
+      "sha": "81e28be99cd026f17d79fa97693899128136095e",
+      "branches": {
+        "main": "81e28be99cd026f17d79fa97693899128136095e"
+      }
+    },
+    "dusk-92/levelrange-octo": {
+      "default_branch": "main",
+      "sha": "fa21fb38cd47454aad65cf8ab53ea5c2f488a8c7",
+      "branches": {
+        "main": "fa21fb38cd47454aad65cf8ab53ea5c2f488a8c7"
+      },
+      "latest_tag": "2.3.1"
+    },
+    "dusk-92/shagutweaks-classicapi": {
+      "default_branch": "main",
+      "sha": "35a26562d0972903b31904a4281965464f70481d",
+      "branches": {
+        "main": "35a26562d0972903b31904a4281965464f70481d"
+      }
+    },
+    "dusk-92/turtlemail": {
+      "default_branch": "master",
+      "sha": "6f41c63922fc5f3314a7a3330fe2e0a57039fd57",
+      "branches": {
+        "master": "6f41c63922fc5f3314a7a3330fe2e0a57039fd57"
+      }
+    },
+    "dusk-92/wowradio-vanilla": {
+      "default_branch": "main",
+      "sha": "e13ebc19d638ab5088fbfc864500f62f72f8aabc",
+      "branches": {
+        "main": "e13ebc19d638ab5088fbfc864500f62f72f8aabc"
+      }
+    },
+    "duvelcorp/metahunt": {
+      "default_branch": "master",
+      "sha": "270da5ab65180a01bfd24f59d126c1e32e06204c",
+      "branches": {
+        "master": "270da5ab65180a01bfd24f59d126c1e32e06204c"
+      },
+      "latest_tag": "v1.5.1"
+    },
+    "duzga/sellvalue": {
+      "default_branch": "master",
+      "sha": "3294787b7bfec725b221177d2685812f95bd85cb",
+      "branches": {
+        "master": "3294787b7bfec725b221177d2685812f95bd85cb"
+      }
+    },
+    "duzga/shagukill": {
+      "default_branch": "master",
+      "sha": "ea7777383aa43e3c87ef293b61d72a4c75d3a641",
+      "branches": {
+        "master": "ea7777383aa43e3c87ef293b61d72a4c75d3a641"
+      }
+    },
+    "dvmanlosa/pfquest-turtle": {
+      "default_branch": "main",
+      "sha": "a7c46448204a8d6d59cf29adec8fb67c6a4cfc97",
+      "branches": {
+        "main": "a7c46448204a8d6d59cf29adec8fb67c6a4cfc97"
+      }
+    },
+    "dvmanlosa/shaguplates": {
+      "default_branch": "master",
+      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
+      "branches": {
+        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
+      }
+    },
+    "dwbclz/cartographer": {
+      "default_branch": "master",
+      "sha": "9b2997bf85f2758e9d3a94028fa0ad158b001245",
+      "branches": {
+        "master": "9b2997bf85f2758e9d3a94028fa0ad158b001245"
+      }
+    },
+    "dwbclz/pfquest-icons": {
+      "default_branch": "master",
+      "sha": "709ba275b7198b93713b5b06cf896dc9006ebeea",
+      "branches": {
+        "master": "709ba275b7198b93713b5b06cf896dc9006ebeea"
+      }
+    },
+    "dwbclz/pfstudio": {
+      "default_branch": "master",
+      "sha": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78",
+      "branches": {
+        "master": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78"
+      }
+    },
+    "dwbclz/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
+      "branches": {
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
+      }
+    },
+    "dwbclz/shaguactions": {
+      "default_branch": "master",
+      "sha": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8",
+      "branches": {
+        "master": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8"
+      }
+    },
+    "dwbclz/shagubop": {
+      "default_branch": "master",
+      "sha": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9",
+      "branches": {
+        "master": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9"
+      }
+    },
+    "dwbclz/shaguchat": {
+      "default_branch": "master",
+      "sha": "01c37853c5e714b218837d24932c316f68b2728f",
+      "branches": {
+        "master": "01c37853c5e714b218837d24932c316f68b2728f"
+      }
+    },
+    "dwbclz/shagucopy": {
+      "default_branch": "master",
+      "sha": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182",
+      "branches": {
+        "master": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182"
+      }
+    },
+    "dwbclz/shagudps": {
+      "default_branch": "master",
+      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
+      "branches": {
+        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
+      }
+    },
+    "dwbclz/shagujunk": {
+      "default_branch": "master",
+      "sha": "9a91065d8ef9078a9ea8b7d254e88605e8367567",
+      "branches": {
+        "master": "9a91065d8ef9078a9ea8b7d254e88605e8367567"
+      }
+    },
+    "dwbclz/shagukill": {
+      "default_branch": "master",
+      "sha": "498e2db84d2d666717d04538641add7ebca967cd",
+      "branches": {
+        "master": "498e2db84d2d666717d04538641add7ebca967cd"
+      }
+    },
+    "dwbclz/shagunotify": {
+      "default_branch": "master",
+      "sha": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49",
+      "branches": {
+        "master": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49"
+      }
+    },
+    "dwbclz/shaguplates": {
+      "default_branch": "master",
+      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
+      "branches": {
+        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
+      }
+    },
+    "dwbclz/shaguscore": {
+      "default_branch": "master",
+      "sha": "b07d25e6a1fa30391d9dca0dd728e33a762c6711",
+      "branches": {
+        "master": "b07d25e6a1fa30391d9dca0dd728e33a762c6711"
+      }
+    },
+    "dwbclz/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
+      "branches": {
+        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
+      }
+    },
+    "dwbclz/shaguvalue": {
+      "default_branch": "master",
+      "sha": "debbde88b68a941b13a614612a7aa867cadbe542",
+      "branches": {
+        "master": "debbde88b68a941b13a614612a7aa867cadbe542"
+      }
+    },
+    "dwbclz/shaguwidget": {
+      "default_branch": "master",
+      "sha": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0",
+      "branches": {
+        "master": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0"
+      }
+    },
+    "dyaxler/blizzmo_vanilla": {
+      "default_branch": "master",
+      "sha": "f599a4c80b80ca2eda534d12934aefb90bd52386",
+      "branches": {
+        "master": "f599a4c80b80ca2eda534d12934aefb90bd52386"
+      },
+      "latest_tag": "v0.1"
+    },
+    "dyaxler/spartanui_vanilla": {
+      "default_branch": "master",
+      "sha": "0e19353f1b689e83bb658e16b494ea16384454a7",
+      "branches": {
+        "master": "0e19353f1b689e83bb658e16b494ea16384454a7"
+      },
+      "latest_tag": "0.9.6.3"
+    },
+    "dyzlexik/quiver": {
+      "default_branch": "main",
+      "sha": "109108a10dc94a3905b26158c783623d5e426cc6",
+      "branches": {
+        "main": "109108a10dc94a3905b26158c783623d5e426cc6"
+      },
+      "latest_tag": "v3.1.4"
+    },
+    "e-oven/kethodoc": {
+      "default_branch": "master",
+      "sha": "b7756d1395867ef87aa4f73d1a63443bc1510651",
+      "branches": {
+        "master": "b7756d1395867ef87aa4f73d1a63443bc1510651"
+      }
+    },
+    "e-oven/wowluavanilla": {
+      "default_branch": "master",
+      "sha": "be006cbbcd6fbf5dcaf769dd300168389225604b",
+      "branches": {
+        "master": "be006cbbcd6fbf5dcaf769dd300168389225604b"
+      }
+    },
+    "ebedanostalrius/fubar_zepmaster": {
+      "default_branch": "master",
+      "sha": "ddf6a5042ef9131dae9ffebe1fe0757253f590e9",
+      "branches": {
+        "master": "ddf6a5042ef9131dae9ffebe1fe0757253f590e9"
+      }
+    },
+    "edanmelar/rat-turtlewow": {
+      "default_branch": "TurtleWoW",
+      "sha": "6c1e289e6d83bce5854d1040b53ddb920deb82f1",
+      "branches": {
+        "TurtleWoW": "6c1e289e6d83bce5854d1040b53ddb920deb82f1"
+      },
+      "latest_tag": "1.10.3"
+    },
+    "edgeofmagic/roid-macros": {
+      "default_branch": "master",
+      "sha": "7f1d3d80c6e7c9866a07e634dea44ebce05342e8",
+      "branches": {
+        "master": "7f1d3d80c6e7c9866a07e634dea44ebce05342e8"
+      }
+    },
+    "eickhardt/cursive": {
+      "default_branch": "master",
+      "sha": "f077efeb9a500d82209fa1bb2a31f1f7009e7263",
+      "branches": {
+        "master": "f077efeb9a500d82209fa1bb2a31f1f7009e7263"
+      }
+    },
+    "einbaum/_autobg": {
+      "default_branch": "master",
+      "sha": "55899bc3aa9acc1e6659e7481ea4f5e424534cc4",
+      "branches": {
+        "master": "55899bc3aa9acc1e6659e7481ea4f5e424534cc4"
+      },
+      "latest_tag": "1.0.0"
+    },
+    "einbaum/announcekick": {
+      "default_branch": "master",
+      "sha": "95e17fc04b70eb48cee7051ff2d739927c0eaafb",
+      "branches": {
+        "master": "95e17fc04b70eb48cee7051ff2d739927c0eaafb"
+      },
+      "latest_tag": "1.0.0"
+    },
+    "einbaum/auctionaltbuy": {
+      "default_branch": "master",
+      "sha": "dca00f12e9a9290b6de5dc48de25a2ee018db7ab",
+      "branches": {
+        "master": "dca00f12e9a9290b6de5dc48de25a2ee018db7ab"
+      },
+      "latest_tag": "1.0.0"
+    },
+    "einbaum/auctionhelper": {
+      "default_branch": "master",
+      "sha": "09998b7d22ec2916826cf8e0eaf2fcce2e2863f8",
+      "branches": {
+        "master": "09998b7d22ec2916826cf8e0eaf2fcce2e2863f8"
+      }
+    },
+    "einbaum/auctionsearchtimer": {
+      "default_branch": "master",
+      "sha": "639a5b7765a6d3d1bb18a8e053865401e0493f89",
+      "branches": {
+        "master": "639a5b7765a6d3d1bb18a8e053865401e0493f89"
+      }
+    },
+    "einbaum/autohump": {
+      "default_branch": "master",
+      "sha": "f0df86e776daffa250f3e67b073e209d9eab8209",
+      "branches": {
+        "master": "f0df86e776daffa250f3e67b073e209d9eab8209"
+      }
+    },
+    "einbaum/chroniclesbuffassignments": {
+      "default_branch": "master",
+      "sha": "996ef976bd97c3312bcdb7656c330ef0c95ce7c1",
+      "branches": {
+        "master": "996ef976bd97c3312bcdb7656c330ef0c95ce7c1"
+      },
+      "latest_tag": "1.0.0"
+    },
+    "einbaum/chroniclespi": {
+      "default_branch": "master",
+      "sha": "fca0da346c4f91f50b7a5b44f72ced84b68dd6dd",
+      "branches": {
+        "master": "fca0da346c4f91f50b7a5b44f72ced84b68dd6dd"
+      },
+      "latest_tag": "1.2.0"
+    },
+    "einbaum/chroniclesptr": {
+      "default_branch": "master",
+      "sha": "027d1dc67cdbaf5a4f10fcba504911eeaba8c0f5",
+      "branches": {
+        "master": "027d1dc67cdbaf5a4f10fcba504911eeaba8c0f5"
+      }
+    },
+    "einbaum/disableescape": {
+      "default_branch": "master",
+      "sha": "14e12e29dfc4512c4d95d623eb02c41ee6c902b1",
+      "branches": {
+        "master": "14e12e29dfc4512c4d95d623eb02c41ee6c902b1"
+      },
+      "latest_tag": "1.0.0"
+    },
+    "einbaum/keyringopener": {
+      "default_branch": "master",
+      "sha": "40511af0a994ae284f5057e3cfe3bdee8b41b4ae",
+      "branches": {
+        "master": "40511af0a994ae284f5057e3cfe3bdee8b41b4ae"
+      }
+    },
+    "einbaum/mail": {
+      "default_branch": "master",
+      "sha": "59c04a41ea4110cd098cc6dddb6799be6edb5892",
+      "branches": {
+        "master": "59c04a41ea4110cd098cc6dddb6799be6edb5892"
+      }
+    },
+    "einbaum/maptarget": {
+      "default_branch": "master",
+      "sha": "8d2939ad8fbcc954a2f98e3c9f02110572c8d204",
+      "branches": {
+        "master": "8d2939ad8fbcc954a2f98e3c9f02110572c8d204"
+      },
+      "latest_tag": "2.1"
+    },
+    "einbaum/raidrollhelper": {
+      "default_branch": "master",
+      "sha": "e1caf2c3bfd343f96f8ea3bc114c162a7545fa0a",
+      "branches": {
+        "master": "e1caf2c3bfd343f96f8ea3bc114c162a7545fa0a"
+      },
+      "latest_tag": "1.0"
+    },
+    "einbaum/rezztimer": {
+      "default_branch": "master",
+      "sha": "b649787a3ec103fbc4d55b2b9d0b80d81bfc3d29",
+      "branches": {
+        "master": "b649787a3ec103fbc4d55b2b9d0b80d81bfc3d29"
+      },
+      "latest_tag": "1.0.0"
+    },
+    "einbaum/skmap": {
+      "default_branch": "master",
+      "sha": "bd4301fbd47e76baa482e48345e63f2832f451f9",
+      "branches": {
+        "master": "bd4301fbd47e76baa482e48345e63f2832f451f9"
+      }
+    },
+    "einbaum/sp_overpower": {
+      "default_branch": "master",
+      "sha": "9e09e73604140a65a5c5cc141377c2310b7e90a6",
+      "branches": {
+        "master": "9e09e73604140a65a5c5cc141377c2310b7e90a6"
+      },
+      "latest_tag": "3.0.0"
+    },
+    "einbaum/tinytip": {
+      "default_branch": "master",
+      "sha": "c4f4947afc7d907033010ec05d46be14d28ed87b",
+      "branches": {
+        "master": "c4f4947afc7d907033010ec05d46be14d28ed87b"
+      }
+    },
+    "einbaum/vendorautobuy": {
+      "default_branch": "master",
+      "sha": "0e82fb2facfb5ab7e3ddaa28c5d9f1f6f81c9532",
+      "branches": {
+        "master": "0e82fb2facfb5ab7e3ddaa28c5d9f1f6f81c9532"
+      },
+      "latest_tag": "1.0.0"
+    },
+    "einbaum/xfactionchat": {
+      "default_branch": "master",
+      "sha": "22a07d52979359792dafd721c1d9e7d1aa7d57fc",
+      "branches": {
+        "master": "22a07d52979359792dafd721c1d9e7d1aa7d57fc"
+      }
+    },
+    "einherjarn/bgflag": {
+      "default_branch": "master",
+      "sha": "043bb62a22f27f32a0095950b5df65ed52eda218",
+      "branches": {
+        "master": "043bb62a22f27f32a0095950b5df65ed52eda218"
+      }
+    },
+    "einherjarn/ct_mailmod": {
+      "default_branch": "master",
+      "sha": "4b51c285a48dd9a64f2a962781e4a45a98f22b0e",
+      "branches": {
+        "master": "4b51c285a48dd9a64f2a962781e4a45a98f22b0e"
+      }
+    },
+    "elboaf/ppbuddy": {
+      "default_branch": "main",
+      "sha": "3f1ac235717464a176eed5e320118d8666945ef5",
+      "branches": {
+        "main": "3f1ac235717464a176eed5e320118d8666945ef5"
+      }
+    },
+    "elboaf/supertotem": {
+      "default_branch": "main",
+      "sha": "936405bfe7931e7368f39e3e14e3c9cb807127ce",
+      "branches": {
+        "main": "936405bfe7931e7368f39e3e14e3c9cb807127ce"
+      }
+    },
+    "elesionwow/bigwigs": {
+      "default_branch": "master",
+      "sha": "47b538024cf127346d624ba7b21a8aff56cb4587",
+      "branches": {
+        "master": "47b538024cf127346d624ba7b21a8aff56cb4587"
+      }
+    },
+    "ellugia/whohas": {
+      "default_branch": "master",
+      "sha": "a77a747ea2e2c41c10b2e7d2752ececd96581b1d",
+      "branches": {
+        "master": "a77a747ea2e2c41c10b2e7d2752ececd96581b1d"
+      }
+    },
+    "email2340x5-byte/easypoisons": {
+      "default_branch": "main",
+      "sha": "7c79f964118995c4cd7874704f561488cb02e2ce",
+      "branches": {
+        "main": "7c79f964118995c4cd7874704f561488cb02e2ce"
+      }
+    },
+    "empty1021/shagudps": {
+      "default_branch": "master",
+      "sha": "2268b73f908fdfa8b6272ae05c66e961f6671576",
+      "branches": {
+        "master": "2268b73f908fdfa8b6272ae05c66e961f6671576"
+      }
+    },
+    "emyrk/chroniclecompanion": {
+      "default_branch": "main",
+      "sha": "36d9265604ad15baa918aeee576264962632dd47",
+      "branches": {
+        "main": "36d9265604ad15baa918aeee576264962632dd47"
+      }
+    },
+    "emyrk/shagudps": {
+      "default_branch": "master",
+      "sha": "07d74490ddfb2e71e0b114780d17ba52123ea421",
+      "branches": {
+        "master": "07d74490ddfb2e71e0b114780d17ba52123ea421"
+      }
+    },
+    "emyrk/smartbuff": {
+      "default_branch": "main",
+      "sha": "27f84d6a51d78e1060e41e63bec659ad25406da8",
+      "branches": {
+        "main": "27f84d6a51d78e1060e41e63bec659ad25406da8"
+      }
+    },
+    "enn-wow-addons/hunterswissknife": {
+      "default_branch": "master",
+      "sha": "441cae66541d9031efeb29fb899b4021a56e35b2",
+      "branches": {
+        "master": "441cae66541d9031efeb29fb899b4021a56e35b2"
+      },
+      "latest_tag": "v1.1"
+    },
+    "ennea/eui": {
+      "default_branch": "master",
+      "sha": "294d94545de5553422b3be45ca1fbb25d2f65cb0",
+      "branches": {
+        "master": "294d94545de5553422b3be45ca1fbb25d2f65cb0"
+      },
+      "latest_tag": "v1.0"
+    },
+    "epitaque/threat": {
+      "default_branch": "master",
+      "sha": "8050803ad8271747b9c109641982a9d6e724e4b7",
+      "branches": {
+        "master": "8050803ad8271747b9c109641982a9d6e724e4b7"
+      }
+    },
+    "eqomdx/atlas-cfm-destinationclick": {
+      "default_branch": "main",
+      "sha": "9d92e187cb327290feccf55542d5d3e05215a2e2",
+      "branches": {
+        "main": "9d92e187cb327290feccf55542d5d3e05215a2e2"
+      }
+    },
+    "eqomdx/equadisthreatmeter": {
+      "default_branch": "main",
+      "sha": "a82bc8be2a213ac5f752ba4ec929d336c075c193",
+      "branches": {
+        "main": "a82bc8be2a213ac5f752ba4ec929d336c075c193"
+      }
+    },
+    "eqomdx/equadisunitframes": {
+      "default_branch": "main",
+      "sha": "9a9d40a078f4d19e1f2c53e46bd25e4a37eecd08",
+      "branches": {
+        "main": "9a9d40a078f4d19e1f2c53e46bd25e4a37eecd08"
+      }
+    },
+    "eqomdx/shaguplates-fixes": {
+      "default_branch": "master",
+      "sha": "fcb999672bb3b7581e91936163df8a3782f326ec",
+      "branches": {
+        "master": "fcb999672bb3b7581e91936163df8a3782f326ec"
+      }
+    },
+    "eqomdx/supercleveroidmacros": {
+      "default_branch": "main",
+      "sha": "102c5a5a4c4a6dd191516ebae55f29b25d283079",
+      "branches": {
+        "main": "102c5a5a4c4a6dd191516ebae55f29b25d283079"
+      }
+    },
+    "erea-turtle-addons/erea-rp-addons": {
+      "default_branch": "main",
+      "sha": "36a58f2899b16163b487343c3c39725d350ceb6e",
+      "branches": {
+        "main": "36a58f2899b16163b487343c3c39725d350ceb6e"
+      },
+      "latest_tag": "1.0.9"
+    },
+    "ericraio/vanilla-wow-addons": {
+      "default_branch": "master",
+      "sha": "238c6d633d5a5b8a0cc4ee7a8cbb548ea80da081",
+      "branches": {
+        "master": "238c6d633d5a5b8a0cc4ee7a8cbb548ea80da081"
+      }
+    },
+    "ericschn/onlyascii": {
+      "default_branch": "main",
+      "sha": "bc9e839976419db0bcc8213c432c94c8a01a6cbe",
+      "branches": {
+        "main": "bc9e839976419db0bcc8213c432c94c8a01a6cbe"
+      }
+    },
+    "erikgrav/wiiiui_for_vanilla": {
+      "default_branch": "master",
+      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
+      "branches": {
+        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
+      }
+    },
+    "eritzman/autodb": {
+      "default_branch": "main",
+      "sha": "b7784ff2b162242114c6876f4ce808f490a89008",
+      "branches": {
+        "main": "b7784ff2b162242114c6876f4ce808f490a89008"
+      }
+    },
+    "eritzman/guidelimevanilla": {
+      "default_branch": "master",
+      "sha": "5640eacebce1054c6196ea0c6ea68c52695ee7e4",
+      "branches": {
+        "master": "5640eacebce1054c6196ea0c6ea68c52695ee7e4"
+      }
+    },
+    "eritzman/levelrange-turtle": {
+      "default_branch": "main",
+      "sha": "bf1c84709fda3fc32871a2b99e4eb41f36a44e97",
+      "branches": {
+        "main": "bf1c84709fda3fc32871a2b99e4eb41f36a44e97"
+      }
+    },
+    "eritzman/simpleauras": {
+      "default_branch": "main",
+      "sha": "a4ffc609fe739d251300c7ca30c8fcabf104e38c",
+      "branches": {
+        "main": "a4ffc609fe739d251300c7ca30c8fcabf104e38c"
+      }
+    },
+    "eryzil-github/rais_autoshot": {
+      "default_branch": "master",
+      "sha": "b2aca3d80423e71d661afb232a6f46611b10a237",
+      "branches": {
+        "master": "b2aca3d80423e71d661afb232a6f46611b10a237"
+      }
+    },
+    "esco-twow/outfitter": {
+      "default_branch": "master",
+      "sha": "1662b8280a79a3065646eb5680eeaf069632c155",
+      "branches": {
+        "master": "1662b8280a79a3065646eb5680eeaf069632c155"
+      }
+    },
+    "esliwka/puppeteer": {
+      "default_branch": "main",
+      "sha": "7fa9db6cc1032852733c0dbf77693c881719dbfd",
+      "branches": {
+        "main": "7fa9db6cc1032852733c0dbf77693c881719dbfd"
+      }
+    },
+    "esqariote/lazyscript": {
+      "default_branch": "master",
+      "sha": "9628d33fb535a08b39cf4b3d86a06861f0405bb8",
+      "branches": {
+        "master": "9628d33fb535a08b39cf4b3d86a06861f0405bb8"
+      }
+    },
+    "esqariote/rabuffs": {
+      "default_branch": "master",
+      "sha": "d9c30685fc780903cf31ee585c53ef93c736fdca",
+      "branches": {
+        "master": "d9c30685fc780903cf31ee585c53ef93c736fdca"
+      }
+    },
+    "evannnn1996/accountant": {
+      "default_branch": "main",
+      "sha": "1e2bc02396eebafd5e1e2e3720e3cae1bcdf47f7",
+      "branches": {
+        "main": "1e2bc02396eebafd5e1e2e3720e3cae1bcdf47f7"
+      }
+    },
+    "evannnn1996/chatbar": {
+      "default_branch": "master",
+      "sha": "4570e5aad1d860ed3a8e6267d26ec71ad82487f9",
+      "branches": {
+        "master": "4570e5aad1d860ed3a8e6267d26ec71ad82487f9"
+      }
+    },
+    "evannnn1996/cursive": {
+      "default_branch": "master",
+      "sha": "e8d46dff3de8ae14fca72c68766862e32892c6c1",
+      "branches": {
+        "master": "e8d46dff3de8ae14fca72c68766862e32892c6c1"
+      }
+    },
+    "evannnn1996/dialogui": {
+      "default_branch": "main",
+      "sha": "df8d33e2fb3f8aff1425ec021528b2d00a925bfb",
+      "branches": {
+        "main": "df8d33e2fb3f8aff1425ec021528b2d00a925bfb"
+      }
+    },
+    "evannnn1996/ezpoison": {
+      "default_branch": "main",
+      "sha": "9732ded02e74e80de57535af8da8ada4d4840ede",
+      "branches": {
+        "main": "9732ded02e74e80de57535af8da8ada4d4840ede"
+      }
+    },
+    "evannnn1996/flighttracker": {
+      "default_branch": "main",
+      "sha": "046c6e63ae9b123d7c07874d8437176054f598da",
+      "branches": {
+        "main": "046c6e63ae9b123d7c07874d8437176054f598da"
+      }
+    },
+    "evannnn1996/modernmapmarkers": {
+      "default_branch": "main",
+      "sha": "5311be6a24979d4119ed59e9f48f90beb41ecfb4",
+      "branches": {
+        "main": "5311be6a24979d4119ed59e9f48f90beb41ecfb4"
+      }
+    },
+    "evannnn1996/outfitter": {
+      "default_branch": "master",
+      "sha": "74a833699b3a3a6f54cc3f3049e28162c01a34d0",
+      "branches": {
+        "master": "74a833699b3a3a6f54cc3f3049e28162c01a34d0"
+      }
+    },
+    "evannnn1996/pfquest-turtle": {
+      "default_branch": "master",
+      "sha": "0f8a218f5aeb76cc74661a659ca17ef8dd7eb19f",
+      "branches": {
+        "master": "0f8a218f5aeb76cc74661a659ca17ef8dd7eb19f"
+      }
+    },
+    "evannnn1996/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "88fe8e3a533817c4a8c591c30454cecb02b18e14",
+      "branches": {
+        "main": "88fe8e3a533817c4a8c591c30454cecb02b18e14"
+      }
+    },
+    "evannnn1996/pfui-weakicons": {
+      "default_branch": "master",
+      "sha": "fe59bea6e70ef6ec54a1f84c914d070cdea065c8",
+      "branches": {
+        "master": "fe59bea6e70ef6ec54a1f84c914d070cdea065c8"
+      }
+    },
+    "evannnn1996/questrepeat": {
+      "default_branch": "master",
+      "sha": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf",
+      "branches": {
+        "master": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf"
+      }
+    },
+    "evannnn1996/rinse": {
+      "default_branch": "master",
+      "sha": "857fad999ebac1286ddc965420e4a41d831ff305",
+      "branches": {
+        "master": "857fad999ebac1286ddc965420e4a41d831ff305"
+      }
+    },
+    "evannnn1996/shaguchat": {
+      "default_branch": "master",
+      "sha": "01c37853c5e714b218837d24932c316f68b2728f",
+      "branches": {
+        "master": "01c37853c5e714b218837d24932c316f68b2728f"
+      }
+    },
+    "evannnn1996/shagudps": {
+      "default_branch": "master",
+      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
+      "branches": {
+        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
+      }
+    },
+    "evannnn1996/simpleactionsets": {
+      "default_branch": "master",
+      "sha": "491464068d0d93ac48dce5b5cca2a9333541ead0",
+      "branches": {
+        "master": "491464068d0d93ac48dce5b5cca2a9333541ead0"
+      }
+    },
+    "evannnn1996/statcompare": {
+      "default_branch": "master",
+      "sha": "5177c91ca0b19a6b085acfe29a343fe6fa633fda",
+      "branches": {
+        "master": "5177c91ca0b19a6b085acfe29a343fe6fa633fda"
+      }
+    },
+    "evannnn1996/superapi": {
+      "default_branch": "master",
+      "sha": "f08fb758a7b97357696086a4c9c7cee7acc9a6fa",
+      "branches": {
+        "master": "f08fb758a7b97357696086a4c9c7cee7acc9a6fa"
+      }
+    },
+    "evannnn1996/turtlehonorspyenhanced": {
+      "default_branch": "master",
+      "sha": "d84c2d9550e4a672059f12a28d8678806585a844",
+      "branches": {
+        "master": "d84c2d9550e4a672059f12a28d8678806585a844"
+      }
+    },
+    "evannnn1996/turtlemail": {
+      "default_branch": "master",
+      "sha": "322429e143db1f1f00afe0d1074678a844bf8c7c",
+      "branches": {
+        "master": "322429e143db1f1f00afe0d1074678a844bf8c7c"
+      }
+    },
+    "ezhug/ezpoison-mod": {
+      "default_branch": "main",
+      "sha": "edb6b0d872d002383ddc5da86318cfa238e2209e",
+      "branches": {
+        "main": "edb6b0d872d002383ddc5da86318cfa238e2209e"
+      }
+    },
+    "falumir/nugenergy": {
+      "default_branch": "master",
+      "sha": "ecf0d4a8f3a5bb08e9d1741d9d9014420e24cda7",
+      "branches": {
+        "master": "ecf0d4a8f3a5bb08e9d1741d9d9014420e24cda7"
+      }
+    },
+    "faraso/warriorcombatmanager": {
+      "default_branch": "main",
+      "sha": "1b4f2a4d775f7035483746f9d1f294397a84a989",
+      "branches": {
+        "main": "1b4f2a4d775f7035483746f9d1f294397a84a989"
+      },
+      "latest_tag": "v0.1.0"
+    },
+    "fastbond/nbr": {
+      "default_branch": "master",
+      "sha": "13980213ecc971dd8de165d3c69acd6b8829f6e5",
+      "branches": {
+        "master": "13980213ecc971dd8de165d3c69acd6b8829f6e5"
+      }
+    },
+    "fdotcico/questprogressshare": {
+      "default_branch": "main",
+      "sha": "afbc780d394dc68131fb1244fe322f149c3ba356",
+      "branches": {
+        "main": "afbc780d394dc68131fb1244fe322f149c3ba356"
+      },
+      "latest_tag": "1.6.0"
+    },
+    "fedilious/roll-for-vanilla": {
+      "default_branch": "master",
+      "sha": "173b7758d205df42807a4dcd2d5b087c91b6ea7a",
+      "branches": {
+        "master": "173b7758d205df42807a4dcd2d5b087c91b6ea7a"
+      }
+    },
+    "fenrirjk2/roid-macros": {
+      "default_branch": "master",
+      "sha": "3ab9f9827e1798d207d6875b25b4c210a9044ab5",
+      "branches": {
+        "master": "3ab9f9827e1798d207d6875b25b4c210a9044ab5"
+      }
+    },
+    "fey/puppeteer": {
+      "default_branch": "main",
+      "sha": "7fa9db6cc1032852733c0dbf77693c881719dbfd",
+      "branches": {
+        "main": "7fa9db6cc1032852733c0dbf77693c881719dbfd"
+      },
+      "latest_tag": "v1.1.3"
+    },
+    "fhh2626/shaguscore-itemlevel": {
+      "default_branch": "master",
+      "sha": "11aa0ea1dcbef6c51534d2836741cd275d8c5eab",
+      "branches": {
+        "master": "11aa0ea1dcbef6c51534d2836741cd275d8c5eab"
+      }
+    },
+    "firenahzku/vanguardanticooldown": {
+      "default_branch": "master",
+      "sha": "f99ac37b0d858a287a7dc2b25fad043195bf92b0",
+      "branches": {
+        "master": "f99ac37b0d858a287a7dc2b25fad043195bf92b0"
+      }
+    },
+    "firenahzku/vanguardshamantools": {
+      "default_branch": "master",
+      "sha": "0b521998c335ed6933e3393ea7ee8066a987239b",
+      "branches": {
+        "master": "0b521998c335ed6933e3393ea7ee8066a987239b"
+      },
+      "latest_tag": "1.02"
     },
     "firenahzku/vgattackbar": {
       "default_branch": "master",
@@ -8015,68 +4358,130 @@
         "master": "83451262197f5a23e58ae9144cfcdc5f93ac4a64"
       }
     },
-    "zythdr/vpeddler": {
+    "firenahzku/vgsmartunbuff": {
+      "default_branch": "master",
+      "sha": "c108a72250db707e98ecccceee78da967f88a356",
+      "branches": {
+        "master": "c108a72250db707e98ecccceee78da967f88a356"
+      }
+    },
+    "fiskehatt/bearcastbar": {
+      "default_branch": "master",
+      "sha": "64944e8c4c653ae9415eae64d4024c23241416c6",
+      "branches": {
+        "master": "64944e8c4c653ae9415eae64d4024c23241416c6"
+      }
+    },
+    "fiskehatt/friendfinder": {
+      "default_branch": "master",
+      "sha": "e339f7c462e034ce49b98f5a1978b4d925cc3b4a",
+      "branches": {
+        "master": "e339f7c462e034ce49b98f5a1978b4d925cc3b4a"
+      }
+    },
+    "fiskehatt/rank14lossa": {
+      "default_branch": "master",
+      "sha": "b1bad3409f185fc96cb59ddd38e028f31490b7ba",
+      "branches": {
+        "master": "b1bad3409f185fc96cb59ddd38e028f31490b7ba"
+      }
+    },
+    "fiskehatt/saysapped": {
+      "default_branch": "master",
+      "sha": "4ace0c9bb52dfd1694ff52f798f54345e8222cf4",
+      "branches": {
+        "master": "4ace0c9bb52dfd1694ff52f798f54345e8222cf4"
+      }
+    },
+    "fiskehatt/saysapped_extended": {
+      "default_branch": "master",
+      "sha": "3eec8d18c9ddfd1087ca75b72cc198de2bd92e12",
+      "branches": {
+        "master": "3eec8d18c9ddfd1087ca75b72cc198de2bd92e12"
+      }
+    },
+    "fiurs-hearth/battlemusic": {
+      "default_branch": "master",
+      "sha": "e92c913c3366dbfb7dc5cd97c67e36dd0d4440c7",
+      "branches": {
+        "master": "e92c913c3366dbfb7dc5cd97c67e36dd0d4440c7"
+      }
+    },
+    "fiurs-hearth/wiiiui": {
+      "default_branch": "master",
+      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
+      "branches": {
+        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
+      }
+    },
+    "flaykz/cursiverevamp": {
+      "default_branch": "master",
+      "sha": "5eabc4f34105689a349c0589009c1a2f7f0e4eb5",
+      "branches": {
+        "master": "5eabc4f34105689a349c0589009c1a2f7f0e4eb5"
+      }
+    },
+    "flyinbed/gryllsswingtimer": {
       "default_branch": "main",
-      "sha": "08a8916743e3ee39c6bde5488d0f187521e1e60e",
+      "sha": "96abc780c73662726c797b72dd813c4dbd5ef48b",
       "branches": {
-        "main": "08a8916743e3ee39c6bde5488d0f187521e1e60e"
-      },
-      "latest_tag": "v1.3"
+        "main": "96abc780c73662726c797b72dd813c4dbd5ef48b"
+      }
     },
-    "goldenpipes/vpeddler": {
+    "flyinbed/shaguplates": {
+      "default_branch": "master",
+      "sha": "7f88d9a12a3d1d0df2a68d3ba94d90490d67ecd5",
+      "branches": {
+        "master": "7f88d9a12a3d1d0df2a68d3ba94d90490d67ecd5"
+      }
+    },
+    "fondlez/unicodefont": {
+      "default_branch": "master",
+      "sha": "f19092f3bf49b5303f9bba16f45d51397b610c0a",
+      "branches": {
+        "master": "f19092f3bf49b5303f9bba16f45d51397b610c0a"
+      }
+    },
+    "forbium/whisperbind": {
       "default_branch": "main",
-      "sha": "08a8916743e3ee39c6bde5488d0f187521e1e60e",
+      "sha": "d3b1472cd45b69ff77e5ae9c42a5492a5131cdd8",
       "branches": {
-        "main": "08a8916743e3ee39c6bde5488d0f187521e1e60e"
+        "main": "d3b1472cd45b69ff77e5ae9c42a5492a5131cdd8"
       }
     },
-    "cernie/warriortank": {
-      "default_branch": "master",
-      "sha": "0e1dfdb342b6e5c3e38e63d487eb9270c4be580c",
-      "branches": {
-        "master": "0e1dfdb342b6e5c3e38e63d487eb9270c4be580c"
-      }
-    },
-    "jakebergeron/warriortank": {
-      "default_branch": "master",
-      "sha": "120a3bf3703691113cf3439b2d94cb83c08da47b",
-      "branches": {
-        "master": "120a3bf3703691113cf3439b2d94cb83c08da47b"
-      }
-    },
-    "goose404/warriortweaks": {
+    "fox2k7/bananarepublicprofs": {
       "default_branch": "main",
-      "sha": "21fdef525dc6fb92b98756d66c879cfdf86404f1",
+      "sha": "fa360b807e302fb40002539c70c9ee3f9099ea3c",
       "branches": {
-        "main": "21fdef525dc6fb92b98756d66c879cfdf86404f1"
+        "main": "fa360b807e302fb40002539c70c9ee3f9099ea3c"
       }
     },
-    "loogosh/warriortweaks": {
+    "francisegan/gudaplates": {
       "default_branch": "main",
-      "sha": "16f00117fbcd42130c0b44133a2a275bb4843bfe",
+      "sha": "a51dc61ccfd1be21185882d61a8ac9cbe0138ac5",
       "branches": {
-        "main": "16f00117fbcd42130c0b44133a2a275bb4843bfe"
+        "main": "a51dc61ccfd1be21185882d61a8ac9cbe0138ac5"
       }
     },
-    "webdkpthroaway/webdkp_elysium": {
-      "default_branch": "master",
-      "sha": "4b84ffa13168d2b1e10955d6a8cdeea023c596e1",
+    "francisegan/turtledebug": {
+      "default_branch": "main",
+      "sha": "0a98d2aadecd0ab6c7ba498fd2dca844dc3ddc82",
       "branches": {
-        "master": "4b84ffa13168d2b1e10955d6a8cdeea023c596e1"
+        "main": "0a98d2aadecd0ab6c7ba498fd2dca844dc3ddc82"
       }
     },
-    "cephel/webdkp_elysium": {
-      "default_branch": "master",
-      "sha": "2e709d87e71517e147fe830c4753fa66fc551ea0",
+    "francisegan/turtlereagentdisplay": {
+      "default_branch": "main",
+      "sha": "caf7832432607e3e70527bce3cb9069b95924f63",
       "branches": {
-        "master": "2e709d87e71517e147fe830c4753fa66fc551ea0"
+        "main": "caf7832432607e3e70527bce3cb9069b95924f63"
       }
     },
-    "jejkas/wfw": {
-      "default_branch": "master",
-      "sha": "71deefad363323bd719d4669c225b1030ae13a5d",
+    "francisegan/turtlerestedxp": {
+      "default_branch": "main",
+      "sha": "a125622f7391cb6e39be953306a7b58ed7fd8c60",
       "branches": {
-        "master": "71deefad363323bd719d4669c225b1030ae13a5d"
+        "main": "a125622f7391cb6e39be953306a7b58ed7fd8c60"
       }
     },
     "francisegan/whatstraining_turtle": {
@@ -8087,1407 +4492,11 @@
       },
       "latest_tag": "1.0.8"
     },
-    "forbium/whisperbind": {
-      "default_branch": "main",
-      "sha": "d3b1472cd45b69ff77e5ae9c42a5492a5131cdd8",
-      "branches": {
-        "main": "d3b1472cd45b69ff77e5ae9c42a5492a5131cdd8"
-      }
-    },
-    "rogolist/whisperbind": {
-      "default_branch": "main",
-      "sha": "c09d2bc88736fc0e44255b87305ad6ea99d43290",
-      "branches": {
-        "main": "c09d2bc88736fc0e44255b87305ad6ea99d43290"
-      }
-    },
-    "zensociety/whisperprofile": {
-      "default_branch": "main",
-      "sha": "da7f2437b43fa2693dc2d4b6aacc789c7fafc372",
-      "branches": {
-        "main": "da7f2437b43fa2693dc2d4b6aacc789c7fafc372"
-      }
-    },
-    "road-block/whofavorites": {
-      "default_branch": "master",
-      "sha": "04fd2b9eaca0d297a24d1daed103c534c344c921",
-      "branches": {
-        "master": "04fd2b9eaca0d297a24d1daed103c534c344c921"
-      },
-      "latest_tag": "1.0-11200"
-    },
-    "road-block/whohas": {
-      "default_branch": "master",
-      "sha": "cf4cc4e7d4b724f711fd34d1d03af54592346b2f",
-      "branches": {
-        "master": "cf4cc4e7d4b724f711fd34d1d03af54592346b2f"
-      },
-      "latest_tag": "2.33-11200"
-    },
-    "ellugia/whohas": {
-      "default_branch": "master",
-      "sha": "a77a747ea2e2c41c10b2e7d2752ececd96581b1d",
-      "branches": {
-        "master": "a77a747ea2e2c41c10b2e7d2752ececd96581b1d"
-      }
-    },
-    "yutsuku/whokicksnow": {
-      "default_branch": "master",
-      "sha": "cdebe08fd20d8057fc3ca787bdd1fe250b6cdb64",
-      "branches": {
-        "master": "cdebe08fd20d8057fc3ca787bdd1fe250b6cdb64"
-      }
-    },
-    "road-block/whokicksnow": {
-      "default_branch": "master",
-      "sha": "cdebe08fd20d8057fc3ca787bdd1fe250b6cdb64",
-      "branches": {
-        "master": "cdebe08fd20d8057fc3ca787bdd1fe250b6cdb64"
-      }
-    },
-    "voidmenull/wholist_fix": {
-      "default_branch": "master",
-      "sha": "07ccd926719160dd6461895eef66148ba0e7fde0",
-      "branches": {
-        "master": "07ccd926719160dd6461895eef66148ba0e7fde0"
-      }
-    },
-    "refaim/wim": {
-      "default_branch": "master",
-      "sha": "83498bba3333a96d1fd59415c11be21c2de3df6b",
-      "branches": {
-        "master": "83498bba3333a96d1fd59415c11be21c2de3df6b"
-      }
-    },
-    "kirchlive/wim": {
-      "default_branch": "master",
-      "sha": "a3a6006d136bcb88a3e303cedd86735390fce15e",
-      "branches": {
-        "master": "a3a6006d136bcb88a3e303cedd86735390fce15e"
-      }
-    },
-    "whtmst/wim": {
-      "default_branch": "master",
-      "sha": "d93427a07c1101b24e977dc36bac453e34687500",
-      "branches": {
-        "master": "d93427a07c1101b24e977dc36bac453e34687500"
-      }
-    },
-    "lythandrawow/rp_wim": {
-      "default_branch": "master",
-      "sha": "e9664e4481167b93ba0379ed00a1e3b65a445c06",
-      "branches": {
-        "master": "e9664e4481167b93ba0379ed00a1e3b65a445c06"
-      }
-    },
-    "mouzu/workaroundselfcast": {
-      "default_branch": "master",
-      "sha": "8587d8bd37b00f5f69c969887812cf21749b2e1c",
-      "branches": {
-        "master": "8587d8bd37b00f5f69c969887812cf21749b2e1c"
-      }
-    },
-    "twothe/worldfilter": {
-      "default_branch": "master",
-      "sha": "005252265b55cd6bfb2bcc6cfddd4eb64612077b",
-      "branches": {
-        "master": "005252265b55cd6bfb2bcc6cfddd4eb64612077b"
-      }
-    },
-    "laytya/wowluavanilla": {
-      "default_branch": "master",
-      "sha": "be006cbbcd6fbf5dcaf769dd300168389225604b",
-      "branches": {
-        "master": "be006cbbcd6fbf5dcaf769dd300168389225604b"
-      },
-      "latest_tag": "v1.0"
-    },
-    "distrattos/wowluavanilla": {
-      "default_branch": "master",
-      "sha": "be006cbbcd6fbf5dcaf769dd300168389225604b",
-      "branches": {
-        "master": "be006cbbcd6fbf5dcaf769dd300168389225604b"
-      }
-    },
-    "e-oven/wowluavanilla": {
-      "default_branch": "master",
-      "sha": "be006cbbcd6fbf5dcaf769dd300168389225604b",
-      "branches": {
-        "master": "be006cbbcd6fbf5dcaf769dd300168389225604b"
-      }
-    },
-    "paokkerkir/wowradio-vanilla": {
-      "default_branch": "main",
-      "sha": "572985067fe04b693cf1684c2dd103fc17632faf",
-      "branches": {
-        "main": "572985067fe04b693cf1684c2dd103fc17632faf"
-      }
-    },
-    "dusk-92/wowradio-vanilla": {
-      "default_branch": "main",
-      "sha": "e13ebc19d638ab5088fbfc864500f62f72f8aabc",
-      "branches": {
-        "main": "e13ebc19d638ab5088fbfc864500f62f72f8aabc"
-      }
-    },
-    "einbaum/xfactionchat": {
-      "default_branch": "master",
-      "sha": "22a07d52979359792dafd721c1d9e7d1aa7d57fc",
-      "branches": {
-        "master": "22a07d52979359792dafd721c1d9e7d1aa7d57fc"
-      }
-    },
-    "kmschr/xiaomount": {
-      "default_branch": "main",
-      "sha": "dc5d777c5c16e84e1ba5d93588cc7890165f2f57",
-      "branches": {
-        "main": "dc5d777c5c16e84e1ba5d93588cc7890165f2f57"
-      }
-    },
-    "amonra/xiaomount": {
-      "default_branch": "main",
-      "sha": "2342d9e5a92d27f5fb128c345c28cc080a313146",
-      "branches": {
-        "main": "2342d9e5a92d27f5fb128c345c28cc080a313146"
-      }
-    },
-    "redbu11dev/x-perl-unitframes": {
-      "default_branch": "main",
-      "sha": "11a423763c17531b0957f909967f3ca1e9ace959",
-      "branches": {
-        "main": "11a423763c17531b0957f909967f3ca1e9ace959"
-      }
-    },
-    "unknauwn/xtranqmanager": {
-      "default_branch": "Classic",
-      "sha": "5c468099500350e0938da703479cb276784dac57",
-      "branches": {
-        "Classic": "5c468099500350e0938da703479cb276784dac57"
-      },
-      "latest_tag": "3.0_classic"
-    },
-    "aspanj/yaht-turtlewowsteady": {
-      "default_branch": "master",
-      "sha": "c117bca876492358f4620a2a76fdcb801a55188c",
-      "branches": {
-        "master": "c117bca876492358f4620a2a76fdcb801a55188c"
-      }
-    },
-    "paenthy/yaht-turtlewow": {
-      "default_branch": "master",
-      "sha": "9696db588c5d8ad62c94a695144c6af89aa855b8",
-      "branches": {
-        "master": "9696db588c5d8ad62c94a695144c6af89aa855b8"
-      }
-    },
-    "freddea/yaht-turtlewow": {
-      "default_branch": "master",
-      "sha": "ffd729c4ba2a9c25934c38fd9cca93489f056bfa",
-      "branches": {
-        "master": "ffd729c4ba2a9c25934c38fd9cca93489f056bfa"
-      }
-    },
-    "minexew/zerodb": {
-      "default_branch": "master",
-      "sha": "b77faf7c78b6dcdfa55e7a02c0eb26e798004392",
-      "branches": {
-        "master": "b77faf7c78b6dcdfa55e7a02c0eb26e798004392"
-      },
-      "latest_tag": "r1"
-    },
-    "xian55/zorlen": {
-      "default_branch": "main",
-      "sha": "3d3b72313d02d8a10b9b908946c918ff5dc7cefc",
-      "branches": {
-        "main": "3d3b72313d02d8a10b9b908946c918ff5dc7cefc"
-      }
-    },
-    "knopex42/zorlen": {
-      "default_branch": "main",
-      "sha": "c6b3b1b7faa5dcdfc495f6b1035e8c6887b7b36b",
-      "branches": {
-        "main": "c6b3b1b7faa5dcdfc495f6b1035e8c6887b7b36b"
-      }
-    },
-    "xcornelius/zorlen": {
-      "default_branch": "main",
-      "sha": "4b844640315ac422ccffbde114c59cea6918a551",
-      "branches": {
-        "main": "4b844640315ac422ccffbde114c59cea6918a551"
-      }
-    },
-    "parzydelkowiec3-hub/zorlen": {
-      "default_branch": "main",
-      "sha": "bc794631e9e25451773b2803e6f2df46ccce58a5",
-      "branches": {
-        "main": "bc794631e9e25451773b2803e6f2df46ccce58a5"
-      }
-    },
-    "raymondsvendsen/zorlentw": {
-      "default_branch": "main",
-      "sha": "bc794631e9e25451773b2803e6f2df46ccce58a5",
-      "branches": {
-        "main": "bc794631e9e25451773b2803e6f2df46ccce58a5"
-      }
-    },
-    "starnuik/zorlen": {
-      "default_branch": "main",
-      "sha": "bc794631e9e25451773b2803e6f2df46ccce58a5",
-      "branches": {
-        "main": "bc794631e9e25451773b2803e6f2df46ccce58a5"
-      }
-    },
-    "hodareh/hardcoredeath": {
-      "default_branch": "main",
-      "sha": "3ee5511f6859e50b8aa8b8373b7d4b9e42e0bde9",
-      "branches": {
-        "main": "3ee5511f6859e50b8aa8b8373b7d4b9e42e0bde9"
-      }
-    },
-    "chad90b/hardcoredeath": {
-      "default_branch": "main",
-      "sha": "342ab3eb9468a4f342c75702960909bf9cb5bc8f",
-      "branches": {
-        "main": "342ab3eb9468a4f342c75702960909bf9cb5bc8f"
-      }
-    },
-    "mrflamberg/hardcoredeath": {
-      "default_branch": "main",
-      "sha": "342ab3eb9468a4f342c75702960909bf9cb5bc8f",
-      "branches": {
-        "main": "342ab3eb9468a4f342c75702960909bf9cb5bc8f"
-      },
-      "latest_tag": "v2.3.1"
-    },
-    "8eightysixed6/hardcoredeath": {
-      "default_branch": "main",
-      "sha": "38521a17b4fac0124151d5aa83ec96f681dd0239",
-      "branches": {
-        "main": "38521a17b4fac0124151d5aa83ec96f681dd0239"
-      }
-    },
-    "neimad-mp/hcdeaths": {
-      "default_branch": "main",
-      "sha": "15e16fa4ad80c3b89f4b0dc27318ca6362faa713",
-      "branches": {
-        "main": "15e16fa4ad80c3b89f4b0dc27318ca6362faa713"
-      }
-    },
-    "trumpetx/turtlehcfilter": {
-      "default_branch": "main",
-      "sha": "bf24747d1a18fde163ecefe0c5cc1b07fb1a7696",
-      "branches": {
-        "main": "bf24747d1a18fde163ecefe0c5cc1b07fb1a7696"
-      }
-    },
-    "leperidot/turtlehcfilter": {
-      "default_branch": "main",
-      "sha": "e6737f46663ed7ee195de316d7548d3df631f01e",
-      "branches": {
-        "main": "e6737f46663ed7ee195de316d7548d3df631f01e"
-      }
-    },
-    "dingleshu/turtlehcfilter": {
-      "default_branch": "main",
-      "sha": "f096c926e69c2c08a8c8afdde74f70c1863c4cfc",
-      "branches": {
-        "main": "f096c926e69c2c08a8c8afdde74f70c1863c4cfc"
-      }
-    },
-    "neimad-mp/hcrank": {
-      "default_branch": "main",
-      "sha": "d28d9bbbc6642de85c34558db963c513177dbec8",
-      "branches": {
-        "main": "d28d9bbbc6642de85c34558db963c513177dbec8"
-      }
-    },
-    "damagepyhun/turtlechatcolors": {
-      "default_branch": "main",
-      "sha": "3360599bccf37e0d7965cddb9c91c85009d931dd",
-      "branches": {
-        "main": "3360599bccf37e0d7965cddb9c91c85009d931dd"
-      }
-    },
-    "uranreactor/octochatcolors": {
-      "default_branch": "main",
-      "sha": "72af27c6e14768af3f0018d75fdf7082254cede3",
-      "branches": {
-        "main": "72af27c6e14768af3f0018d75fdf7082254cede3"
-      }
-    },
-    "al3xc1985/turtlechatcolors": {
-      "default_branch": "main",
-      "sha": "3360599bccf37e0d7965cddb9c91c85009d931dd",
-      "branches": {
-        "main": "3360599bccf37e0d7965cddb9c91c85009d931dd"
-      }
-    },
-    "refaim/turtlehardcorechattamer": {
-      "default_branch": "master",
-      "sha": "d75592277db26e57cdd73445fa1d29477b695ea0",
-      "branches": {
-        "master": "d75592277db26e57cdd73445fa1d29477b695ea0"
-      }
-    },
-    "rmarc29/unifiedtalentguides": {
-      "default_branch": "main",
-      "sha": "186691f8d98ef084e7e1c483380b27d9474a66bf",
-      "branches": {
-        "main": "186691f8d98ef084e7e1c483380b27d9474a66bf"
-      }
-    },
-    "shagu/cartographer": {
-      "default_branch": "master",
-      "sha": "9b2997bf85f2758e9d3a94028fa0ad158b001245",
-      "branches": {
-        "master": "9b2997bf85f2758e9d3a94028fa0ad158b001245"
-      }
-    },
-    "redbu11dev/cartographer": {
-      "default_branch": "master",
-      "sha": "f90b5b4db54a3ad65846454a93ca98e5a8d90ed6",
-      "branches": {
-        "master": "f90b5b4db54a3ad65846454a93ca98e5a8d90ed6"
-      }
-    },
-    "amonra/cartographer": {
-      "default_branch": "master",
-      "sha": "9b2997bf85f2758e9d3a94028fa0ad158b001245",
-      "branches": {
-        "master": "9b2997bf85f2758e9d3a94028fa0ad158b001245"
-      }
-    },
-    "dwbclz/cartographer": {
-      "default_branch": "master",
-      "sha": "9b2997bf85f2758e9d3a94028fa0ad158b001245",
-      "branches": {
-        "master": "9b2997bf85f2758e9d3a94028fa0ad158b001245"
-      }
-    },
-    "jiangxt316/cartographer": {
-      "default_branch": "master",
-      "sha": "9b2997bf85f2758e9d3a94028fa0ad158b001245",
-      "branches": {
-        "master": "9b2997bf85f2758e9d3a94028fa0ad158b001245"
-      }
-    },
-    "bergador/charactermap": {
-      "default_branch": "master",
-      "sha": "3f4194d5b438cee3ea48bf6fe84871951fb6ca31",
-      "branches": {
-        "master": "3f4194d5b438cee3ea48bf6fe84871951fb6ca31"
-      }
-    },
-    "cryptokn1ght-dev/chatmonitor": {
-      "default_branch": "main",
-      "sha": "2095edc3e5a10c8065304dbb567914424b8d9bf5",
-      "branches": {
-        "main": "2095edc3e5a10c8065304dbb567914424b8d9bf5"
-      }
-    },
-    "kogorash/chatmonitor": {
-      "default_branch": "main",
-      "sha": "2095edc3e5a10c8065304dbb567914424b8d9bf5",
-      "branches": {
-        "main": "2095edc3e5a10c8065304dbb567914424b8d9bf5"
-      }
-    },
-    "turinpt/cmap": {
-      "default_branch": "master",
-      "sha": "3849500c58db047a5455c8e7fa48ce48e80e221b",
-      "branches": {
-        "master": "3849500c58db047a5455c8e7fa48ce48e80e221b"
-      }
-    },
-    "kirchlive/deathlog_vanilla": {
-      "default_branch": "main",
-      "sha": "81e28be99cd026f17d79fa97693899128136095e",
-      "branches": {
-        "main": "81e28be99cd026f17d79fa97693899128136095e"
-      }
-    },
-    "bretharte89/deathlog_vanilla": {
-      "default_branch": "main",
-      "sha": "81e28be99cd026f17d79fa97693899128136095e",
-      "branches": {
-        "main": "81e28be99cd026f17d79fa97693899128136095e"
-      }
-    },
-    "dusk-92/deathlog_vanilla": {
-      "default_branch": "main",
-      "sha": "81e28be99cd026f17d79fa97693899128136095e",
-      "branches": {
-        "main": "81e28be99cd026f17d79fa97693899128136095e"
-      }
-    },
-    "stormhand-dev/dragonflightui-reforged": {
-      "default_branch": "main",
-      "sha": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8",
-      "branches": {
-        "main": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8"
-      },
-      "latest_tag": "1.3.4"
-    },
-    "hippoom/dragonflightui-reforged": {
-      "default_branch": "dev",
-      "sha": "64824b7442e93c8d0720efd09e0758378aef4507",
-      "branches": {
-        "dev": "64824b7442e93c8d0720efd09e0758378aef4507"
-      }
-    },
-    "thezephyrsong/dragonflightui-capybara": {
-      "default_branch": "main",
-      "sha": "014defeb8acec1b5e4a6a9985bfc1579c31c5ec6",
-      "branches": {
-        "main": "014defeb8acec1b5e4a6a9985bfc1579c31c5ec6"
-      },
-      "latest_tag": "1.3.3"
-    },
-    "hordexl/dragonflightui-reforged": {
-      "default_branch": "main",
-      "sha": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8",
-      "branches": {
-        "main": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8"
-      },
-      "latest_tag": "1.3.4"
-    },
-    "wigmox/dragonflightui-reforged": {
-      "default_branch": "main",
-      "sha": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8",
-      "branches": {
-        "main": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8"
-      },
-      "latest_tag": "1.3.4"
-    },
-    "al3xc1985/dragonflightui-reforged": {
-      "default_branch": "main",
-      "sha": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8",
-      "branches": {
-        "main": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8"
-      }
-    },
-    "immortalsom/dragonflightui-reforged": {
-      "default_branch": "main",
-      "sha": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8",
-      "branches": {
-        "main": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8"
-      }
-    },
-    "bretharte89/dragonflightui-reforged": {
-      "default_branch": "main",
-      "sha": "0f97b722bdc2f0c5fd31b5ee55ffd91d1bc8c26b",
-      "branches": {
-        "main": "0f97b722bdc2f0c5fd31b5ee55ffd91d1bc8c26b"
-      }
-    },
-    "rudaznoe/dragonflightui-reforged": {
-      "default_branch": "main",
-      "sha": "3e692803af230a4f5fc81a5fc9cd39dba848aa11",
-      "branches": {
-        "main": "3e692803af230a4f5fc81a5fc9cd39dba848aa11"
-      }
-    },
-    "rumchiller/em_yatlas": {
-      "default_branch": "master",
-      "sha": "5147dcb566afd42bcc1c694b004bdc7d6a6f0579",
-      "branches": {
-        "master": "5147dcb566afd42bcc1c694b004bdc7d6a6f0579"
-      }
-    },
-    "keldisko/em_yatlas-turtlewow": {
-      "default_branch": "master",
-      "sha": "2e86389160b33795b46bd47206752daa53297f23",
-      "branches": {
-        "master": "2e86389160b33795b46bd47206752daa53297f23"
-      },
-      "latest_tag": "V.02"
-    },
-    "bagan95/fadeframeui": {
-      "default_branch": "main",
-      "sha": "cbc475155f193b6553fdd4963e51e432e13e8c70",
-      "branches": {
-        "main": "cbc475155f193b6553fdd4963e51e432e13e8c70"
-      },
-      "latest_tag": "v1.2.0"
-    },
-    "kameleonuk/fadeframeui": {
-      "default_branch": "main",
-      "sha": "94a8aa13d167ba885b1184f9dd04950533d7ebe0",
-      "branches": {
-        "main": "94a8aa13d167ba885b1184f9dd04950533d7ebe0"
-      }
-    },
-    "trangoul/flightmap": {
-      "default_branch": "main",
-      "sha": "8231f8f95de2f361774bb55162a731702409a26c",
-      "branches": {
-        "main": "8231f8f95de2f361774bb55162a731702409a26c"
-      }
-    },
-    "tolle44/flightmap": {
-      "default_branch": "main",
-      "sha": "ea81e52a833be28f8b3c10db3a20c6b51ef02152",
-      "branches": {
-        "main": "ea81e52a833be28f8b3c10db3a20c6b51ef02152"
-      }
-    },
-    "al3xc1985/flightmap": {
-      "default_branch": "main",
-      "sha": "8231f8f95de2f361774bb55162a731702409a26c",
-      "branches": {
-        "main": "8231f8f95de2f361774bb55162a731702409a26c"
-      }
-    },
-    "tilare/flighttracker": {
-      "default_branch": "main",
-      "sha": "a28d3bdfe6c6e03da70657ef412ff4a423e59824",
-      "branches": {
-        "main": "a28d3bdfe6c6e03da70657ef412ff4a423e59824"
-      }
-    },
-    "lexxoi/flighttracker": {
-      "default_branch": "main",
-      "sha": "cc46bf61ee1c9d5cc33fa7ce9c1cca1c71332795",
-      "branches": {
-        "main": "cc46bf61ee1c9d5cc33fa7ce9c1cca1c71332795"
-      }
-    },
-    "evannnn1996/flighttracker": {
-      "default_branch": "main",
-      "sha": "046c6e63ae9b123d7c07874d8437176054f598da",
-      "branches": {
-        "main": "046c6e63ae9b123d7c07874d8437176054f598da"
-      }
-    },
-    "bretharte89/flighttracker": {
-      "default_branch": "main",
-      "sha": "a28d3bdfe6c6e03da70657ef412ff4a423e59824",
-      "branches": {
-        "main": "a28d3bdfe6c6e03da70657ef412ff4a423e59824"
-      }
-    },
-    "kameleonuk/flighttracker": {
-      "default_branch": "main",
-      "sha": "23bebc73fc6410f5b065e710522a233808609003",
-      "branches": {
-        "main": "23bebc73fc6410f5b065e710522a233808609003"
-      }
-    },
-    "nemanuel/forged_mapnotes": {
-      "default_branch": "main",
-      "sha": "ef4ee14d1b94a55312d23aab0ddfac8eb9cea1b7",
-      "branches": {
-        "main": "ef4ee14d1b94a55312d23aab0ddfac8eb9cea1b7"
-      }
-    },
-    "road-block/fubar_tofu": {
-      "default_branch": "master",
-      "sha": "18838b126bd3417b8d32778961dc1e72590b33ab",
-      "branches": {
-        "master": "18838b126bd3417b8d32778961dc1e72590b33ab"
-      },
-      "latest_tag": "r15647"
-    },
-    "shikulja/fubar_tofu": {
-      "default_branch": "master",
-      "sha": "cd17532c32125651ae7f78f9d34266a514f6a3d1",
-      "branches": {
-        "master": "cd17532c32125651ae7f78f9d34266a514f6a3d1"
-      },
-      "latest_tag": "r15647"
-    },
-    "haaxor1689/gatherer": {
-      "default_branch": "master",
-      "sha": "81ee08ba49d14b3f2dc670749af7c9821b71d621",
-      "branches": {
-        "master": "81ee08ba49d14b3f2dc670749af7c9821b71d621"
-      }
-    },
-    "trite2k3/gatherer": {
-      "default_branch": "master",
-      "sha": "bf4cccdaf8dde5be933cc28c8c40379f8fdc56a6",
-      "branches": {
-        "master": "bf4cccdaf8dde5be933cc28c8c40379f8fdc56a6"
-      }
-    },
-    "roland-rwl/gatherer": {
-      "default_branch": "master",
-      "sha": "b6d5bc9df917ba2a2050f28d71fcaa0222653f99",
-      "branches": {
-        "master": "b6d5bc9df917ba2a2050f28d71fcaa0222653f99"
-      }
-    },
-    "nabelon/gatherer": {
-      "default_branch": "master",
-      "sha": "225fdf8fd721c94ccb0495d3559611671797bd51",
-      "branches": {
-        "master": "225fdf8fd721c94ccb0495d3559611671797bd51"
-      }
-    },
-    "nefalas/gatherer": {
-      "default_branch": "master",
-      "sha": "bf4cccdaf8dde5be933cc28c8c40379f8fdc56a6",
-      "branches": {
-        "master": "bf4cccdaf8dde5be933cc28c8c40379f8fdc56a6"
-      }
-    },
-    "txuscolchonero/gatherer": {
-      "default_branch": "master",
-      "sha": "bf4cccdaf8dde5be933cc28c8c40379f8fdc56a6",
-      "branches": {
-        "master": "bf4cccdaf8dde5be933cc28c8c40379f8fdc56a6"
-      }
-    },
-    "haaxor1689/guildmap": {
-      "default_branch": "master",
-      "sha": "e3788a64d7a524430df4bef941a6814ff5bd5635",
-      "branches": {
-        "master": "e3788a64d7a524430df4bef941a6814ff5bd5635"
-      }
-    },
-    "spartelfant/levelrange-turtle": {
-      "default_branch": "main",
-      "sha": "f280a18abe9b32ffd901050c5934f0e60df25f3a",
-      "branches": {
-        "main": "f280a18abe9b32ffd901050c5934f0e60df25f3a"
-      }
-    },
-    "dusk-92/levelrange-octo": {
-      "default_branch": "main",
-      "sha": "fa21fb38cd47454aad65cf8ab53ea5c2f488a8c7",
-      "branches": {
-        "main": "fa21fb38cd47454aad65cf8ab53ea5c2f488a8c7"
-      },
-      "latest_tag": "2.3.1"
-    },
-    "paokkerkir/levelrange-octo": {
-      "default_branch": "main",
-      "sha": "6ae70cad4ee911ba3fe1e297fa84d4bb1b8d6d4a",
-      "branches": {
-        "main": "6ae70cad4ee911ba3fe1e297fa84d4bb1b8d6d4a"
-      }
-    },
-    "starnuik/levelrange-turtle": {
-      "default_branch": "main",
-      "sha": "8611a0f10df98dcb11fc08918c343dd071ef18c6",
-      "branches": {
-        "main": "8611a0f10df98dcb11fc08918c343dd071ef18c6"
-      }
-    },
-    "eritzman/levelrange-turtle": {
-      "default_branch": "main",
-      "sha": "bf1c84709fda3fc32871a2b99e4eb41f36a44e97",
-      "branches": {
-        "main": "bf1c84709fda3fc32871a2b99e4eb41f36a44e97"
-      }
-    },
-    "mxttosierrv/levelrange-turtle-espanol": {
-      "default_branch": "main",
-      "sha": "01a5ae13848d4da7e54321644520126428858992",
-      "branches": {
-        "main": "01a5ae13848d4da7e54321644520126428858992"
-      }
-    },
-    "lookino/magnify": {
-      "default_branch": "main",
-      "sha": "3ff15a844a5ade917c6ac63489a9dc375b1411b2",
-      "branches": {
-        "main": "3ff15a844a5ade917c6ac63489a9dc375b1411b2"
-      }
-    },
-    "paokkerkir/magnify": {
-      "default_branch": "main",
-      "sha": "86d11cbcb9a0e8d5ba3459c5815e392c296213d1",
-      "branches": {
-        "main": "86d11cbcb9a0e8d5ba3459c5815e392c296213d1"
-      }
-    },
-    "blehz-be/magnify": {
-      "default_branch": "main",
-      "sha": "3ff15a844a5ade917c6ac63489a9dc375b1411b2",
-      "branches": {
-        "main": "3ff15a844a5ade917c6ac63489a9dc375b1411b2"
-      }
-    },
-    "yutsuku/mapofscars": {
-      "default_branch": "master",
-      "sha": "57733c84d3a1ce23ef213edcfb052ae77ece7ccf",
-      "branches": {
-        "master": "57733c84d3a1ce23ef213edcfb052ae77ece7ccf"
-      }
-    },
-    "einbaum/maptarget": {
-      "default_branch": "master",
-      "sha": "8d2939ad8fbcc954a2f98e3c9f02110572c8d204",
-      "branches": {
-        "master": "8d2939ad8fbcc954a2f98e3c9f02110572c8d204"
-      },
-      "latest_tag": "2.1"
-    },
-    "laytya/metamap-vanilla": {
-      "default_branch": "master",
-      "sha": "8dcc99d182480cac3e44efd9b4ac2ccb9f441e14",
-      "branches": {
-        "master": "8dcc99d182480cac3e44efd9b4ac2ccb9f441e14"
-      },
-      "latest_tag": "11200-10"
-    },
-    "stevensnoeijen/metamap-vanilla": {
-      "default_branch": "master",
-      "sha": "8dcc99d182480cac3e44efd9b4ac2ccb9f441e14",
-      "branches": {
-        "master": "8dcc99d182480cac3e44efd9b4ac2ccb9f441e14"
-      }
-    },
-    "laytya/minimapbuttonframe-vanilla": {
-      "default_branch": "master",
-      "sha": "0923f9e4128c6fcdc97df448c7665ca71bca2a18",
-      "branches": {
-        "master": "0923f9e4128c6fcdc97df448c7665ca71bca2a18"
-      },
-      "latest_tag": "1.12"
-    },
-    "mcpewpew/minimapbuttonframe": {
-      "default_branch": "master",
-      "sha": "c49fc6491934726cdce012194fd17c355c2014a3",
-      "branches": {
-        "master": "c49fc6491934726cdce012194fd17c355c2014a3"
-      }
-    },
-    "chad90b/minimapbuttonframe-vanilla": {
-      "default_branch": "master",
-      "sha": "0923f9e4128c6fcdc97df448c7665ca71bca2a18",
-      "branches": {
-        "master": "0923f9e4128c6fcdc97df448c7665ca71bca2a18"
-      },
-      "latest_tag": "1.12"
-    },
-    "whtmst/minimapbuttonframe-vanilla": {
-      "default_branch": "master",
-      "sha": "0923f9e4128c6fcdc97df448c7665ca71bca2a18",
-      "branches": {
-        "master": "0923f9e4128c6fcdc97df448c7665ca71bca2a18"
-      }
-    },
-    "road-block/pingomatic": {
-      "default_branch": "master",
-      "sha": "9f20a088971d43b1152344ddb5a19fea0d65319c",
-      "branches": {
-        "master": "9f20a088971d43b1152344ddb5a19fea0d65319c"
-      },
-      "latest_tag": "1.12-11200"
-    },
-    "acid9000/pizzaworldbuffs": {
-      "default_branch": "main",
-      "sha": "72d6861926c1a2106c8773e8e251da27ab617471",
-      "branches": {
-        "main": "72d6861926c1a2106c8773e8e251da27ab617471"
-      }
-    },
-    "kingfisher387/pizzaworldbuffs": {
-      "default_branch": "main",
-      "sha": "72d6861926c1a2106c8773e8e251da27ab617471",
-      "branches": {
-        "main": "72d6861926c1a2106c8773e8e251da27ab617471"
-      }
-    },
-    "ravenofseven/pizzaworldbuffs": {
-      "default_branch": "main",
-      "sha": "72d6861926c1a2106c8773e8e251da27ab617471",
-      "branches": {
-        "main": "72d6861926c1a2106c8773e8e251da27ab617471"
-      }
-    },
-    "thezephyrsong/pizzaworldbuffs": {
-      "default_branch": "main",
-      "sha": "d65a510f7567f8f7fdaea0633731907330e2b17f",
-      "branches": {
-        "main": "d65a510f7567f8f7fdaea0633731907330e2b17f"
-      }
-    },
-    "daniilsokolyuk/ripmap": {
-      "default_branch": "master",
-      "sha": "0f864a5e25de22ee7f5dd66ee740434a12d07bba",
-      "branches": {
-        "master": "0f864a5e25de22ee7f5dd66ee740434a12d07bba"
-      }
-    },
-    "mcpewpew/simpleminimap": {
-      "default_branch": "master",
-      "sha": "b02e7be9995ecac8c7055f2f31b5d661fe65cf38",
-      "branches": {
-        "master": "b02e7be9995ecac8c7055f2f31b5d661fe65cf38"
-      }
-    },
-    "montspy/sqminimapfix": {
-      "default_branch": "master",
-      "sha": "407ccee4c0b99db89c8c2191f841d567690c56c0",
-      "branches": {
-        "master": "407ccee4c0b99db89c8c2191f841d567690c56c0"
-      }
-    },
-    "blomma/bc_trackingmenu": {
-      "default_branch": "master",
-      "sha": "0d462546337f620454635bdbc7dfbbdbc51d8636",
-      "branches": {
-        "master": "0d462546337f620454635bdbc7dfbbdbc51d8636"
-      }
-    },
-    "mcpewpew/turtlesnacks": {
-      "default_branch": "main",
-      "sha": "4c0f3b1746ee06e020d4ea94434e8fd90e94f3dc",
-      "branches": {
-        "main": "4c0f3b1746ee06e020d4ea94434e8fd90e94f3dc"
-      }
-    },
-    "ageous27/twmapreveal": {
-      "default_branch": "main",
-      "sha": "49015343ff0bb76366a9b0fcd377902e747fb5d0",
-      "branches": {
-        "main": "49015343ff0bb76366a9b0fcd377902e747fb5d0"
-      }
-    },
-    "0ldi/vanillamaps": {
-      "default_branch": "master",
-      "sha": "38babd3c213a6f1845f7b711f09d17295ef0fd78",
-      "branches": {
-        "master": "38babd3c213a6f1845f7b711f09d17295ef0fd78"
-      }
-    },
-    "arthur-helias/zoneslevel": {
-      "default_branch": "master",
-      "sha": "985652b77532fe09dd3a1044bb736f92d7cfefd1",
-      "branches": {
-        "master": "985652b77532fe09dd3a1044bb736f92d7cfefd1"
-      }
-    },
-    "ravenofseven/zoneslevel": {
-      "default_branch": "master",
-      "sha": "971eb5938524f0007ad2aab8eb2cf7a5e71d60ca",
-      "branches": {
-        "master": "971eb5938524f0007ad2aab8eb2cf7a5e71d60ca"
-      }
-    },
-    "shellyoung/advancedtradeskillwindow2": {
-      "default_branch": "main",
-      "sha": "9f35415ce20fdea6b42e19b944c17547f2d93f31",
-      "branches": {
-        "main": "9f35415ce20fdea6b42e19b944c17547f2d93f31"
-      },
-      "latest_tag": "2.1.16"
-    },
-    "ghbset/advancedtradeskillwindow2": {
-      "default_branch": "main",
-      "sha": "9f35415ce20fdea6b42e19b944c17547f2d93f31",
-      "branches": {
-        "main": "9f35415ce20fdea6b42e19b944c17547f2d93f31"
-      }
-    },
-    "otari98/artisan": {
-      "default_branch": "main",
-      "sha": "e0ad216e86764120003388d1219574cad715302a",
-      "branches": {
-        "main": "e0ad216e86764120003388d1219574cad715302a"
-      }
-    },
-    "valnaut/artisan": {
-      "default_branch": "main",
-      "sha": "cd2089bb15240a764dfc9d68b0755166c0f2a7d2",
-      "branches": {
-        "main": "cd2089bb15240a764dfc9d68b0755166c0f2a7d2"
-      }
-    },
-    "fox2k7/bananarepublicprofs": {
-      "default_branch": "main",
-      "sha": "fa360b807e302fb40002539c70c9ee3f9099ea3c",
-      "branches": {
-        "main": "fa360b807e302fb40002539c70c9ee3f9099ea3c"
-      }
-    },
-    "akileos/happyprofs": {
-      "default_branch": "main",
-      "sha": "a9d75c380d14602c261a8b24bef4c7005fdf6cbf",
-      "branches": {
-        "main": "a9d75c380d14602c261a8b24bef4c7005fdf6cbf"
-      }
-    },
-    "arthur-helias/bettercharacterpanel": {
-      "default_branch": "main",
-      "sha": "c81f8b7146fc34927f43331b469d08ce5556b78d",
-      "branches": {
-        "main": "c81f8b7146fc34927f43331b469d08ce5556b78d"
-      }
-    },
-    "ravenofseven/bettercharacterpanel": {
-      "default_branch": "main",
-      "sha": "6f98ab5460fc6e697d6e2660a8f89affd124a8e4",
-      "branches": {
-        "main": "6f98ab5460fc6e697d6e2660a8f89affd124a8e4"
-      }
-    },
-    "cinecom/consumesmanager": {
-      "default_branch": "main",
-      "sha": "9662595123519609bad09ff49061ca969a5249e8",
-      "branches": {
-        "main": "9662595123519609bad09ff49061ca969a5249e8"
-      }
-    },
-    "marcelinevq/consumesmanager": {
-      "default_branch": "main",
-      "sha": "202fadadeadc22477ea25903137bca03707e3664",
-      "branches": {
-        "main": "202fadadeadc22477ea25903137bca03707e3664"
-      }
-    },
-    "mimiwarmini/consumesmanager": {
-      "default_branch": "main",
-      "sha": "10284dbd9947122a0bd988461c4e7ebf089989fc",
-      "branches": {
-        "main": "10284dbd9947122a0bd988461c4e7ebf089989fc"
-      }
-    },
-    "freohr/consumesmanager": {
-      "default_branch": "main",
-      "sha": "bda817859bd0c0fc4f87a9d830248c61531ad087",
-      "branches": {
-        "main": "bda817859bd0c0fc4f87a9d830248c61531ad087"
-      }
-    },
-    "kirchlive/consumesmanager": {
-      "default_branch": "main",
-      "sha": "f6c8e17c583f4a6d0b9d78f29720731f55072fd9",
-      "branches": {
-        "main": "f6c8e17c583f4a6d0b9d78f29720731f55072fd9"
-      }
-    },
-    "logicsec/consumesmanager": {
-      "default_branch": "main",
-      "sha": "f6c8e17c583f4a6d0b9d78f29720731f55072fd9",
-      "branches": {
-        "main": "f6c8e17c583f4a6d0b9d78f29720731f55072fd9"
-      }
-    },
-    "whtmst/consumesmanager": {
-      "default_branch": "main",
-      "sha": "f6c8e17c583f4a6d0b9d78f29720731f55072fd9",
-      "branches": {
-        "main": "f6c8e17c583f4a6d0b9d78f29720731f55072fd9"
-      }
-    },
-    "wierdthing/consumesmanager": {
-      "default_branch": "main",
-      "sha": "817c50a34b6d2d135365c3b4077ea0c8ffc7f67a",
-      "branches": {
-        "main": "817c50a34b6d2d135365c3b4077ea0c8ffc7f67a"
-      }
-    },
-    "azzc0/consumesmanager": {
-      "default_branch": "main",
-      "sha": "7a8a179c81ea2a3923eeabf0a9b4b37388c23aee",
-      "branches": {
-        "main": "7a8a179c81ea2a3923eeabf0a9b4b37388c23aee"
-      }
-    },
-    "shirsig/crafty": {
-      "default_branch": "master",
-      "sha": "06ec40f0c4820ae14a1d959fbeb1492fe2b44fe5",
-      "branches": {
-        "master": "06ec40f0c4820ae14a1d959fbeb1492fe2b44fe5"
-      }
-    },
-    "akzkak/craftyplus": {
-      "default_branch": "master",
-      "sha": "ba31bc48b931ffe9b77903481a4f1cc6e1a8ff33",
-      "branches": {
-        "master": "ba31bc48b931ffe9b77903481a4f1cc6e1a8ff33"
-      }
-    },
-    "mcpewpew/gfw_disenchantpredictor": {
-      "default_branch": "master",
-      "sha": "54cbcf2f377028253ae7f6a88cb093c83ca6e1b3",
-      "branches": {
-        "master": "54cbcf2f377028253ae7f6a88cb093c83ca6e1b3"
-      }
-    },
-    "carolluparu/gryllsbongos": {
-      "default_branch": "main",
-      "sha": "485e3840c5975e0da1fed4070a0eb71e0f429e85",
-      "branches": {
-        "main": "485e3840c5975e0da1fed4070a0eb71e0f429e85"
-      }
-    },
-    "sica42/guildrecipes": {
-      "default_branch": "main",
-      "sha": "ee10a84da53f5e85fac4da48a98d6fd9adfdde51",
-      "branches": {
-        "main": "ee10a84da53f5e85fac4da48a98d6fd9adfdde51"
-      }
-    },
-    "aalandriel/guildrecipes": {
-      "default_branch": "main",
-      "sha": "740912132f4d66cc517ad567204c1ea9146916d5",
-      "branches": {
-        "main": "740912132f4d66cc517ad567204c1ea9146916d5"
-      }
-    },
-    "arthur-helias/instancejournal": {
-      "default_branch": "master",
-      "sha": "b58ebe0ffd9bd7bc1c18d0a7d009795d1c2a942c",
-      "branches": {
-        "master": "b58ebe0ffd9bd7bc1c18d0a7d009795d1c2a942c"
-      }
-    },
-    "samahee/instancejournal": {
-      "default_branch": "master",
-      "sha": "b58ebe0ffd9bd7bc1c18d0a7d009795d1c2a942c",
-      "branches": {
-        "master": "b58ebe0ffd9bd7bc1c18d0a7d009795d1c2a942c"
-      }
-    },
-    "kameleonuk/instancejournal": {
-      "default_branch": "master",
-      "sha": "458523854e726c9b0f44c16c86e4a51643990e76",
-      "branches": {
-        "master": "458523854e726c9b0f44c16c86e4a51643990e76"
-      }
-    },
-    "bretharte89/instancejournal": {
-      "default_branch": "master",
-      "sha": "77eade63939ecab01c32f2983913fbf801b7b8c2",
-      "branches": {
-        "master": "77eade63939ecab01c32f2983913fbf801b7b8c2"
-      }
-    },
-    "ghbset/instancejournal": {
-      "default_branch": "master",
-      "sha": "77eade63939ecab01c32f2983913fbf801b7b8c2",
-      "branches": {
-        "master": "77eade63939ecab01c32f2983913fbf801b7b8c2"
-      }
-    },
-    "mrmaffen/instancejournal": {
-      "default_branch": "master",
-      "sha": "05dbfdd6bc7721e74d5bda0a191e6f756d3708ad",
-      "branches": {
-        "master": "05dbfdd6bc7721e74d5bda0a191e6f756d3708ad"
-      }
-    },
-    "paenthy/instancejournal": {
-      "default_branch": "master",
-      "sha": "39612fde087b3bff15b88fd73b9f8d717e2244d6",
-      "branches": {
-        "master": "39612fde087b3bff15b88fd73b9f8d717e2244d6"
-      }
-    },
-    "ravenofseven/instancejournal": {
-      "default_branch": "master",
-      "sha": "39612fde087b3bff15b88fd73b9f8d717e2244d6",
-      "branches": {
-        "master": "39612fde087b3bff15b88fd73b9f8d717e2244d6"
-      }
-    },
-    "haaxor1689/instancejournal": {
-      "default_branch": "master",
-      "sha": "6ec791f7d31129ca4783fc5e5bb9e5c66f0c505b",
-      "branches": {
-        "master": "6ec791f7d31129ca4783fc5e5bb9e5c66f0c505b"
-      }
-    },
-    "refaim/itemtooltipicons": {
-      "default_branch": "master",
-      "sha": "819e7565cc105cf58f54c6193d49b350a66a87c6",
-      "branches": {
-        "master": "819e7565cc105cf58f54c6193d49b350a66a87c6"
-      }
-    },
-    "gitgrom/itemtooltipicons": {
-      "default_branch": "master",
-      "sha": "40e4836d87a1e4f0ee59dc2314dc952cd4a3b77b",
-      "branches": {
-        "master": "40e4836d87a1e4f0ee59dc2314dc952cd4a3b77b"
-      }
-    },
-    "laytya/lilsparkysworkshop-vanilla": {
-      "default_branch": "master",
-      "sha": "326db62006d5281b749bb0b3587fd0b977575581",
-      "branches": {
-        "master": "326db62006d5281b749bb0b3587fd0b977575581"
-      },
-      "latest_tag": "v0.7"
-    },
-    "bretharte89/lilsparkysworkshop-vanilla": {
-      "default_branch": "master",
-      "sha": "326db62006d5281b749bb0b3587fd0b977575581",
-      "branches": {
-        "master": "326db62006d5281b749bb0b3587fd0b977575581"
-      }
-    },
-    "chad90b/lilsparkysworkshop-vanilla": {
-      "default_branch": "master",
-      "sha": "b20712697cd5ece1a4553f113d7ffcb4569a9055",
-      "branches": {
-        "master": "b20712697cd5ece1a4553f113d7ffcb4569a9055"
-      }
-    },
-    "trangoul/lookup": {
-      "default_branch": "master",
-      "sha": "4584b55e864f419f6774a52a8620aa86e9ad98f0",
-      "branches": {
-        "master": "4584b55e864f419f6774a52a8620aa86e9ad98f0"
-      }
-    },
-    "refaim/mastertradeskills": {
-      "default_branch": "master",
-      "sha": "3c79aa916488a1703ccd83bdc6ca653c5db99436",
-      "branches": {
-        "master": "3c79aa916488a1703ccd83bdc6ca653c5db99436"
-      }
-    },
-    "al3xc1985/mastertradeskills": {
-      "default_branch": "master",
-      "sha": "3c79aa916488a1703ccd83bdc6ca653c5db99436",
-      "branches": {
-        "master": "3c79aa916488a1703ccd83bdc6ca653c5db99436"
-      }
-    },
-    "shigemunekurogane/mastertradeskills": {
-      "default_branch": "master",
-      "sha": "46bd70ceb60a30a671e9da3caf092a057e2abf17",
-      "branches": {
-        "master": "46bd70ceb60a30a671e9da3caf092a057e2abf17"
-      }
-    },
-    "chad90b/mastertradeskills": {
-      "default_branch": "master",
-      "sha": "bb780c85a6855d1cb5af63df0f68bf5ff9e642e1",
-      "branches": {
-        "master": "bb780c85a6855d1cb5af63df0f68bf5ff9e642e1"
-      }
-    },
     "freadblangks/mastertradeskills": {
       "default_branch": "master",
       "sha": "391efbd0cebd1e28970c5cc793d644ab42ba935d",
       "branches": {
         "master": "391efbd0cebd1e28970c5cc793d644ab42ba935d"
-      }
-    },
-    "blehz-be/mastertradeskills": {
-      "default_branch": "master",
-      "sha": "18535fe277dcda131789e3be5d2b8d8c6950a5e4",
-      "branches": {
-        "master": "18535fe277dcda131789e3be5d2b8d8c6950a5e4"
-      }
-    },
-    "shikulja/mastertradeskills": {
-      "default_branch": "master",
-      "sha": "18535fe277dcda131789e3be5d2b8d8c6950a5e4",
-      "branches": {
-        "master": "18535fe277dcda131789e3be5d2b8d8c6950a5e4"
-      }
-    },
-    "vini-sousa/mastertradeskills-vanilla": {
-      "default_branch": "master",
-      "sha": "8ffeef5fc15a138d4c143d718b897cbce47ba2ca",
-      "branches": {
-        "master": "8ffeef5fc15a138d4c143d718b897cbce47ba2ca"
-      }
-    },
-    "laytya/mendeleev": {
-      "default_branch": "main",
-      "sha": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a",
-      "branches": {
-        "main": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a"
-      },
-      "latest_tag": "1.1"
-    },
-    "avirar/mendeleev": {
-      "default_branch": "main",
-      "sha": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a",
-      "branches": {
-        "main": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a"
-      }
-    },
-    "distrattos/mendeleev": {
-      "default_branch": "main",
-      "sha": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a",
-      "branches": {
-        "main": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a"
-      }
-    },
-    "lxxie1988/mendeleev": {
-      "default_branch": "main",
-      "sha": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a",
-      "branches": {
-        "main": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a"
-      }
-    },
-    "refaim/missingcrafts": {
-      "default_branch": "master",
-      "sha": "e702ce7d781d68c2ead5f8223e59689edb8cfc91",
-      "branches": {
-        "master": "e702ce7d781d68c2ead5f8223e59689edb8cfc91"
-      }
-    },
-    "chad90b/missingcrafts": {
-      "default_branch": "master",
-      "sha": "e702ce7d781d68c2ead5f8223e59689edb8cfc91",
-      "branches": {
-        "master": "e702ce7d781d68c2ead5f8223e59689edb8cfc91"
-      }
-    },
-    "conquistadorestwow/missingcrafts": {
-      "default_branch": "master",
-      "sha": "e702ce7d781d68c2ead5f8223e59689edb8cfc91",
-      "branches": {
-        "master": "e702ce7d781d68c2ead5f8223e59689edb8cfc91"
-      }
-    },
-    "manalow/missingcrafts": {
-      "default_branch": "master",
-      "sha": "e702ce7d781d68c2ead5f8223e59689edb8cfc91",
-      "branches": {
-        "master": "e702ce7d781d68c2ead5f8223e59689edb8cfc91"
-      }
-    },
-    "paenthy/missingcrafts": {
-      "default_branch": "master",
-      "sha": "e702ce7d781d68c2ead5f8223e59689edb8cfc91",
-      "branches": {
-        "master": "e702ce7d781d68c2ead5f8223e59689edb8cfc91"
-      }
-    },
-    "shigemunekurogane/missingcrafts": {
-      "default_branch": "master",
-      "sha": "cda4bdac4eb9a29e4a1baa1bfbe56104b89e8962",
-      "branches": {
-        "master": "cda4bdac4eb9a29e4a1baa1bfbe56104b89e8962"
-      }
-    },
-    "refaim/missingtradeskillslist": {
-      "default_branch": "master",
-      "sha": "807469745ce1ad1133073d814e2bb513666300ac",
-      "branches": {
-        "master": "807469745ce1ad1133073d814e2bb513666300ac"
-      }
-    },
-    "alchem1ster/missingtradeskillslist": {
-      "default_branch": "master",
-      "sha": "545095062c5609e2cdb9d853faeb17c0c9dfc34d",
-      "branches": {
-        "master": "545095062c5609e2cdb9d853faeb17c0c9dfc34d"
-      }
-    },
-    "darkovian/missingtradeskillslist-libcrafts": {
-      "default_branch": "master",
-      "sha": "545095062c5609e2cdb9d853faeb17c0c9dfc34d",
-      "branches": {
-        "master": "545095062c5609e2cdb9d853faeb17c0c9dfc34d"
-      }
-    },
-    "blehz-be/missingtradeskillslist": {
-      "default_branch": "master",
-      "sha": "dca6269945e67226ee7874957188f056d5b50b1b",
-      "branches": {
-        "master": "dca6269945e67226ee7874957188f056d5b50b1b"
-      }
-    },
-    "chad90b/missingtradeskillslist": {
-      "default_branch": "master",
-      "sha": "d40172f3d2e61d8541f35c01460e4f0b595a470e",
-      "branches": {
-        "master": "d40172f3d2e61d8541f35c01460e4f0b595a470e"
-      }
-    },
-    "tubtubs/panda": {
-      "default_branch": "main",
-      "sha": "a328bbc165db8e8e4fe113d751db74b5d227f96b",
-      "branches": {
-        "main": "a328bbc165db8e8e4fe113d751db74b5d227f96b"
-      }
-    },
-    "al3xc1985/panda": {
-      "default_branch": "main",
-      "sha": "a328bbc165db8e8e4fe113d751db74b5d227f96b",
-      "branches": {
-        "main": "a328bbc165db8e8e4fe113d751db74b5d227f96b"
-      }
-    },
-    "niclaseriksen/profesjonell": {
-      "default_branch": "main",
-      "sha": "5c1c57e5a2f8ebc86a0535c9b776ffc71c525c50",
-      "branches": {
-        "main": "5c1c57e5a2f8ebc86a0535c9b776ffc71c525c50"
-      }
-    },
-    "gregdeichler/professionlevels": {
-      "default_branch": "main",
-      "sha": "5b97d211a8096d42b1c8bc76cf2bdbff0f405c65",
-      "branches": {
-        "main": "5b97d211a8096d42b1c8bc76cf2bdbff0f405c65"
-      },
-      "latest_tag": "Release2.8"
-    },
-    "shirsig/profession_query": {
-      "default_branch": "master",
-      "sha": "5386fc98ec9b3cdf3c68a7e47a1fcebe286f5ac6",
-      "branches": {
-        "master": "5386fc98ec9b3cdf3c68a7e47a1fcebe286f5ac6"
-      }
-    },
-    "refaim/reagentdata": {
-      "default_branch": "master",
-      "sha": "546f00fd43ae30f77f62ed3465dfafcebbfffffb",
-      "branches": {
-        "master": "546f00fd43ae30f77f62ed3465dfafcebbfffffb"
-      }
-    },
-    "shikulja/reagentdata": {
-      "default_branch": "master",
-      "sha": "42602d2ca183612168c23e20d6c19afa032b6feb",
-      "branches": {
-        "master": "42602d2ca183612168c23e20d6c19afa032b6feb"
-      }
-    },
-    "chad90b/reagentdata": {
-      "default_branch": "master",
-      "sha": "c10ad1e2a9044dfa2f6c21fe4917fad42e2365c3",
-      "branches": {
-        "master": "c10ad1e2a9044dfa2f6c21fe4917fad42e2365c3"
-      }
-    },
-    "gbl/tradechat": {
-      "default_branch": "master",
-      "sha": "ef76057e10220d8138955c3e027a238d3b3825d9",
-      "branches": {
-        "master": "ef76057e10220d8138955c3e027a238d3b3825d9"
-      }
-    },
-    "whtmst/tradechat": {
-      "default_branch": "master",
-      "sha": "ef76057e10220d8138955c3e027a238d3b3825d9",
-      "branches": {
-        "master": "ef76057e10220d8138955c3e027a238d3b3825d9"
-      }
-    },
-    "refaim/tradeskillsdata": {
-      "default_branch": "master",
-      "sha": "262734ac1703dd93c4990458e08c52f175bde6ea",
-      "branches": {
-        "master": "262734ac1703dd93c4990458e08c52f175bde6ea"
-      }
-    },
-    "chad90b/tradeskillsdata": {
-      "default_branch": "master",
-      "sha": "9cc02127ae479ed39689f9e3a82eeadb5db81caa",
-      "branches": {
-        "master": "9cc02127ae479ed39689f9e3a82eeadb5db81caa"
-      }
-    },
-    "cw60/tradeskillsdata": {
-      "default_branch": "master",
-      "sha": "9cc02127ae479ed39689f9e3a82eeadb5db81caa",
-      "branches": {
-        "master": "9cc02127ae479ed39689f9e3a82eeadb5db81caa"
       }
     },
     "freadblangks/tradeskillsdata": {
@@ -9497,20 +4506,6 @@
         "master": "9cc02127ae479ed39689f9e3a82eeadb5db81caa"
       }
     },
-    "refaim/tradeskillsdata-turtle": {
-      "default_branch": "master",
-      "sha": "a3a09fea9e753d85907fdd7b80b70b742c180950",
-      "branches": {
-        "master": "a3a09fea9e753d85907fdd7b80b70b742c180950"
-      }
-    },
-    "cw60/tradeskillsdata-turtle": {
-      "default_branch": "master",
-      "sha": "81b9653cdb21ad26839a849e9548aa57f4d0a6ed",
-      "branches": {
-        "master": "81b9653cdb21ad26839a849e9548aa57f4d0a6ed"
-      }
-    },
     "freadblangks/tradeskillsdata-turtle": {
       "default_branch": "master",
       "sha": "81b9653cdb21ad26839a849e9548aa57f4d0a6ed",
@@ -9518,2650 +4513,18 @@
         "master": "81b9653cdb21ad26839a849e9548aa57f4d0a6ed"
       }
     },
-    "refaim/trainerskills-vanilla": {
+    "freddea/yaht-turtlewow": {
       "default_branch": "master",
-      "sha": "2ee09ea012ba493505772c56162bc61feed7c2dc",
+      "sha": "ffd729c4ba2a9c25934c38fd9cca93489f056bfa",
       "branches": {
-        "master": "2ee09ea012ba493505772c56162bc61feed7c2dc"
+        "master": "ffd729c4ba2a9c25934c38fd9cca93489f056bfa"
       }
     },
-    "dbfblackbull/trainerskills": {
-      "default_branch": "master",
-      "sha": "cfae8cbcb64a265ab0cc9b1cf07151cb37eb6d65",
-      "branches": {
-        "master": "cfae8cbcb64a265ab0cc9b1cf07151cb37eb6d65"
-      }
-    },
-    "chad90b/trainerskills": {
-      "default_branch": "master",
-      "sha": "20468df1622b9edd3b6ea6c8bfd61fdf641c3598",
-      "branches": {
-        "master": "20468df1622b9edd3b6ea6c8bfd61fdf641c3598"
-      }
-    },
-    "shikulja/trainerskills-vanilla": {
-      "default_branch": "master",
-      "sha": "3d7e4c6edd7526b123261c000a9d8f4db559ca54",
-      "branches": {
-        "master": "3d7e4c6edd7526b123261c000a9d8f4db559ca54"
-      }
-    },
-    "madamsmall/turtleenchant": {
-      "default_branch": "master",
-      "sha": "79a8aab329f579b995dbb4aae19a62cffb5d5ff9",
-      "branches": {
-        "master": "79a8aab329f579b995dbb4aae19a62cffb5d5ff9"
-      }
-    },
-    "firenahzku/vanguardshamantools": {
-      "default_branch": "master",
-      "sha": "0b521998c335ed6933e3393ea7ee8066a987239b",
-      "branches": {
-        "master": "0b521998c335ed6933e3393ea7ee8066a987239b"
-      },
-      "latest_tag": "1.02"
-    },
-    "fiurs-hearth/wiiiui": {
-      "default_branch": "master",
-      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
-      "branches": {
-        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
-      }
-    },
-    "sureshchouksey8/wiiiui": {
-      "default_branch": "master",
-      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
-      "branches": {
-        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
-      }
-    },
-    "starburtmr/wiiiui": {
-      "default_branch": "master",
-      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
-      "branches": {
-        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
-      }
-    },
-    "hmimesh/wiiiui-tbc-anniversary": {
-      "default_branch": "master",
-      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
-      "branches": {
-        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
-      }
-    },
-    "erikgrav/wiiiui_for_vanilla": {
-      "default_branch": "master",
-      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
-      "branches": {
-        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
-      }
-    },
-    "kevinchow9527/wiiiui": {
-      "default_branch": "master",
-      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
-      "branches": {
-        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
-      }
-    },
-    "ronjebara/wiiiui_redux": {
-      "default_branch": "master",
-      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
-      "branches": {
-        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
-      }
-    },
-    "andresuarezschou/wiiiui": {
-      "default_branch": "master",
-      "sha": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600",
-      "branches": {
-        "master": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600"
-      }
-    },
-    "bruceanhuifs/wiiiui": {
-      "default_branch": "master",
-      "sha": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600",
-      "branches": {
-        "master": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600"
-      }
-    },
-    "celguar/wiiiui": {
-      "default_branch": "master",
-      "sha": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600",
-      "branches": {
-        "master": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600"
-      }
-    },
-    "donneyluck/wiiiui": {
-      "default_branch": "master",
-      "sha": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600",
-      "branches": {
-        "master": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600"
-      }
-    },
-    "mtools-top/wiiiui": {
-      "default_branch": "master",
-      "sha": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600",
-      "branches": {
-        "master": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600"
-      }
-    },
-    "herrtrigger/wiiiui": {
-      "default_branch": "master",
-      "sha": "3901983b56129ca5754da1cbfeb86f1c1287caf2",
-      "branches": {
-        "master": "3901983b56129ca5754da1cbfeb86f1c1287caf2"
-      }
-    },
-    "nobrains21/wiiiui": {
-      "default_branch": "master",
-      "sha": "530ade4ef544e1cf8cb269a579c5c8f2dd9abff2",
-      "branches": {
-        "master": "530ade4ef544e1cf8cb269a579c5c8f2dd9abff2"
-      }
-    },
-    "krekog/wiiiui": {
-      "default_branch": "master",
-      "sha": "c6e0170171054612cf7bdc7766c399bc17dff2c0",
-      "branches": {
-        "master": "c6e0170171054612cf7bdc7766c399bc17dff2c0"
-      }
-    },
-    "ratkosrb/wiiiui": {
-      "default_branch": "master",
-      "sha": "530ade4ef544e1cf8cb269a579c5c8f2dd9abff2",
-      "branches": {
-        "master": "530ade4ef544e1cf8cb269a579c5c8f2dd9abff2"
-      }
-    },
-    "einbaum/_autobg": {
-      "default_branch": "master",
-      "sha": "55899bc3aa9acc1e6659e7481ea4f5e424534cc4",
-      "branches": {
-        "master": "55899bc3aa9acc1e6659e7481ea4f5e424534cc4"
-      },
-      "latest_tag": "1.0.0"
-    },
-    "topfreestyle/avbars": {
-      "default_branch": "main",
-      "sha": "4f86368f80da3cb52c6fd5bd05cb9f3e968e4cfa",
-      "branches": {
-        "main": "4f86368f80da3cb52c6fd5bd05cb9f3e968e4cfa"
-      }
-    },
-    "yutsuku/bgreport": {
-      "default_branch": "master",
-      "sha": "11d5db68c06e913ff211deb79fe447b262acb561",
-      "branches": {
-        "master": "11d5db68c06e913ff211deb79fe447b262acb561"
-      }
-    },
-    "neimad-mp/hcwarn": {
-      "default_branch": "main",
-      "sha": "fa5aff09992d412a6079f5289b0d3b3b81b037b1",
-      "branches": {
-        "main": "fa5aff09992d412a6079f5289b0d3b3b81b037b1"
-      }
-    },
-    "mikefirefly/mouseoversounds_pvp": {
-      "default_branch": "main",
-      "sha": "791787d62a0b0065477bc235f861cf4c2b0b1d5a",
-      "branches": {
-        "main": "791787d62a0b0065477bc235f861cf4c2b0b1d5a"
-      }
-    },
-    "ragedunicorn/wow-pvpwarn": {
-      "default_branch": "master",
-      "sha": "9b26bb247e34209ec73d3858443738ace551c3f6",
-      "branches": {
-        "master": "9b26bb247e34209ec73d3858443738ace551c3f6"
-      },
-      "latest_tag": "v1.1.1"
-    },
-    "vargv666/wow-vanilla-pvpwarn": {
-      "default_branch": "master",
-      "sha": "9b26bb247e34209ec73d3858443738ace551c3f6",
-      "branches": {
-        "master": "9b26bb247e34209ec73d3858443738ace551c3f6"
-      }
-    },
-    "shirsig/sentry": {
-      "default_branch": "master",
-      "sha": "4632082624c6c20f445f4c4f26af6a9f96238d8b",
-      "branches": {
-        "master": "4632082624c6c20f445f4c4f26af6a9f96238d8b"
-      }
-    },
-    "einbaum/skmap": {
-      "default_branch": "master",
-      "sha": "bd4301fbd47e76baa482e48345e63f2832f451f9",
-      "branches": {
-        "master": "bd4301fbd47e76baa482e48345e63f2832f451f9"
-      }
-    },
-    "dnkrse/turtlehonorspyenhanced": {
-      "default_branch": "master",
-      "sha": "0ced057f763eb1097a9d96297f530d4c613cfa97",
-      "branches": {
-        "master": "0ced057f763eb1097a9d96297f530d4c613cfa97"
-      }
-    },
-    "evannnn1996/turtlehonorspyenhanced": {
-      "default_branch": "master",
-      "sha": "d84c2d9550e4a672059f12a28d8678806585a844",
-      "branches": {
-        "master": "d84c2d9550e4a672059f12a28d8678806585a844"
-      }
-    },
-    "arektor/turtlehonorspyenhanced": {
-      "default_branch": "master",
-      "sha": "354b88eea4c59236e37ade08e4d3d57122c8f0f3",
-      "branches": {
-        "master": "354b88eea4c59236e37ade08e4d3d57122c8f0f3"
-      }
-    },
-    "yangliang2016/turtlehonorspyenhanced": {
-      "default_branch": "master",
-      "sha": "703707d384418f4935db926f12362c03df271e6f",
-      "branches": {
-        "master": "703707d384418f4935db926f12362c03df271e6f"
-      }
-    },
-    "ravenofseven/turtlehonorspyenhanced": {
-      "default_branch": "master",
-      "sha": "85f3b67a7f1d5100c165045d02f2a845ab39102d",
-      "branches": {
-        "master": "85f3b67a7f1d5100c165045d02f2a845ab39102d"
-      }
-    },
-    "clungo/turtlepvp": {
-      "default_branch": "main",
-      "sha": "bd3f5ed3004c2aabf21bdb6825667ccbabd31883",
-      "branches": {
-        "main": "bd3f5ed3004c2aabf21bdb6825667ccbabd31883"
-      }
-    },
-    "yutsuku/voidbattle": {
-      "default_branch": "master",
-      "sha": "0548bf3bb02a007ca031cce3d6c10d36b775603f",
-      "branches": {
-        "master": "0548bf3bb02a007ca031cce3d6c10d36b775603f"
-      }
-    },
-    "whtmst/youvegotredonyou": {
-      "default_branch": "master",
-      "sha": "b61805c0da7b8cbef410af95b703d217b7e56d55",
-      "branches": {
-        "master": "b61805c0da7b8cbef410af95b703d217b7e56d55"
-      }
-    },
-    "laytya/autobar-for-turtle-wow": {
-      "default_branch": "main",
-      "sha": "5ea82b9cf57571e48836eff76944ac84ccc0a709",
-      "branches": {
-        "main": "5ea82b9cf57571e48836eff76944ac84ccc0a709"
-      }
-    },
-    "bestoriop/autobar": {
-      "default_branch": "octo",
-      "sha": "867064ee5553b4f42dceb887a6bffb049f886279",
-      "branches": {
-        "octo": "867064ee5553b4f42dceb887a6bffb049f886279"
-      }
-    },
-    "lukeelrod/autoconfirm": {
-      "default_branch": "turtle-wow",
-      "sha": "fe4495d0d32a1d208900a6fed1de8a05af844329",
-      "branches": {
-        "turtle-wow": "fe4495d0d32a1d208900a6fed1de8a05af844329"
-      }
-    },
-    "eritzman/autodb": {
-      "default_branch": "main",
-      "sha": "b7784ff2b162242114c6876f4ce808f490a89008",
-      "branches": {
-        "main": "b7784ff2b162242114c6876f4ce808f490a89008"
-      }
-    },
-    "refaim/autodb2": {
-      "default_branch": "main",
-      "sha": "30969e81d98def1e948426f405e7f510563d78c8",
-      "branches": {
-        "main": "30969e81d98def1e948426f405e7f510563d78c8"
-      }
-    },
-    "mcpewpew/hidebattlegroundfinder": {
-      "default_branch": "main",
-      "sha": "dba37510eb9dd867db350d083d7d7ecae53a2479",
-      "branches": {
-        "main": "dba37510eb9dd867db350d083d7d7ecae53a2479"
-      }
-    },
-    "mickeypickey/autoquest": {
-      "default_branch": "master",
-      "sha": "0190202588b29d1d7f8bac73845e78ce46301210",
-      "branches": {
-        "master": "0190202588b29d1d7f8bac73845e78ce46301210"
-      },
-      "latest_tag": "v2.0.3"
-    },
-    "valiusha90/autoturnin": {
-      "default_branch": "main",
-      "sha": "9c8c0c08863cab9860b79205ffea1358b65aae29",
-      "branches": {
-        "main": "9c8c0c08863cab9860b79205ffea1358b65aae29"
-      }
-    },
-    "profiler781/autoturnin": {
-      "default_branch": "main",
-      "sha": "af79320ed201332dd63e2439bfb72c10e890f6d0",
-      "branches": {
-        "main": "af79320ed201332dd63e2439bfb72c10e890f6d0"
-      }
-    },
-    "tlplayer/betterquest": {
-      "default_branch": "main",
-      "sha": "73d67930f718bef6fc595495af4099866b04c137",
-      "branches": {
-        "main": "73d67930f718bef6fc595495af4099866b04c137"
-      },
-      "latest_tag": "0.2"
-    },
-    "karstenbade/betterquest": {
-      "default_branch": "main",
-      "sha": "9957848d96a606b3880ce366228768208adf3eaa",
-      "branches": {
-        "main": "9957848d96a606b3880ce366228768208adf3eaa"
-      }
-    },
-    "einbaum/chroniclespi": {
-      "default_branch": "master",
-      "sha": "fca0da346c4f91f50b7a5b44f72ced84b68dd6dd",
-      "branches": {
-        "master": "fca0da346c4f91f50b7a5b44f72ced84b68dd6dd"
-      },
-      "latest_tag": "1.2.0"
-    },
-    "northyn/chroniclespi": {
-      "default_branch": "master",
-      "sha": "b26612714ace6183b62d5d10726e8d3db126467e",
-      "branches": {
-        "master": "b26612714ace6183b62d5d10726e8d3db126467e"
-      }
-    },
-    "muehe/classicdb": {
-      "default_branch": "master",
-      "sha": "e7ecc0f18fd764694b3acc5c3a31d297b1c4eb3e",
-      "branches": {
-        "master": "e7ecc0f18fd764694b3acc5c3a31d297b1c4eb3e"
-      },
-      "latest_tag": "1.0-beta.2"
-    },
-    "jslquintero/dialogui": {
-      "default_branch": "main",
-      "sha": "99cb4864753c716bbcdd756d49c64edb35c58dcc",
-      "branches": {
-        "main": "99cb4864753c716bbcdd756d49c64edb35c58dcc"
-      }
-    },
-    "evannnn1996/dialogui": {
-      "default_branch": "main",
-      "sha": "df8d33e2fb3f8aff1425ec021528b2d00a925bfb",
-      "branches": {
-        "main": "df8d33e2fb3f8aff1425ec021528b2d00a925bfb"
-      }
-    },
-    "wiggen94/dialogui": {
-      "default_branch": "main",
-      "sha": "b0632607d01382f1eadfa222cebdb9f430660342",
-      "branches": {
-        "main": "b0632607d01382f1eadfa222cebdb9f430660342"
-      }
-    },
-    "adrianocastro189/dialogui": {
-      "default_branch": "main",
-      "sha": "68177f7af67175453c157932a43fe648e0d8fa0f",
-      "branches": {
-        "main": "68177f7af67175453c157932a43fe648e0d8fa0f"
-      }
-    },
-    "hestiacn/dialogui": {
-      "default_branch": "main",
-      "sha": "fc4e5986b06b230a3ca3f706dcf5f908b7e51b9c",
-      "branches": {
-        "main": "fc4e5986b06b230a3ca3f706dcf5f908b7e51b9c"
-      }
-    },
-    "saulfire/dialogui-turtlelatam": {
-      "default_branch": "main",
-      "sha": "c82da045147a534a0526a7b602a17d8940b73557",
-      "branches": {
-        "main": "c82da045147a534a0526a7b602a17d8940b73557"
-      }
-    },
-    "rumchiller/em_monkeyquest": {
-      "default_branch": "master",
-      "sha": "e5bc0ce47d3ae5a61ebdfd449ece7c485446cb2a",
-      "branches": {
-        "master": "e5bc0ce47d3ae5a61ebdfd449ece7c485446cb2a"
-      }
-    },
-    "laytya/eql3": {
-      "default_branch": "master",
-      "sha": "a0ced1c73e99aa2662e5d959dd96fcec33ddcfb4",
-      "branches": {
-        "master": "a0ced1c73e99aa2662e5d959dd96fcec33ddcfb4"
-      }
-    },
-    "trashcanhands/explorermap": {
-      "default_branch": "master",
-      "sha": "3f943992dafb32fbcf0cff31260dc7806db2277d",
-      "branches": {
-        "master": "3f943992dafb32fbcf0cff31260dc7806db2277d"
-      }
-    },
-    "goldenpipes/pfquest_fu": {
-      "default_branch": "main",
-      "sha": "c37708cd290b6e06c2a3476f3f05f2c72bf48008",
-      "branches": {
-        "main": "c37708cd290b6e06c2a3476f3f05f2c72bf48008"
-      }
-    },
-    "jeromem/guidelimevanilla": {
-      "default_branch": "master",
-      "sha": "bd87cdb5fc9c3bd125afdb6da5819b5e92f2dec5",
-      "branches": {
-        "master": "bd87cdb5fc9c3bd125afdb6da5819b5e92f2dec5"
-      },
-      "latest_tag": "v0.12.7"
-    },
-    "tubtubs/guidelimevanilla": {
-      "default_branch": "master",
-      "sha": "bd87cdb5fc9c3bd125afdb6da5819b5e92f2dec5",
-      "branches": {
-        "master": "bd87cdb5fc9c3bd125afdb6da5819b5e92f2dec5"
-      }
-    },
-    "eritzman/guidelimevanilla": {
-      "default_branch": "master",
-      "sha": "5640eacebce1054c6196ea0c6ea68c52695ee7e4",
-      "branches": {
-        "master": "5640eacebce1054c6196ea0c6ea68c52695ee7e4"
-      }
-    },
-    "kameleonuk/lootcrestreminder": {
-      "default_branch": "main",
-      "sha": "927f1a414bba42a817dd3900632e8ea2947bc959",
-      "branches": {
-        "main": "927f1a414bba42a817dd3900632e8ea2947bc959"
-      }
-    },
-    "scoboose/notesuneed-turtle": {
-      "default_branch": "master",
-      "sha": "0f35ca358bc0ea052bd4ce38bd1a13f977dd37ef",
-      "branches": {
-        "master": "0f35ca358bc0ea052bd4ce38bd1a13f977dd37ef"
-      }
-    },
-    "taabu-git/notesuneed-turtle": {
-      "default_branch": "master",
-      "sha": "fc3ce8c9607bd58069a9748671c0e46042ccd2f9",
-      "branches": {
-        "master": "fc3ce8c9607bd58069a9748671c0e46042ccd2f9"
-      }
-    },
-    "cliencer/pfextend": {
-      "default_branch": "main",
-      "sha": "6a8e03142901771fca71fefe8df5c2aa41f6105d",
-      "branches": {
-        "main": "6a8e03142901771fca71fefe8df5c2aa41f6105d"
-      },
-      "latest_tag": "1.0.6"
-    },
-    "roby-brok/pfextend": {
-      "default_branch": "main",
-      "sha": "27c56f5ea75eced6249b349d4a61c86fd5ff9bcb",
-      "branches": {
-        "main": "27c56f5ea75eced6249b349d4a61c86fd5ff9bcb"
-      },
-      "latest_tag": "1.0.8"
-    },
-    "ravenofseven/pfextend": {
-      "default_branch": "main",
-      "sha": "7281b5d3747591f7b043ccb5656283ce5dec8c7f",
-      "branches": {
-        "main": "7281b5d3747591f7b043ccb5656283ce5dec8c7f"
-      }
-    },
-    "al3xc1985/pfextend": {
-      "default_branch": "main",
-      "sha": "7281b5d3747591f7b043ccb5656283ce5dec8c7f",
-      "branches": {
-        "main": "7281b5d3747591f7b043ccb5656283ce5dec8c7f"
-      }
-    },
-    "the-kludge-bureau/pfquest": {
-      "default_branch": "main",
-      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
-      "branches": {
-        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
-      },
-      "latest_tag": "8.0.0"
-    },
-    "brues-code/pfquest": {
-      "default_branch": "main",
-      "sha": "f5ff7f3ed220027a2cf9c8aaa4fd6fc037211b3d",
-      "branches": {
-        "main": "f5ff7f3ed220027a2cf9c8aaa4fd6fc037211b3d"
-      }
-    },
-    "liruqi/pfquest": {
-      "default_branch": "main",
-      "sha": "b349cd5e3e71d6deef78601efccb84a3093df60e",
-      "branches": {
-        "main": "b349cd5e3e71d6deef78601efccb84a3093df60e"
-      }
-    },
-    "bluewhale1337/pfquest": {
-      "default_branch": "main",
-      "sha": "cd45867716f2269faa4cfb8fc6b69fde0723d60c",
-      "branches": {
-        "main": "cd45867716f2269faa4cfb8fc6b69fde0723d60c"
-      }
-    },
-    "shagu/pfquest-icons": {
-      "default_branch": "master",
-      "sha": "709ba275b7198b93713b5b06cf896dc9006ebeea",
-      "branches": {
-        "master": "709ba275b7198b93713b5b06cf896dc9006ebeea"
-      }
-    },
-    "amonra/pfquest-icons": {
-      "default_branch": "master",
-      "sha": "709ba275b7198b93713b5b06cf896dc9006ebeea",
-      "branches": {
-        "master": "709ba275b7198b93713b5b06cf896dc9006ebeea"
-      }
-    },
-    "dwbclz/pfquest-icons": {
-      "default_branch": "master",
-      "sha": "709ba275b7198b93713b5b06cf896dc9006ebeea",
-      "branches": {
-        "master": "709ba275b7198b93713b5b06cf896dc9006ebeea"
-      }
-    },
-    "jiangxt316/pfquest-icons": {
-      "default_branch": "master",
-      "sha": "709ba275b7198b93713b5b06cf896dc9006ebeea",
-      "branches": {
-        "master": "709ba275b7198b93713b5b06cf896dc9006ebeea"
-      }
-    },
-    "ravenofseven/pfquest-icons": {
-      "default_branch": "master",
-      "sha": "709ba275b7198b93713b5b06cf896dc9006ebeea",
-      "branches": {
-        "master": "709ba275b7198b93713b5b06cf896dc9006ebeea"
-      }
-    },
-    "chad90b/pfquest-icons": {
-      "default_branch": "master",
-      "sha": "399eaa6391aa816f91c989dfe5a96a69b884457b",
-      "branches": {
-        "master": "399eaa6391aa816f91c989dfe5a96a69b884457b"
-      }
-    },
-    "the-kludge-bureau/pfquest-turtle": {
-      "default_branch": "main",
-      "sha": "d11e7631774f390edb5b26b86cd84cf43aee5e20",
-      "branches": {
-        "main": "d11e7631774f390edb5b26b86cd84cf43aee5e20"
-      }
-    },
-    "kameleonuk/pfquest-turtle": {
-      "default_branch": "main",
-      "sha": "5b8eeeeb4119be9d075087f0f0e08c187b35ad61",
-      "branches": {
-        "main": "5b8eeeeb4119be9d075087f0f0e08c187b35ad61"
-      }
-    },
-    "dvmanlosa/pfquest-turtle": {
-      "default_branch": "main",
-      "sha": "a7c46448204a8d6d59cf29adec8fb67c6a4cfc97",
-      "branches": {
-        "main": "a7c46448204a8d6d59cf29adec8fb67c6a4cfc97"
-      }
-    },
-    "al3xc1985/pfquest-turtle": {
-      "default_branch": "main",
-      "sha": "d11e7631774f390edb5b26b86cd84cf43aee5e20",
-      "branches": {
-        "main": "d11e7631774f390edb5b26b86cd84cf43aee5e20"
-      }
-    },
-    "mrmaffen/pfquest-turtle": {
-      "default_branch": "main",
-      "sha": "6228f8f780e5850013f8612a4e0a45430ca6336d",
-      "branches": {
-        "main": "6228f8f780e5850013f8612a4e0a45430ca6336d"
-      }
-    },
-    "ravenofseven/pfquest-turtle": {
-      "default_branch": "main",
-      "sha": "df24087b9f958cd4e4b057b58805233e820c9981",
-      "branches": {
-        "main": "df24087b9f958cd4e4b057b58805233e820c9981"
-      }
-    },
-    "elboaf/ppbuddy": {
-      "default_branch": "main",
-      "sha": "3f1ac235717464a176eed5e320118d8666945ef5",
-      "branches": {
-        "main": "3f1ac235717464a176eed5e320118d8666945ef5"
-      }
-    },
-    "moiian/immersivedialogui": {
-      "default_branch": "main",
-      "sha": "6acec0e0c01bbdf846c468c94ac583cd28b33705",
-      "branches": {
-        "main": "6acec0e0c01bbdf846c468c94ac583cd28b33705"
-      },
-      "latest_tag": "1.2"
-    },
-    "or0bas/immersivedialogui": {
-      "default_branch": "main",
-      "sha": "6a3eb0afe136921a9bed9fe5fa2c9b7f787b0625",
-      "branches": {
-        "main": "6a3eb0afe136921a9bed9fe5fa2c9b7f787b0625"
-      }
-    },
-    "ahhh-reptar/questannouncer": {
-      "default_branch": "main",
-      "sha": "cf324e82e89e3eb87d62c3aed717f93ab2656a02",
-      "branches": {
-        "main": "cf324e82e89e3eb87d62c3aed717f93ab2656a02"
-      }
-    },
-    "jembawow/questannouncer": {
-      "default_branch": "main",
-      "sha": "bbf71adc957d6c5d2e637a0f974845ff69903691",
-      "branches": {
-        "main": "bbf71adc957d6c5d2e637a0f974845ff69903691"
-      }
-    },
-    "fusionpit/questframefixer": {
-      "default_branch": "master",
-      "sha": "6eef35fbfcc51039f7d1e3cff78061468abeb69e",
-      "branches": {
-        "master": "6eef35fbfcc51039f7d1e3cff78061468abeb69e"
-      },
-      "latest_tag": "4.0.2"
-    },
-    "chad90b/questframefixer": {
-      "default_branch": "master",
-      "sha": "3cce407a9acd8a035507c6022f47109320509031",
-      "branches": {
-        "master": "3cce407a9acd8a035507c6022f47109320509031"
-      }
-    },
-    "grenderg/questhistory": {
-      "default_branch": "master",
-      "sha": "3e2b54a8e5d6b381e4827a305d2879b9d09b6b83",
-      "branches": {
-        "master": "3e2b54a8e5d6b381e4827a305d2879b9d09b6b83"
-      }
-    },
-    "graved/questprogressshare": {
-      "default_branch": "main",
-      "sha": "afbc780d394dc68131fb1244fe322f149c3ba356",
-      "branches": {
-        "main": "afbc780d394dc68131fb1244fe322f149c3ba356"
-      },
-      "latest_tag": "1.6.0"
-    },
-    "fdotcico/questprogressshare": {
-      "default_branch": "main",
-      "sha": "afbc780d394dc68131fb1244fe322f149c3ba356",
-      "branches": {
-        "main": "afbc780d394dc68131fb1244fe322f149c3ba356"
-      },
-      "latest_tag": "1.6.0"
-    },
-    "longpiggy/questprogressshare": {
-      "default_branch": "main",
-      "sha": "46bd8bb6a9f67c54b99ed3d7ea6b1fcdae7f9f62",
-      "branches": {
-        "main": "46bd8bb6a9f67c54b99ed3d7ea6b1fcdae7f9f62"
-      }
-    },
-    "bestoriop/questprogressshare": {
-      "default_branch": "main",
-      "sha": "c96de984adc175a8e293e402837af256e9a31abf",
-      "branches": {
-        "main": "c96de984adc175a8e293e402837af256e9a31abf"
-      }
-    },
-    "thezephyrsong/questprogressshare": {
-      "default_branch": "main",
-      "sha": "331b538af655c6cc129d68232871d5a9eb1a9b34",
-      "branches": {
-        "main": "331b538af655c6cc129d68232871d5a9eb1a9b34"
-      },
-      "latest_tag": "1.5.1"
-    },
-    "cdmichaelb/questprogressshare": {
-      "default_branch": "main",
-      "sha": "50261dd1cf7ac85c746b4693a763353c90dd10c7",
-      "branches": {
-        "main": "50261dd1cf7ac85c746b4693a763353c90dd10c7"
-      }
-    },
-    "tr0812/questprogressshare": {
-      "default_branch": "main",
-      "sha": "11e0164ea2f3a4aeab420259b7cf71b0fa2567f6",
-      "branches": {
-        "main": "11e0164ea2f3a4aeab420259b7cf71b0fa2567f6"
-      }
-    },
-    "marcelinevq/questrepeat": {
-      "default_branch": "master",
-      "sha": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf",
-      "branches": {
-        "master": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf"
-      }
-    },
-    "al3xc1985/questrepeat": {
-      "default_branch": "master",
-      "sha": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf",
-      "branches": {
-        "master": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf"
-      }
-    },
-    "evannnn1996/questrepeat": {
-      "default_branch": "master",
-      "sha": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf",
-      "branches": {
-        "master": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf"
-      }
-    },
-    "paenthy/questrepeat": {
-      "default_branch": "master",
-      "sha": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf",
-      "branches": {
-        "master": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf"
-      }
-    },
-    "valiusha90/questshell": {
-      "default_branch": "main",
-      "sha": "2c18024c288f48b524175aab1ec1803db5154d60",
-      "branches": {
-        "main": "2c18024c288f48b524175aab1ec1803db5154d60"
-      }
-    },
-    "road-block/questsoundbits": {
-      "default_branch": "master",
-      "sha": "2ddce3ae7d854b37cb4d11df227b796be510ddbe",
-      "branches": {
-        "master": "2ddce3ae7d854b37cb4d11df227b796be510ddbe"
-      },
-      "latest_tag": "2.11-11200"
-    },
-    "gabcinder2004/questtracker": {
-      "default_branch": "master",
-      "sha": "85697ea3837ef3b872e2dc3a0f33780a6e807188",
-      "branches": {
-        "master": "85697ea3837ef3b872e2dc3a0f33780a6e807188"
-      }
-    },
-    "daribon/questtranslator": {
-      "default_branch": "master",
-      "sha": "151667024e19be5640440596e1b41f984eaa9677",
-      "branches": {
-        "master": "151667024e19be5640440596e1b41f984eaa9677"
-      }
-    },
-    "noranbits/questtranslator": {
-      "default_branch": "master",
-      "sha": "fd40fc25a4eab5495ac0257305cbb4998cf7777f",
-      "branches": {
-        "master": "fd40fc25a4eab5495ac0257305cbb4998cf7777f"
-      }
-    },
-    "zirtox1992/showchests": {
-      "default_branch": "main",
-      "sha": "844065c7334d4eb97d78167dab6db2729f214e7d",
-      "branches": {
-        "main": "844065c7334d4eb97d78167dab6db2729f214e7d"
-      }
-    },
-    "cralor/tourguide_professions": {
-      "default_branch": "master",
-      "sha": "c5ed92c003f625b1c84d37dfa724b7ef298e21c0",
-      "branches": {
-        "master": "c5ed92c003f625b1c84d37dfa724b7ef298e21c0"
-      },
-      "latest_tag": "1.0.2-beta"
-    },
-    "road-block/tourguide_professions": {
-      "default_branch": "master",
-      "sha": "3a03ed5ba31329b7c30e85238c3f07911108f725",
-      "branches": {
-        "master": "3a03ed5ba31329b7c30e85238c3f07911108f725"
-      },
-      "latest_tag": "1.0.0-beta"
-    },
-    "cyaohiri/triviabot-turtlewow": {
-      "default_branch": "master",
-      "sha": "e11b168dd15d3d0eac358bf2f7c7a75c68dcd63b",
-      "branches": {
-        "master": "e11b168dd15d3d0eac358bf2f7c7a75c68dcd63b"
-      }
-    },
-    "greendam/triviabot-turtlewow": {
-      "default_branch": "master",
-      "sha": "320c59d1a63022b08672f52008e9e69f6135c4a1",
-      "branches": {
-        "master": "320c59d1a63022b08672f52008e9e69f6135c4a1"
-      }
-    },
-    "tubtubs/vanillastoryline": {
-      "default_branch": "master",
-      "sha": "47bf6bbd174db51623a1b6bb27879f08e04dc390",
-      "branches": {
-        "master": "47bf6bbd174db51623a1b6bb27879f08e04dc390"
-      }
-    },
-    "al3xc1985/vanillastoryline": {
-      "default_branch": "master",
-      "sha": "47bf6bbd174db51623a1b6bb27879f08e04dc390",
-      "branches": {
-        "master": "47bf6bbd174db51623a1b6bb27879f08e04dc390"
-      }
-    },
-    "alanli7991/vanillastoryline": {
-      "default_branch": "master",
-      "sha": "47bf6bbd174db51623a1b6bb27879f08e04dc390",
-      "branches": {
-        "master": "47bf6bbd174db51623a1b6bb27879f08e04dc390"
-      }
-    },
-    "callumhoughton18/vanillastoryline": {
-      "default_branch": "master",
-      "sha": "259e712611e3cc81881d776eed527dc82725d8e0",
-      "branches": {
-        "master": "259e712611e3cc81881d776eed527dc82725d8e0"
-      }
-    },
-    "kirillserogodsky/vanillastoryline-turtle": {
-      "default_branch": "master",
-      "sha": "b5536df41bf71437e6d0373906b63a3c7662e5b1",
-      "branches": {
-        "master": "b5536df41bf71437e6d0373906b63a3c7662e5b1"
-      }
-    },
-    "jayparry/xtolevel-classic": {
-      "default_branch": "develop",
-      "sha": "41e8a92d79e565959492e6e3c3f704bff5701d1e",
-      "branches": {
-        "develop": "41e8a92d79e565959492e6e3c3f704bff5701d1e"
-      }
-    },
-    "kirchlive/atlasloot-gearfilter": {
-      "default_branch": "main",
-      "sha": "7b24283dc1e428b01d9a9535c5ae9c05e666336d",
-      "branches": {
-        "main": "7b24283dc1e428b01d9a9535c5ae9c05e666336d"
-      },
-      "latest_tag": "v1.1.2"
-    },
-    "balakethelock/automasterlooter": {
-      "default_branch": "master",
-      "sha": "5d2b0cf849120ff7bd4835c1593c4a2e28a843ab",
-      "branches": {
-        "master": "5d2b0cf849120ff7bd4835c1593c4a2e28a843ab"
-      }
-    },
-    "noaf-guild/automasterlooter": {
-      "default_branch": "master",
-      "sha": "813fb146b5f1f98abe7e53461d9a6673b0360ff9",
-      "branches": {
-        "master": "813fb146b5f1f98abe7e53461d9a6673b0360ff9"
-      }
-    },
-    "bahamutxd/automasterlooter": {
-      "default_branch": "master",
-      "sha": "f2d18ce595159702d4a067477278e6fa73e7c5c3",
-      "branches": {
-        "master": "f2d18ce595159702d4a067477278e6fa73e7c5c3"
-      }
-    },
-    "otari98/automasterlooter": {
-      "default_branch": "master",
-      "sha": "d28d1a0873209bb5933a309e46c93ee3bcbb6f68",
-      "branches": {
-        "master": "d28d1a0873209bb5933a309e46c93ee3bcbb6f68"
-      }
-    },
-    "balakethelock/bananabar": {
-      "default_branch": "master",
-      "sha": "d1f000b43d7e5e42f1b249b0a280ccf66aa3fb22",
-      "branches": {
-        "master": "d1f000b43d7e5e42f1b249b0a280ccf66aa3fb22"
-      }
-    },
-    "otari98/bananabar": {
-      "default_branch": "master",
-      "sha": "8ea75d51c39c8a17b48a1d586d859e4887cd17fb",
-      "branches": {
-        "master": "8ea75d51c39c8a17b48a1d586d859e4887cd17fb"
-      }
-    },
-    "mcpewpew/bmloot": {
-      "default_branch": "master",
-      "sha": "73585e353410ea0bbf205fc22ef337ad3c850d5b",
-      "branches": {
-        "master": "73585e353410ea0bbf205fc22ef337ad3c850d5b"
-      }
-    },
-    "npeschke/bmloot": {
-      "default_branch": "master",
-      "sha": "73585e353410ea0bbf205fc22ef337ad3c850d5b",
-      "branches": {
-        "master": "73585e353410ea0bbf205fc22ef337ad3c850d5b"
-      }
-    },
-    "aubreykun/bmloot": {
-      "default_branch": "master",
-      "sha": "3fee37cdc301bfac11a7f231b5a2401eecbf4eee",
-      "branches": {
-        "master": "3fee37cdc301bfac11a7f231b5a2401eecbf4eee"
-      }
-    },
-    "yamayaml/bossmechanicshelper": {
-      "default_branch": "main",
-      "sha": "11c79323862865d6a110dbb3c40016a1714b84cd",
-      "branches": {
-        "main": "11c79323862865d6a110dbb3c40016a1714b84cd"
-      }
-    },
-    "therealfayz/bossmechanicshelper": {
-      "default_branch": "main",
-      "sha": "20f4487b8fb302291bcad45e8d40bce2c17ffb69",
-      "branches": {
-        "main": "20f4487b8fb302291bcad45e8d40bce2c17ffb69"
-      }
-    },
-    "jrc13245/bosstactics": {
-      "default_branch": "main",
-      "sha": "e21c19dee734cf3f647f8298ad6c37ba253b15b9",
-      "branches": {
-        "main": "e21c19dee734cf3f647f8298ad6c37ba253b15b9"
-      }
-    },
-    "trumpetx/chatlootbidder": {
-      "default_branch": "master",
-      "sha": "bc6c2f807d2c7790308f8abf503b00d83dbc6988",
-      "branches": {
-        "master": "bc6c2f807d2c7790308f8abf503b00d83dbc6988"
-      },
-      "latest_tag": "v1.11.2"
-    },
-    "asyncwithsky/chatlootbidder": {
-      "default_branch": "master",
-      "sha": "065c1e2b8a676ba230b6441abea7dccc0ffa1a31",
-      "branches": {
-        "master": "065c1e2b8a676ba230b6441abea7dccc0ffa1a31"
-      }
-    },
-    "orfc/chatlootbidder": {
-      "default_branch": "master",
-      "sha": "faba50a00e66ada8c20e70b542d23081450d2656",
-      "branches": {
-        "master": "faba50a00e66ada8c20e70b542d23081450d2656"
-      }
-    },
-    "emyrk/chroniclecompanion": {
-      "default_branch": "main",
-      "sha": "36d9265604ad15baa918aeee576264962632dd47",
-      "branches": {
-        "main": "36d9265604ad15baa918aeee576264962632dd47"
-      }
-    },
-    "artificialowl/chroniclecompanion": {
-      "default_branch": "main",
-      "sha": "0aa90950cd198c55de5025501a22826411716523",
-      "branches": {
-        "main": "0aa90950cd198c55de5025501a22826411716523"
-      }
-    },
-    "einbaum/chroniclesbuffassignments": {
-      "default_branch": "master",
-      "sha": "996ef976bd97c3312bcdb7656c330ef0c95ce7c1",
-      "branches": {
-        "master": "996ef976bd97c3312bcdb7656c330ef0c95ce7c1"
-      },
-      "latest_tag": "1.0.0"
-    },
-    "einbaum/chroniclesptr": {
-      "default_branch": "master",
-      "sha": "027d1dc67cdbaf5a4f10fcba504911eeaba8c0f5",
-      "branches": {
-        "master": "027d1dc67cdbaf5a4f10fcba504911eeaba8c0f5"
-      }
-    },
-    "trumpetx/combatloggingreminder": {
-      "default_branch": "master",
-      "sha": "12aa83d21401fe3cb655258ddf4f5859e18e3f4d",
-      "branches": {
-        "master": "12aa83d21401fe3cb655258ddf4f5859e18e3f4d"
-      }
-    },
-    "mcpewpew/cthunwarner": {
-      "default_branch": "master",
-      "sha": "70f5129730bb96834abab7678ec7e51c402fbbc8",
-      "branches": {
-        "master": "70f5129730bb96834abab7678ec7e51c402fbbc8"
-      }
-    },
-    "bretharte89/cthunwarner": {
-      "default_branch": "master",
-      "sha": "70f5129730bb96834abab7678ec7e51c402fbbc8",
-      "branches": {
-        "master": "70f5129730bb96834abab7678ec7e51c402fbbc8"
-      }
-    },
-    "dogmax/damagemeters": {
-      "default_branch": "main",
-      "sha": "4b42534ff9c80b128d5830985c812ea08e77e267",
-      "branches": {
-        "main": "4b42534ff9c80b128d5830985c812ea08e77e267"
-      }
-    },
-    "ravenofseven/damagemeters": {
-      "default_branch": "main",
-      "sha": "4b42534ff9c80b128d5830985c812ea08e77e267",
-      "branches": {
-        "main": "4b42534ff9c80b128d5830985c812ea08e77e267"
-      }
-    },
-    "yutsuku/lvbm": {
-      "default_branch": "master",
-      "sha": "84c4311a9c3d6b4af24c94079d6d157705444bf4",
-      "branches": {
-        "master": "84c4311a9c3d6b4af24c94079d6d157705444bf4"
-      }
-    },
-    "jejkas/devilshunters": {
-      "default_branch": "master",
-      "sha": "2b76f0d2647fc8d53adedde1532b74ac652d1e98",
-      "branches": {
-        "master": "2b76f0d2647fc8d53adedde1532b74ac652d1e98"
-      }
-    },
-    "yutsuku/dpepgp": {
-      "default_branch": "master",
-      "sha": "aadc9f40cc0d567922df8d6a9deebe5decdf8dc4",
-      "branches": {
-        "master": "aadc9f40cc0d567922df8d6a9deebe5decdf8dc4"
-      }
-    },
-    "numielle/easyloot": {
-      "default_branch": "master",
-      "sha": "c3ee8e6d4970db3df35ae0d5fb7484e29cd9a6f5",
-      "branches": {
-        "master": "c3ee8e6d4970db3df35ae0d5fb7484e29cd9a6f5"
-      }
-    },
-    "isitlove/epgpexport": {
-      "default_branch": "master",
-      "sha": "9d50d4df254bc50aecb57880c54216df74759864",
-      "branches": {
-        "master": "9d50d4df254bc50aecb57880c54216df74759864"
-      },
-      "latest_tag": "1.0"
-    },
-    "0ldi/exoraidsetup": {
-      "default_branch": "master",
-      "sha": "bb2447fad6623620bf575245f090d268e37f9307",
-      "branches": {
-        "master": "bb2447fad6623620bf575245f090d268e37f9307"
-      }
-    },
-    "geigerkind/expandassist": {
-      "default_branch": "master",
-      "sha": "c002b9b1bf403d4ecb8045a1283baa02ec0ebb69",
-      "branches": {
-        "master": "c002b9b1bf403d4ecb8045a1283baa02ec0ebb69"
-      },
-      "latest_tag": "b1"
-    },
-    "itslusse/fika": {
-      "default_branch": "main",
-      "sha": "062c34120fdc10dddb499f6fd3fef8442af9db94",
-      "branches": {
-        "main": "062c34120fdc10dddb499f6fd3fef8442af9db94"
-      }
-    },
-    "trumpetx/flyertimer": {
-      "default_branch": "master",
-      "sha": "58a1a62caae40c6e4a0147352cc425f5611fe31d",
-      "branches": {
-        "master": "58a1a62caae40c6e4a0147352cc425f5611fe31d"
-      }
-    },
-    "bycfm2/fonzappraiser": {
-      "default_branch": "main",
-      "sha": "924a5521532e0cbac8f90f7f4aac5fe855cc9072",
-      "branches": {
-        "main": "924a5521532e0cbac8f90f7f4aac5fe855cc9072"
-      }
-    },
-    "cubenicke/fury": {
-      "default_branch": "master",
-      "sha": "e832d00beebe52c32989f8621e4eaf05730ecd7e",
-      "branches": {
-        "master": "e832d00beebe52c32989f8621e4eaf05730ecd7e"
-      },
-      "latest_tag": "fury_1_15"
-    },
-    "tperraut/fury": {
-      "default_branch": "master",
-      "sha": "e6a78fb22e8657db8f582b614604e544817742a5",
-      "branches": {
-        "master": "e6a78fb22e8657db8f582b614604e544817742a5"
-      }
-    },
-    "joseph-box/fury": {
-      "default_branch": "master",
-      "sha": "d66923619abd0b6d22f2c6f95a4f2080338d8a19",
-      "branches": {
-        "master": "d66923619abd0b6d22f2c6f95a4f2080338d8a19"
-      }
-    },
-    "srazdokunebil/fury": {
-      "default_branch": "master",
-      "sha": "3a184d75ccae8f35dbf58bf9c4e1eab5e228446f",
-      "branches": {
-        "master": "3a184d75ccae8f35dbf58bf9c4e1eab5e228446f"
-      },
-      "latest_tag": "fury_1_15"
-    },
-    "j0n12/fury": {
-      "default_branch": "master",
-      "sha": "e832d00beebe52c32989f8621e4eaf05730ecd7e",
-      "branches": {
-        "master": "e832d00beebe52c32989f8621e4eaf05730ecd7e"
-      }
-    },
-    "0ldi/imba": {
-      "default_branch": "master",
-      "sha": "88c87ffd4e73e7542e9f46aa411264419d1b815b",
-      "branches": {
-        "master": "88c87ffd4e73e7542e9f46aa411264419d1b815b"
-      }
-    },
-    "bergador/insigniataken": {
-      "default_branch": "master",
-      "sha": "d0958f91a5246cc970cd350e40b62d380962db51",
-      "branches": {
-        "master": "d0958f91a5246cc970cd350e40b62d380962db51"
-      }
-    },
-    "blackhaste/lazyres": {
-      "default_branch": "master",
-      "sha": "ffed45c8d6912aef7cb8e2531745928edce54af9",
-      "branches": {
-        "master": "ffed45c8d6912aef7cb8e2531745928edce54af9"
-      }
-    },
-    "vargv666/lazyres": {
-      "default_branch": "master",
-      "sha": "ffed45c8d6912aef7cb8e2531745928edce54af9",
-      "branches": {
-        "master": "ffed45c8d6912aef7cb8e2531745928edce54af9"
-      }
-    },
-    "marcelinevq/lazyweirdo": {
-      "default_branch": "master",
-      "sha": "5e248132d6814788f3154e00445c6f7ea45a74fb",
-      "branches": {
-        "master": "5e248132d6814788f3154e00445c6f7ea45a74fb"
-      }
-    },
-    "autignem/lazyweirdo": {
-      "default_branch": "master",
-      "sha": "713b621d6e6bdd9b73f4f3ebaa87d3650e7ead97",
-      "branches": {
-        "master": "713b621d6e6bdd9b73f4f3ebaa87d3650e7ead97"
-      }
-    },
-    "paenthy/easyloot": {
-      "default_branch": "master",
-      "sha": "e464dff7d1d6104e306cbbcb9cba91b9561c9d0b",
-      "branches": {
-        "master": "e464dff7d1d6104e306cbbcb9cba91b9561c9d0b"
-      }
-    },
-    "zedorff/lockassignment": {
-      "default_branch": "main",
-      "sha": "68b448250b826b7791dfc020d469128c77ea03d8",
-      "branches": {
-        "main": "68b448250b826b7791dfc020d469128c77ea03d8"
-      }
-    },
-    "creohex/lockassignment": {
-      "default_branch": "main",
-      "sha": "c82e4b47c969736fb83cfd0ce56d451ad4ecab0e",
-      "branches": {
-        "main": "c82e4b47c969736fb83cfd0ce56d451ad4ecab0e"
-      }
-    },
-    "mitjafelicijan/lootatmouse": {
-      "default_branch": "master",
-      "sha": "b9801539d7366c9f17d76c97fde77f8f42a10d75",
-      "branches": {
-        "master": "b9801539d7366c9f17d76c97fde77f8f42a10d75"
-      }
-    },
-    "zaazbb/lootatmouse": {
-      "default_branch": "master",
-      "sha": "2c9602b633ff62cb129bec9c24683cff2e3c9208",
-      "branches": {
-        "master": "2c9602b633ff62cb129bec9c24683cff2e3c9208"
-      }
-    },
-    "marcelinevq/lootblare": {
-      "default_branch": "master",
-      "sha": "eccea47172a2d600aa73001008cc3c1f34b221da",
-      "branches": {
-        "master": "eccea47172a2d600aa73001008cc3c1f34b221da"
-      }
-    },
-    "siventt/lootblare": {
-      "default_branch": "master",
-      "sha": "7a17a8d1e617cbd61bcd363ff7bb1e2c9e09eb93",
-      "branches": {
-        "master": "7a17a8d1e617cbd61bcd363ff7bb1e2c9e09eb93"
-      }
-    },
-    "kornfedfred/lootblare-wrath": {
-      "default_branch": "master",
-      "sha": "c85151700613ba77bbf29a70509afbd769079222",
-      "branches": {
-        "master": "c85151700613ba77bbf29a70509afbd769079222"
-      },
-      "latest_tag": "2.0.7"
-    },
-    "al3xc1985/lootblare": {
-      "default_branch": "master",
-      "sha": "eccea47172a2d600aa73001008cc3c1f34b221da",
-      "branches": {
-        "master": "eccea47172a2d600aa73001008cc3c1f34b221da"
-      }
-    },
-    "bretharte89/lootblare": {
-      "default_branch": "master",
-      "sha": "eccea47172a2d600aa73001008cc3c1f34b221da",
-      "branches": {
-        "master": "eccea47172a2d600aa73001008cc3c1f34b221da"
-      }
-    },
-    "nikki1993/lootblare": {
-      "default_branch": "master",
-      "sha": "c4b5031f3f7f41c6c05ced84b9f8d0836acb6de0",
-      "branches": {
-        "master": "c4b5031f3f7f41c6c05ced84b9f8d0836acb6de0"
-      }
-    },
-    "graved/lootblare": {
-      "default_branch": "master",
-      "sha": "29d4c1c13b2d07e88c5ee63cf8e49c3278ffcf8b",
-      "branches": {
-        "master": "29d4c1c13b2d07e88c5ee63cf8e49c3278ffcf8b"
-      }
-    },
-    "tisette01/lootblare": {
-      "default_branch": "master",
-      "sha": "5bea9c10cc617467d904db2aec4ae083986e1bf3",
-      "branches": {
-        "master": "5bea9c10cc617467d904db2aec4ae083986e1bf3"
-      }
-    },
-    "thedarklordsunderland/lootblare": {
-      "default_branch": "master",
-      "sha": "4eda417fbb2ff30cc16b157e00ecec42b223de3d",
-      "branches": {
-        "master": "4eda417fbb2ff30cc16b157e00ecec42b223de3d"
-      }
-    },
-    "vargv666/lootblare": {
-      "default_branch": "master",
-      "sha": "2ae4a170794da724020acc7fe8cb4408b9d29648",
-      "branches": {
-        "master": "2ae4a170794da724020acc7fe8cb4408b9d29648"
-      }
-    },
-    "azuredrak0/lootblare": {
-      "default_branch": "master",
-      "sha": "3289c64e668b7e24cef6be22615dfbfe203aa951",
-      "branches": {
-        "master": "3289c64e668b7e24cef6be22615dfbfe203aa951"
-      }
-    },
-    "fsuhas/lootblare-for-roolfor": {
-      "default_branch": "main",
-      "sha": "3f2a2deec0affc69009b91042436355c36ed4a2e",
-      "branches": {
-        "main": "3f2a2deec0affc69009b91042436355c36ed4a2e"
-      }
-    },
-    "zanthor/lootblare": {
-      "default_branch": "main",
-      "sha": "686e2940186e33ae680e0635a5eda56a493e40ba",
-      "branches": {
-        "main": "686e2940186e33ae680e0635a5eda56a493e40ba"
-      }
-    },
-    "kameleonuk/lootblare": {
-      "default_branch": "main",
-      "sha": "16164655407924b01974fcbf3f7b27e1a866b0ac",
-      "branches": {
-        "main": "16164655407924b01974fcbf3f7b27e1a866b0ac"
-      }
-    },
-    "wiggen94/lootmonitor": {
-      "default_branch": "main",
-      "sha": "551ec4b89c747b1a87e85b818021867c57fef358",
-      "branches": {
-        "main": "551ec4b89c747b1a87e85b818021867c57fef358"
-      }
-    },
-    "reece844/lootmonitor": {
-      "default_branch": "main",
-      "sha": "8db67f4a8c99714cbb0b17a07fbdfa271b3cdb3b",
-      "branches": {
-        "main": "8db67f4a8c99714cbb0b17a07fbdfa271b3cdb3b"
-      }
-    },
-    "mentalxgit/lootmonitor": {
-      "default_branch": "main",
-      "sha": "90982082f384104f46aabefb2fd4dab093efcf97",
-      "branches": {
-        "main": "90982082f384104f46aabefb2fd4dab093efcf97"
-      }
-    },
-    "cosminpop/lootres": {
-      "default_branch": "master",
-      "sha": "f757716d8cebc6f75ff8a4de33d91b3207e07191",
-      "branches": {
-        "master": "f757716d8cebc6f75ff8a4de33d91b3207e07191"
-      }
-    },
-    "road-block/loottracker": {
-      "default_branch": "master",
-      "sha": "889856f11922954c04dd179d9fd969d8e4445cb0",
-      "branches": {
-        "master": "889856f11922954c04dd179d9fd969d8e4445cb0"
-      },
-      "latest_tag": "1.38rb"
-    },
-    "otari98/masterlootbyclass": {
-      "default_branch": "master",
-      "sha": "3981dbf0f3c108f7ed7d6c4b58a05585cfb90105",
-      "branches": {
-        "master": "3981dbf0f3c108f7ed7d6c4b58a05585cfb90105"
-      }
-    },
-    "bahamutxd/masterlootbyclass": {
-      "default_branch": "master",
-      "sha": "5744a57a95880f0604229aeab79b7c511731a8b7",
-      "branches": {
-        "master": "5744a57a95880f0604229aeab79b7c511731a8b7"
-      }
-    },
-    "kameleonuk/masterlootbyclass": {
-      "default_branch": "master",
-      "sha": "15c85de28fcc4f86819b79e42a66817d9b9cfcc3",
-      "branches": {
-        "master": "15c85de28fcc4f86819b79e42a66817d9b9cfcc3"
-      }
-    },
-    "road-block/masterlootremind": {
-      "default_branch": "master",
-      "sha": "ef9e73f27e13095b358897e223f20b626a91d9ed",
-      "branches": {
-        "master": "ef9e73f27e13095b358897e223f20b626a91d9ed"
-      },
-      "latest_tag": "1.21"
-    },
-    "bahamutxd/masterlootremind": {
-      "default_branch": "master",
-      "sha": "9da60e47196e167c76f23b3ad03ad3fa6812a90c",
-      "branches": {
-        "master": "9da60e47196e167c76f23b3ad03ad3fa6812a90c"
-      }
-    },
-    "asyncwithsky/masterlootremind": {
-      "default_branch": "master",
-      "sha": "f5377589b98a336d2380a4a930a50416ba7e7f9d",
-      "branches": {
-        "master": "f5377589b98a336d2380a4a930a50416ba7e7f9d"
-      }
-    },
-    "yutsuku/masterlute": {
-      "default_branch": "master",
-      "sha": "94a5ce43e99b952b3dd6b74f910d8efa3e1d2015",
-      "branches": {
-        "master": "94a5ce43e99b952b3dd6b74f910d8efa3e1d2015"
-      }
-    },
-    "mijkrofl/mijksraidassist": {
-      "default_branch": "main",
-      "sha": "a556201bada046e4c4d072d08baf1a638d10710e",
-      "branches": {
-        "main": "a556201bada046e4c4d072d08baf1a638d10710e"
-      }
-    },
-    "tilare/modernmapmarkers": {
-      "default_branch": "main",
-      "sha": "5311be6a24979d4119ed59e9f48f90beb41ecfb4",
-      "branches": {
-        "main": "5311be6a24979d4119ed59e9f48f90beb41ecfb4"
-      }
-    },
-    "drakensangs/modernmapmarkers-vanilla": {
-      "default_branch": "master",
-      "sha": "ccb00b4bf87e57f47dbdb60964ddfbfc9edd8984",
-      "branches": {
-        "master": "ccb00b4bf87e57f47dbdb60964ddfbfc9edd8984"
-      },
-      "latest_tag": "1.65"
-    },
-    "paokkerkir/modernmapmarkers-octo": {
-      "default_branch": "main",
-      "sha": "4e6de29ffa6f07c1c2ed7da3bb8f891858ebe2e9",
-      "branches": {
-        "main": "4e6de29ffa6f07c1c2ed7da3bb8f891858ebe2e9"
-      }
-    },
-    "mrmaffen/modernmapmarkers": {
-      "default_branch": "main",
-      "sha": "063f2fd8bf932f003c6671ac8a4dfdd73283b8f0",
-      "branches": {
-        "main": "063f2fd8bf932f003c6671ac8a4dfdd73283b8f0"
-      }
-    },
-    "al3xc1985/modernmapmarkers": {
-      "default_branch": "main",
-      "sha": "5311be6a24979d4119ed59e9f48f90beb41ecfb4",
-      "branches": {
-        "main": "5311be6a24979d4119ed59e9f48f90beb41ecfb4"
-      }
-    },
-    "bretharte89/modernmapmarkers": {
-      "default_branch": "main",
-      "sha": "5311be6a24979d4119ed59e9f48f90beb41ecfb4",
-      "branches": {
-        "main": "5311be6a24979d4119ed59e9f48f90beb41ecfb4"
-      }
-    },
-    "evannnn1996/modernmapmarkers": {
-      "default_branch": "main",
-      "sha": "5311be6a24979d4119ed59e9f48f90beb41ecfb4",
-      "branches": {
-        "main": "5311be6a24979d4119ed59e9f48f90beb41ecfb4"
-      }
-    },
-    "ravenofseven/modernmapmarkers": {
-      "default_branch": "main",
-      "sha": "5311be6a24979d4119ed59e9f48f90beb41ecfb4",
-      "branches": {
-        "main": "5311be6a24979d4119ed59e9f48f90beb41ecfb4"
-      }
-    },
-    "commanderkeen34/modernmapmarkersenhanced": {
-      "default_branch": "main",
-      "sha": "67ae4ab6b9ff711537c46b0365f14a53938c669a",
-      "branches": {
-        "main": "67ae4ab6b9ff711537c46b0365f14a53938c669a"
-      }
-    },
-    "xiao-ma-cookiemx/modernmapmarkers-": {
-      "default_branch": "main",
-      "sha": "a95e8d39d3ea7143896873e245e621847b1a5ef2",
-      "branches": {
-        "main": "a95e8d39d3ea7143896873e245e621847b1a5ef2"
-      },
-      "latest_tag": "1.3"
-    },
-    "whtmst/modernmapmarkers": {
-      "default_branch": "main",
-      "sha": "603b107cf550271048bcecdc850e9f74c4520188",
-      "branches": {
-        "main": "603b107cf550271048bcecdc850e9f74c4520188"
-      }
-    },
-    "trust-wow/modernmapmarkers-german": {
-      "default_branch": "main",
-      "sha": "184184a5925db272dd76a8395e1cb7c5e84a0d7b",
-      "branches": {
-        "main": "184184a5925db272dd76a8395e1cb7c5e84a0d7b"
-      }
-    },
-    "amonra/modernmapmarkers": {
-      "default_branch": "main",
-      "sha": "6873ba5fc85739cdf0185c5cad1dd5bfc98791a2",
-      "branches": {
-        "main": "6873ba5fc85739cdf0185c5cad1dd5bfc98791a2"
-      }
-    },
-    "trumpetx/notchatlootbidder": {
-      "default_branch": "master",
-      "sha": "3a450b58d3d05bf2fa7efade1d9bc0ba63fe2c1a",
-      "branches": {
-        "master": "3a450b58d3d05bf2fa7efade1d9bc0ba63fe2c1a"
-      },
-      "latest_tag": "v1.9.4"
-    },
-    "asyncwithsky/notchatlootbidder": {
-      "default_branch": "master",
-      "sha": "8b85120c5111dc55f65ed9fe1799bb96fab6ceb3",
-      "branches": {
-        "master": "8b85120c5111dc55f65ed9fe1799bb96fab6ceb3"
-      }
-    },
-    "orfc/notchatlootbidder": {
-      "default_branch": "master",
-      "sha": "45576166ef12bd33f9c3eba189f8fc337a1d7d0e",
-      "branches": {
-        "master": "45576166ef12bd33f9c3eba189f8fc337a1d7d0e"
-      }
-    },
-    "zanthor/og-raidhelper": {
-      "default_branch": "main",
-      "sha": "bfed882bfc7714df6d5086fc60e8a1ced6373278",
-      "branches": {
-        "main": "bfed882bfc7714df6d5086fc60e8a1ced6373278"
-      }
-    },
-    "kameleonuk/og-raidhelper": {
-      "default_branch": "main",
-      "sha": "53b6035d8fc372ccdd60ad671558083fac3bc333",
-      "branches": {
-        "main": "53b6035d8fc372ccdd60ad671558083fac3bc333"
-      }
-    },
-    "goldenpipes/openclam": {
-      "default_branch": "main",
-      "sha": "c4be429be59a81ee34076d93616d8393720da3c1",
-      "branches": {
-        "main": "c4be429be59a81ee34076d93616d8393720da3c1"
-      }
-    },
-    "maxcodk/paladinsalvaremover": {
-      "default_branch": "main",
-      "sha": "f2c68fd14699b54e4ba3230fc28b94783401987c",
-      "branches": {
-        "main": "f2c68fd14699b54e4ba3230fc28b94783401987c"
-      }
-    },
-    "pepopo978/rabuffs": {
-      "default_branch": "master",
-      "sha": "95eed1f4823f34ff7a85fa4bccaf688fb2385045",
-      "branches": {
-        "master": "95eed1f4823f34ff7a85fa4bccaf688fb2385045"
-      }
-    },
-    "dcv-2142/rabuffs": {
-      "default_branch": "master",
-      "sha": "6000d7140b8ea486094cbce85de68b079443f00f",
-      "branches": {
-        "master": "6000d7140b8ea486094cbce85de68b079443f00f"
-      }
-    },
-    "zepheo/rabuffs": {
-      "default_branch": "master",
-      "sha": "95eed1f4823f34ff7a85fa4bccaf688fb2385045",
-      "branches": {
-        "master": "95eed1f4823f34ff7a85fa4bccaf688fb2385045"
-      }
-    },
-    "purple-bloom/rabuffs": {
-      "default_branch": "master",
-      "sha": "66243fdb1574434bbaa8b91dcd961b501591680b",
-      "branches": {
-        "master": "66243fdb1574434bbaa8b91dcd961b501591680b"
-      }
-    },
-    "andrgita/rabuffs": {
-      "default_branch": "master",
-      "sha": "a201330411959166b6e2646f38c2f6950b4b195b",
-      "branches": {
-        "master": "a201330411959166b6e2646f38c2f6950b4b195b"
-      }
-    },
-    "marcelinevq/rabuffs": {
-      "default_branch": "master",
-      "sha": "9abaa03ad37b6a484cb7271018455ce1eacb7291",
-      "branches": {
-        "master": "9abaa03ad37b6a484cb7271018455ce1eacb7291"
-      }
-    },
-    "zhinj/rabuffs": {
-      "default_branch": "master",
-      "sha": "9a5597f427c1e2a9872c84b58b79a8c0beb9c551",
-      "branches": {
-        "master": "9a5597f427c1e2a9872c84b58b79a8c0beb9c551"
-      }
-    },
-    "zanthor/rabuffs": {
-      "default_branch": "master",
-      "sha": "417db2d5581d400a237c5df2a1b97755322a8765",
-      "branches": {
-        "master": "417db2d5581d400a237c5df2a1b97755322a8765"
-      }
-    },
-    "loogosh/rabuffs": {
-      "default_branch": "master",
-      "sha": "5ff997ec79456eda99616cc517e5823cad161bbc",
-      "branches": {
-        "master": "5ff997ec79456eda99616cc517e5823cad161bbc"
-      }
-    },
-    "greendam/rabuffs": {
-      "default_branch": "master",
-      "sha": "3e6c8bdcd2ccf3770a3353c98aa9c7cedd77c75d",
-      "branches": {
-        "master": "3e6c8bdcd2ccf3770a3353c98aa9c7cedd77c75d"
-      }
-    },
-    "profiler781/rabuffs": {
-      "default_branch": "master",
-      "sha": "7466f394673835073fd5def734856de702ec4c2d",
-      "branches": {
-        "master": "7466f394673835073fd5def734856de702ec4c2d"
-      }
-    },
-    "acid9000/rabuffs": {
-      "default_branch": "master",
-      "sha": "6ae5e7cb86ddc6f5112903f7fa32e5f001c7613a",
-      "branches": {
-        "master": "6ae5e7cb86ddc6f5112903f7fa32e5f001c7613a"
-      }
-    },
-    "kameleonuk/rabuffs": {
-      "default_branch": "master",
-      "sha": "6ae5e7cb86ddc6f5112903f7fa32e5f001c7613a",
-      "branches": {
-        "master": "6ae5e7cb86ddc6f5112903f7fa32e5f001c7613a"
-      }
-    },
-    "esqariote/rabuffs": {
-      "default_branch": "master",
-      "sha": "d9c30685fc780903cf31ee585c53ef93c736fdca",
-      "branches": {
-        "master": "d9c30685fc780903cf31ee585c53ef93c736fdca"
-      }
-    },
-    "sica42/raidcalendar": {
-      "default_branch": "main",
-      "sha": "0e822dce563bd05886759e9d20cd53592305f5c1",
-      "branches": {
-        "main": "0e822dce563bd05886759e9d20cd53592305f5c1"
-      },
-      "latest_tag": "v0.1"
-    },
-    "bretharte89/raidcalendar": {
-      "default_branch": "main",
-      "sha": "0e822dce563bd05886759e9d20cd53592305f5c1",
-      "branches": {
-        "main": "0e822dce563bd05886759e9d20cd53592305f5c1"
-      }
-    },
-    "jlabranche/raidmemberexport": {
-      "default_branch": "main",
-      "sha": "3dd211673a47e0e03102f4461318d7477abaab40",
-      "branches": {
-        "main": "3dd211673a47e0e03102f4461318d7477abaab40"
-      }
-    },
-    "azuredrak0/raidmemberexport": {
-      "default_branch": "main",
-      "sha": "3dd211673a47e0e03102f4461318d7477abaab40",
-      "branches": {
-        "main": "3dd211673a47e0e03102f4461318d7477abaab40"
-      }
-    },
-    "tylkaw/raidorganizer": {
-      "default_branch": "master",
-      "sha": "747b977e6830ea2b7d152f4d2f0e04599e2c4e36",
-      "branches": {
-        "master": "747b977e6830ea2b7d152f4d2f0e04599e2c4e36"
-      },
-      "latest_tag": "v0.9.910"
-    },
-    "djramsey01/raidorganizer": {
-      "default_branch": "master",
-      "sha": "efca3a7567a20f72152c933d924d54e7ac5cdda3",
-      "branches": {
-        "master": "efca3a7567a20f72152c933d924d54e7ac5cdda3"
-      },
-      "latest_tag": "v0.9.920"
-    },
-    "creohex/raidorganizer": {
-      "default_branch": "master",
-      "sha": "67c743e2ea844ae4f2ca086f0b33b253bbd182b5",
-      "branches": {
-        "master": "67c743e2ea844ae4f2ca086f0b33b253bbd182b5"
-      }
-    },
-    "goose404/raidrollbuddy": {
-      "default_branch": "main",
-      "sha": "4d1c7a6ee4be2bcc00dc57eaeefa60ba60c03cd1",
-      "branches": {
-        "main": "4d1c7a6ee4be2bcc00dc57eaeefa60ba60c03cd1"
-      }
-    },
-    "michewarr/raidrollbuddy": {
-      "default_branch": "main",
-      "sha": "20b43dcb1750dd5657ebab5d8c0e37ad6973fc9e",
-      "branches": {
-        "main": "20b43dcb1750dd5657ebab5d8c0e37ad6973fc9e"
-      }
-    },
-    "einbaum/raidrollhelper": {
-      "default_branch": "master",
-      "sha": "e1caf2c3bfd343f96f8ea3bc114c162a7545fa0a",
-      "branches": {
-        "master": "e1caf2c3bfd343f96f8ea3bc114c162a7545fa0a"
-      },
-      "latest_tag": "1.0"
-    },
-    "linae-kronos/raidsummon": {
-      "default_branch": "master",
-      "sha": "cd982bfbef2bc88ca5ad5aa654cf3ca86b85c33e",
-      "branches": {
-        "master": "cd982bfbef2bc88ca5ad5aa654cf3ca86b85c33e"
-      },
-      "latest_tag": "latest"
-    },
-    "akzkak/raidsummonplus": {
-      "default_branch": "master",
-      "sha": "dae4221d953f9f7a46d764d05d43a729be594bc5",
-      "branches": {
-        "master": "dae4221d953f9f7a46d764d05d43a729be594bc5"
-      }
-    },
-    "commandersouza/raidsummon": {
-      "default_branch": "master",
-      "sha": "d8d58be6bfaeb570f9ab89c7513014e9181542fb",
-      "branches": {
-        "master": "d8d58be6bfaeb570f9ab89c7513014e9181542fb"
-      }
-    },
-    "parzydelkowiec3-hub/raidsummonplus": {
-      "default_branch": "master",
-      "sha": "4ada883332cebd63cc11635e163020cfeacca4a5",
-      "branches": {
-        "master": "4ada883332cebd63cc11635e163020cfeacca4a5"
-      }
-    },
-    "paenthy/raidsummonplus": {
-      "default_branch": "master",
-      "sha": "8238883684169f6a76057f74f277486657e45ef0",
-      "branches": {
-        "master": "8238883684169f6a76057f74f277486657e45ef0"
-      }
-    },
-    "atreyyo/rat": {
-      "default_branch": "master",
-      "sha": "0c3add0173307a955f245f2aec52832b21862a22",
-      "branches": {
-        "master": "0c3add0173307a955f245f2aec52832b21862a22"
-      }
-    },
-    "edanmelar/rat-turtlewow": {
-      "default_branch": "TurtleWoW",
-      "sha": "6c1e289e6d83bce5854d1040b53ddb920deb82f1",
-      "branches": {
-        "TurtleWoW": "6c1e289e6d83bce5854d1040b53ddb920deb82f1"
-      },
-      "latest_tag": "1.10.3"
-    },
-    "coryo/rdx": {
-      "default_branch": "master",
-      "sha": "d413628bbca92b0da93a7872523e5a30bc5aaee5",
-      "branches": {
-        "master": "d413628bbca92b0da93a7872523e5a30bc5aaee5"
-      }
-    },
-    "zerf/renewspam": {
-      "default_branch": "master",
-      "sha": "f819bb16eb9d4bad5f4669949de8b71059b2c1ae",
-      "branches": {
-        "master": "f819bb16eb9d4bad5f4669949de8b71059b2c1ae"
-      }
-    },
-    "retherz/retherztargettracker": {
-      "default_branch": "master",
-      "sha": "4f9d4c7851e5bb92d51c7201a3c2d97b6f1fee7a",
-      "branches": {
-        "master": "4f9d4c7851e5bb92d51c7201a3c2d97b6f1fee7a"
-      }
-    },
-    "obszczymucha/roll-for-vanilla": {
-      "default_branch": "master",
-      "sha": "e70200790b79a8d8650126d2a5c795d69a0bba44",
-      "branches": {
-        "master": "e70200790b79a8d8650126d2a5c795d69a0bba44"
-      },
-      "latest_tag": "v4.6.5"
-    },
-    "sica42/roll-for-vanilla": {
-      "default_branch": "master",
-      "sha": "b833a9699242816a947f844e182754ef32961042",
-      "branches": {
-        "master": "b833a9699242816a947f844e182754ef32961042"
-      },
-      "latest_tag": "v4.8.1"
-    },
-    "fedilious/roll-for-vanilla": {
-      "default_branch": "master",
-      "sha": "173b7758d205df42807a4dcd2d5b087c91b6ea7a",
-      "branches": {
-        "master": "173b7758d205df42807a4dcd2d5b087c91b6ea7a"
-      }
-    },
-    "thezephyrsong/rollfor": {
-      "default_branch": "master",
-      "sha": "64c83f89dfb11cc156ff6c47c55d752865b0c57e",
-      "branches": {
-        "master": "64c83f89dfb11cc156ff6c47c55d752865b0c57e"
-      },
-      "latest_tag": "v4.6.5"
-    },
-    "fu-blizz/roll-for-vanilla": {
-      "default_branch": "master",
-      "sha": "05b964006ec4b9dd35decc0581fd84ddf78cb343",
-      "branches": {
-        "master": "05b964006ec4b9dd35decc0581fd84ddf78cb343"
-      },
-      "latest_tag": "v4.6.5"
-    },
-    "reilly00/roll-for-group-therapy": {
-      "default_branch": "master",
-      "sha": "f10e9f682a88612c176ea9bb2021026ad9f1dbc5",
-      "branches": {
-        "master": "f10e9f682a88612c176ea9bb2021026ad9f1dbc5"
-      }
-    },
-    "moonshinephoenix/roll-for-vanilla-quiet": {
-      "default_branch": "master",
-      "sha": "ec6518df78c7903ab9229065d9e9d21b2fe4d0e2",
-      "branches": {
-        "master": "ec6518df78c7903ab9229065d9e9d21b2fe4d0e2"
-      }
-    },
-    "bretharte89/roll-for-vanilla": {
-      "default_branch": "master",
-      "sha": "05b964006ec4b9dd35decc0581fd84ddf78cb343",
-      "branches": {
-        "master": "05b964006ec4b9dd35decc0581fd84ddf78cb343"
-      }
-    },
-    "nicoleharding61-netizen/roll-for-vanilla": {
-      "default_branch": "master",
-      "sha": "05b964006ec4b9dd35decc0581fd84ddf78cb343",
-      "branches": {
-        "master": "05b964006ec4b9dd35decc0581fd84ddf78cb343"
-      }
-    },
-    "slimewizzard/roll-for-vanilla-tsc": {
-      "default_branch": "master",
-      "sha": "05b964006ec4b9dd35decc0581fd84ddf78cb343",
-      "branches": {
-        "master": "05b964006ec4b9dd35decc0581fd84ddf78cb343"
-      }
-    },
-    "wdrx70xn/roll-for-vanilla": {
-      "default_branch": "master",
-      "sha": "05b964006ec4b9dd35decc0581fd84ddf78cb343",
-      "branches": {
-        "master": "05b964006ec4b9dd35decc0581fd84ddf78cb343"
-      },
-      "latest_tag": "v4.6.5"
-    },
-    "whtmst/roll-for-vanilla": {
-      "default_branch": "master",
-      "sha": "05b964006ec4b9dd35decc0581fd84ddf78cb343",
-      "branches": {
-        "master": "05b964006ec4b9dd35decc0581fd84ddf78cb343"
-      }
-    },
-    "christiancook/roll-for-vanilla": {
-      "default_branch": "master",
-      "sha": "268f7a78b4e43f7ee3c40272360262775e6a2b11",
-      "branches": {
-        "master": "268f7a78b4e43f7ee3c40272360262775e6a2b11"
-      }
-    },
-    "zensociety/roundrobinhood": {
-      "default_branch": "main",
-      "sha": "df93c2b0966e07b25e5daa3d671c7d9246a719c5",
-      "branches": {
-        "main": "df93c2b0966e07b25e5daa3d671c7d9246a719c5"
-      },
-      "latest_tag": "v0.02"
-    },
-    "shirsig/rwsync": {
-      "default_branch": "master",
-      "sha": "798e17d47b24b688e486b23a51d85d2395f609d3",
-      "branches": {
-        "master": "798e17d47b24b688e486b23a51d85d2395f609d3"
-      }
-    },
-    "yutsuku/seethungroups": {
-      "default_branch": "master",
-      "sha": "1dcbc2c4f5c85bd9058717d452965909c5e8493c",
-      "branches": {
-        "master": "1dcbc2c4f5c85bd9058717d452965909c5e8493c"
-      }
-    },
-    "laytya/seethungroups": {
-      "default_branch": "master",
-      "sha": "86193af2f6fe285da9959f172acb939680497d96",
-      "branches": {
-        "master": "86193af2f6fe285da9959f172acb939680497d96"
-      }
-    },
-    "shagu/shagubop": {
-      "default_branch": "master",
-      "sha": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9",
-      "branches": {
-        "master": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9"
-      }
-    },
-    "amonra/shagubop": {
-      "default_branch": "master",
-      "sha": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9",
-      "branches": {
-        "master": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9"
-      }
-    },
-    "dwbclz/shagubop": {
-      "default_branch": "master",
-      "sha": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9",
-      "branches": {
-        "master": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9"
-      }
-    },
-    "jiangxt316/shagubop": {
-      "default_branch": "master",
-      "sha": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9",
-      "branches": {
-        "master": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9"
-      }
-    },
-    "road-block/shootyepgp": {
-      "default_branch": "master",
-      "sha": "402d96b72234ff3a3adbb6e1d56dc6d32e96ffb8",
-      "branches": {
-        "master": "402d96b72234ff3a3adbb6e1d56dc6d32e96ffb8"
-      },
-      "latest_tag": "3.60"
-    },
-    "cinecom/shootyepgp": {
-      "default_branch": "master",
-      "sha": "aae250f73a0c745fd448ce179030b8458a1a2feb",
-      "branches": {
-        "master": "aae250f73a0c745fd448ce179030b8458a1a2feb"
-      }
-    },
-    "aethusx/shootyepgp": {
-      "default_branch": "master",
-      "sha": "c62c7481f4cbf298922fd7cf60f5b342a1411afb",
-      "branches": {
-        "master": "c62c7481f4cbf298922fd7cf60f5b342a1411afb"
-      }
-    },
-    "teranveril/shootyepgp": {
-      "default_branch": "master",
-      "sha": "39948dcd6bb0bd54857b8567c32f34df6c6b9431",
-      "branches": {
-        "master": "39948dcd6bb0bd54857b8567c32f34df6c6b9431"
-      }
-    },
-    "drepetsky/shootyepgp": {
-      "default_branch": "master",
-      "sha": "64826eac4ace616ad9a2b0d56594fa384fc791ea",
-      "branches": {
-        "master": "64826eac4ace616ad9a2b0d56594fa384fc791ea"
-      }
-    },
-    "phoenixrisinghost/shootyepgp": {
-      "default_branch": "master",
-      "sha": "b819e4bd063a40531d8ce48e08ce9de242135afa",
-      "branches": {
-        "master": "b819e4bd063a40531d8ce48e08ce9de242135afa"
-      }
-    },
-    "andrgita/simpleshareepgp": {
-      "default_branch": "master",
-      "sha": "c045e7250b953b497dc97aad0038e366d4e6c2ab",
-      "branches": {
-        "master": "c045e7250b953b497dc97aad0038e366d4e6c2ab"
-      },
-      "latest_tag": "v2.7"
-    },
-    "therealfayz/shootyepgp": {
-      "default_branch": "master",
-      "sha": "37700c9c5889633b1931e83f4731e735ba9ac861",
-      "branches": {
-        "master": "37700c9c5889633b1931e83f4731e735ba9ac861"
-      }
-    },
-    "newcomerblack/shootyepgp-sp": {
-      "default_branch": "master",
-      "sha": "ea8c6a5dbd9fe1f94d841a93ff337124831c9fbc",
-      "branches": {
-        "master": "ea8c6a5dbd9fe1f94d841a93ff337124831c9fbc"
-      }
-    },
-    "mjesp20/shootyepgp": {
-      "default_branch": "master",
-      "sha": "04f2aee0e0ce1a926419b571554a3f1cbcbd54d1",
-      "branches": {
-        "master": "04f2aee0e0ce1a926419b571554a3f1cbcbd54d1"
-      }
-    },
-    "tperraut/shootyepgp": {
-      "default_branch": "master",
-      "sha": "4d4b4098fe9e00671b8ab6c8420d2407eaa0a4b9",
-      "branches": {
-        "master": "4d4b4098fe9e00671b8ab6c8420d2407eaa0a4b9"
-      }
-    },
-    "mijohansen/shootyepgp": {
-      "default_branch": "master",
-      "sha": "167f1b37b64b068bf0a521a104a02e77b39bf2db",
-      "branches": {
-        "master": "167f1b37b64b068bf0a521a104a02e77b39bf2db"
-      }
-    },
-    "laytya/shootyepgp": {
-      "default_branch": "master",
-      "sha": "57c787f2719cfd71a247600ed18ba0daa1962331",
-      "branches": {
-        "master": "57c787f2719cfd71a247600ed18ba0daa1962331"
-      }
-    },
-    "road-block/simpleraidtargeticons": {
-      "default_branch": "master",
-      "sha": "d3fc111d31165da561be9b71e42e90aa01d8322b",
-      "branches": {
-        "master": "d3fc111d31165da561be9b71e42e90aa01d8322b"
-      },
-      "latest_tag": "2.11"
-    },
-    "sandworlds-mmo/sw-simpleraidtargeticons": {
-      "default_branch": "master",
-      "sha": "d3fc111d31165da561be9b71e42e90aa01d8322b",
-      "branches": {
-        "master": "d3fc111d31165da561be9b71e42e90aa01d8322b"
-      }
-    },
-    "dsidirop/simpleraidtargeticons": {
-      "default_branch": "master",
-      "sha": "6432ff69ed55a0e761bb54856840c4f27a6b79f3",
-      "branches": {
-        "master": "6432ff69ed55a0e761bb54856840c4f27a6b79f3"
-      }
-    },
-    "azzc0/smartbuff": {
-      "default_branch": "main",
-      "sha": "f5c828b55cf96206fd1d195e86b651103391114c",
-      "branches": {
-        "main": "f5c828b55cf96206fd1d195e86b651103391114c"
-      }
-    },
-    "emyrk/smartbuff": {
-      "default_branch": "main",
-      "sha": "27f84d6a51d78e1060e41e63bec659ad25406da8",
-      "branches": {
-        "main": "27f84d6a51d78e1060e41e63bec659ad25406da8"
-      }
-    },
-    "necroskillz/smartloot": {
-      "default_branch": "master",
-      "sha": "4e06b1800eeb6298d05c9acae07a6ac160185d36",
-      "branches": {
-        "master": "4e06b1800eeb6298d05c9acae07a6ac160185d36"
-      },
-      "latest_tag": "v1.1"
-    },
-    "sulpitz/smartloot": {
-      "default_branch": "master",
-      "sha": "1013cede392e2d8a4af98dbc1e9556bf7618fde2",
-      "branches": {
-        "master": "1013cede392e2d8a4af98dbc1e9556bf7618fde2"
-      },
-      "latest_tag": "v1.3-bcc"
-    },
-    "jejkas/smartroll": {
-      "default_branch": "master",
-      "sha": "fd2ca53c752e198070e032c86ab8f43d8e03ed16",
-      "branches": {
-        "master": "fd2ca53c752e198070e032c86ab8f43d8e03ed16"
-      }
-    },
-    "sentilix/sota": {
-      "default_branch": "master",
-      "sha": "bb7f8d172cc5c9885d2c40c4701e6df78fcf05ab",
-      "branches": {
-        "master": "bb7f8d172cc5c9885d2c40c4701e6df78fcf05ab"
-      },
-      "latest_tag": "sota-1.2.0"
-    },
-    "loogosh/sotamockbadkp": {
-      "default_branch": "master",
-      "sha": "980bdb03270cacb1a5a667882ffaea4909f114cf",
-      "branches": {
-        "master": "980bdb03270cacb1a5a667882ffaea4909f114cf"
-      }
-    },
-    "fsuhas/soundboard": {
+    "freohr/consumesmanager": {
       "default_branch": "main",
-      "sha": "643be948143f8cdc513bc73c8aba1fb3513c6782",
-      "branches": {
-        "main": "643be948143f8cdc513bc73c8aba1fb3513c6782"
-      }
-    },
-    "satan666/sraidframes_improved": {
-      "default_branch": "master",
-      "sha": "4642e662aeb628b1df510666407ace422def6a16",
-      "branches": {
-        "master": "4642e662aeb628b1df510666407ace422def6a16"
-      }
-    },
-    "grimfiendish/statcompare": {
-      "default_branch": "master",
-      "sha": "4b325f1b2d599c171e409f712c84b275294eb9a8",
-      "branches": {
-        "master": "4b325f1b2d599c171e409f712c84b275294eb9a8"
-      }
-    },
-    "evannnn1996/statcompare": {
-      "default_branch": "master",
-      "sha": "5177c91ca0b19a6b085acfe29a343fe6fa633fda",
-      "branches": {
-        "master": "5177c91ca0b19a6b085acfe29a343fe6fa633fda"
-      }
-    },
-    "uss-enterprise-guild/statcompare": {
-      "default_branch": "master",
-      "sha": "7f37fa33e5e5f431f883605ae7da3e47b5cfc838",
-      "branches": {
-        "master": "7f37fa33e5e5f431f883605ae7da3e47b5cfc838"
-      }
-    },
-    "grimwow/statcompare": {
-      "default_branch": "master",
-      "sha": "f54e0082204265899cb746d48b23c7d21a1b26c6",
-      "branches": {
-        "master": "f54e0082204265899cb746d48b23c7d21a1b26c6"
-      },
-      "latest_tag": "2.0.1"
-    },
-    "grymskvll/swapraidsubgroupbyname": {
-      "default_branch": "master",
-      "sha": "2b2e73ec3abd00478bf64b4dd208f2b54cd17dce",
-      "branches": {
-        "master": "2b2e73ec3abd00478bf64b4dd208f2b54cd17dce"
-      }
-    },
-    "player-doite/tactica": {
-      "default_branch": "main",
-      "sha": "f85e7fb0ded1a9178f207d3940c153e6e06f5e48",
-      "branches": {
-        "main": "f85e7fb0ded1a9178f207d3940c153e6e06f5e48"
-      }
-    },
-    "thezephyrsong/tactica": {
-      "default_branch": "main",
-      "sha": "f85e7fb0ded1a9178f207d3940c153e6e06f5e48",
-      "branches": {
-        "main": "f85e7fb0ded1a9178f207d3940c153e6e06f5e48"
-      }
-    },
-    "bretharte89/tactica": {
-      "default_branch": "main",
-      "sha": "f85e7fb0ded1a9178f207d3940c153e6e06f5e48",
-      "branches": {
-        "main": "f85e7fb0ded1a9178f207d3940c153e6e06f5e48"
-      }
-    },
-    "caspervk/tactica": {
-      "default_branch": "main",
-      "sha": "54475a88c11f286733e0418dee3030a1797cf78d",
-      "branches": {
-        "main": "54475a88c11f286733e0418dee3030a1797cf78d"
-      }
-    },
-    "zanthor/tactica": {
-      "default_branch": "main",
-      "sha": "0094aef193ba8c816ff83d38bb77cd6fbbe9b8d7",
-      "branches": {
-        "main": "0094aef193ba8c816ff83d38bb77cd6fbbe9b8d7"
-      }
-    },
-    "atreyyo/tankassignments": {
-      "default_branch": "master",
-      "sha": "d465f021627ce56ca857cb825a8d0cd664493e20",
-      "branches": {
-        "master": "d465f021627ce56ca857cb825a8d0cd664493e20"
-      }
-    },
-    "srazdokunebil/tankbuddy": {
-      "default_branch": "main",
-      "sha": "a005cdabc24c2938ca4ad6fe77b1fb3d1be68863",
-      "branches": {
-        "main": "a005cdabc24c2938ca4ad6fe77b1fb3d1be68863"
-      }
-    },
-    "laytya/tankbuddyenh": {
-      "default_branch": "master",
-      "sha": "41823497534e08be7055ff9fe14ac9e280b492a1",
-      "branches": {
-        "master": "41823497534e08be7055ff9fe14ac9e280b492a1"
-      }
-    },
-    "0ldi/targetassist": {
-      "default_branch": "master",
-      "sha": "8167f541f1ba2d2cf8bc28711dad7973042124f7",
-      "branches": {
-        "master": "8167f541f1ba2d2cf8bc28711dad7973042124f7"
-      }
-    },
-    "oozgul/tframes": {
-      "default_branch": "main",
-      "sha": "1fde9bce6df33f19c8209a778e4767b05a761ce8",
-      "branches": {
-        "main": "1fde9bce6df33f19c8209a778e4767b05a761ce8"
-      }
-    },
-    "kirillserogodsky/tframes": {
-      "default_branch": "main",
-      "sha": "3f9d5d16d858c1ec74934bbcef9932404a9a99cb",
-      "branches": {
-        "main": "3f9d5d16d858c1ec74934bbcef9932404a9a99cb"
-      }
-    },
-    "sentilix/thaliz": {
-      "default_branch": "master",
-      "sha": "501cdab796a711bb4c0a7e22e8fdd360b4d095fe",
-      "branches": {
-        "master": "501cdab796a711bb4c0a7e22e8fdd360b4d095fe"
-      },
-      "latest_tag": "thaliz-1.5.0"
-    },
-    "shikulja/thaliz": {
-      "default_branch": "master",
-      "sha": "301c0cfa08974bd4082bc561842195bf6feedeff",
-      "branches": {
-        "master": "301c0cfa08974bd4082bc561842195bf6feedeff"
-      },
-      "latest_tag": "thaliz-1.5.0"
-    },
-    "muellerj/threat": {
-      "default_branch": "master",
-      "sha": "9fa3b290ff864eca3e12bedd4cf0ea1f4546a57e",
-      "branches": {
-        "master": "9fa3b290ff864eca3e12bedd4cf0ea1f4546a57e"
-      }
-    },
-    "xleone1/threat": {
-      "default_branch": "master",
-      "sha": "72168120a25e4cc47c131e301778ced9e9c1db13",
-      "branches": {
-        "master": "72168120a25e4cc47c131e301778ced9e9c1db13"
-      }
-    },
-    "epitaque/threat": {
-      "default_branch": "master",
-      "sha": "8050803ad8271747b9c109641982a9d6e724e4b7",
-      "branches": {
-        "master": "8050803ad8271747b9c109641982a9d6e724e4b7"
-      }
-    },
-    "zensociety/threatlogger": {
-      "default_branch": "main",
-      "sha": "e0e7f651a4a2b6e07ccd5bfd2d592f62bc33f1bf",
-      "branches": {
-        "main": "e0e7f651a4a2b6e07ccd5bfd2d592f62bc33f1bf"
-      }
-    },
-    "sica42/turtlecalendar": {
-      "default_branch": "main",
-      "sha": "aad7b6a628992ea7d96e59982215e0bcd6901135",
-      "branches": {
-        "main": "aad7b6a628992ea7d96e59982215e0bcd6901135"
-      }
-    },
-    "wayoff333/turtlecalendar": {
-      "default_branch": "main",
-      "sha": "5e546506f104a61babfa5514f1c5aa521066ad71",
-      "branches": {
-        "main": "5e546506f104a61babfa5514f1c5aa521066ad71"
-      },
-      "latest_tag": "1.7"
-    },
-    "ravenofseven/turtlecalendar": {
-      "default_branch": "main",
-      "sha": "d469a685d5746bbcce57399a3e7e92413bc568af",
-      "branches": {
-        "main": "d469a685d5746bbcce57399a3e7e92413bc568af"
-      }
-    },
-    "cosminpop/twlc2c": {
-      "default_branch": "master",
-      "sha": "ced533890980f8e7170c191c27d3aca2363905f0",
-      "branches": {
-        "master": "ced533890980f8e7170c191c27d3aca2363905f0"
-      },
-      "latest_tag": "v1.1.1-beta.1"
-    },
-    "marcelinevq/twthreat": {
-      "default_branch": "master",
-      "sha": "e1af6d03776233569a9d6dc75c3045e13f71e78f",
-      "branches": {
-        "master": "e1af6d03776233569a9d6dc75c3045e13f71e78f"
-      }
-    },
-    "unknauwn/xckmasterlootadvanced": {
-      "default_branch": "Classic",
-      "sha": "1c4234df9cb13d5f6b16aab6bccae46ad0c7fb13",
-      "branches": {
-        "Classic": "1c4234df9cb13d5f6b16aab6bccae46ad0c7fb13"
-      },
-      "latest_tag": "3.7_classic"
-    },
-    "asyncwithsky/xckmasterlootadvanced": {
-      "default_branch": "Classic",
-      "sha": "a6870300ad35603276738f13a0f3495dd891d8d1",
-      "branches": {
-        "Classic": "a6870300ad35603276738f13a0f3495dd891d8d1"
-      }
-    },
-    "ko0z/xloot": {
-      "default_branch": "master",
-      "sha": "e693b39dcae6254072ec6b663622f36b4e9a783f",
-      "branches": {
-        "master": "e693b39dcae6254072ec6b663622f36b4e9a783f"
-      }
-    },
-    "road-block/xloot_addons": {
-      "default_branch": "master",
-      "sha": "4b7eab944828b061862f1fefb9b95f2f94f836c0",
-      "branches": {
-        "master": "4b7eab944828b061862f1fefb9b95f2f94f836c0"
-      },
-      "latest_tag": "0.93"
-    },
-    "unknauwn/xtraunitframe": {
-      "default_branch": "master",
-      "sha": "46121e25c1c72ea012de28658a29fe83a443a862",
-      "branches": {
-        "master": "46121e25c1c72ea012de28658a29fe83a443a862"
-      },
-      "latest_tag": "4.0"
-    },
-    "lichery/zgloot": {
-      "default_branch": "master",
-      "sha": "ded78b18d4a28f7cd157b763d25116aea698d5be",
-      "branches": {
-        "master": "ded78b18d4a28f7cd157b763d25116aea698d5be"
-      }
-    },
-    "thekk1/zgloot": {
-      "default_branch": "master",
-      "sha": "b711c3e1cc8b90ae16fa3dc8cbac0caef6bd85b8",
-      "branches": {
-        "master": "b711c3e1cc8b90ae16fa3dc8cbac0caef6bd85b8"
-      }
-    },
-    "rsheep/zgtracker": {
-      "default_branch": "master",
-      "sha": "b6dee9ff1d670adbd95643b7eff3fea1e5d18bae",
-      "branches": {
-        "master": "b6dee9ff1d670adbd95643b7eff3fea1e5d18bae"
-      },
-      "latest_tag": "v0.095"
-    },
-    "abstr4ctz/enhancer": {
-      "default_branch": "master",
-      "sha": "79a78ada52810a9cf6cb80ae127aeff0a0d45a4e",
-      "branches": {
-        "master": "79a78ada52810a9cf6cb80ae127aeff0a0d45a4e"
-      }
-    },
-    "xalzul/dwarvenizer-1.12": {
-      "default_branch": "master",
-      "sha": "2b28d2a62a61f3d4a5251ef34a541a868d25acb0",
-      "branches": {
-        "master": "2b28d2a62a61f3d4a5251ef34a541a868d25acb0"
-      }
-    },
-    "erea-turtle-addons/erea-rp-addons": {
-      "default_branch": "main",
-      "sha": "36a58f2899b16163b487343c3c39725d350ceb6e",
-      "branches": {
-        "main": "36a58f2899b16163b487343c3c39725d350ceb6e"
-      },
-      "latest_tag": "1.0.9"
-    },
-    "gitstrom/turtle-journal": {
-      "default_branch": "main",
-      "sha": "18200cfd061d7b180cae7cc92fd7783379c9d9a2",
-      "branches": {
-        "main": "18200cfd061d7b180cae7cc92fd7783379c9d9a2"
-      }
-    },
-    "xalzul/roleplayinghelper-1.12": {
-      "default_branch": "master",
-      "sha": "8962fbdfc55fc02bdda4614dd899c2d658e174c5",
-      "branches": {
-        "master": "8962fbdfc55fc02bdda4614dd899c2d658e174c5"
-      }
-    },
-    "vaaslite/turtleroleplayinghelper": {
-      "default_branch": "main",
-      "sha": "07ae5a6de1a0426c2efb085cd45044f910e4067f",
-      "branches": {
-        "main": "07ae5a6de1a0426c2efb085cd45044f910e4067f"
-      }
-    },
-    "grim-tale-tavern/turtleroleplayinghelper": {
-      "default_branch": "main",
-      "sha": "07ae5a6de1a0426c2efb085cd45044f910e4067f",
-      "branches": {
-        "main": "07ae5a6de1a0426c2efb085cd45044f910e4067f"
-      }
-    },
-    "oldmanalpha/turtleroleplayinghelper": {
-      "default_branch": "main",
-      "sha": "b044baf0e04ad5551e23cf46d1e42c5cbde9ff75",
-      "branches": {
-        "main": "b044baf0e04ad5551e23cf46d1e42c5cbde9ff75"
-      }
-    },
-    "grymessa/turtleroleplayinghelper": {
-      "default_branch": "main",
-      "sha": "0c4a861d225d2b1b57dd523dccdbf6897e3dbf5d",
-      "branches": {
-        "main": "0c4a861d225d2b1b57dd523dccdbf6897e3dbf5d"
-      }
-    },
-    "oldmanalpha/turtlerp": {
-      "default_branch": "main",
-      "sha": "f82cf3ba85dc5a76a342bf1dcc2ac2feb44232d9",
-      "branches": {
-        "main": "f82cf3ba85dc5a76a342bf1dcc2ac2feb44232d9"
-      },
-      "latest_tag": "1.1.1-Optimized"
-    },
-    "bratmage/turtlerp": {
-      "default_branch": "main",
-      "sha": "395756d1355e37b4a8babf3531484f733d13ecdc",
-      "branches": {
-        "main": "395756d1355e37b4a8babf3531484f733d13ecdc"
-      },
-      "latest_tag": "2.0.3"
-    },
-    "carnvanbeck/turtlerp": {
-      "default_branch": "main",
-      "sha": "6a908cbb9c30ceaf42c7bafedcf739733f908e9f",
-      "branches": {
-        "main": "6a908cbb9c30ceaf42c7bafedcf739733f908e9f"
-      }
-    },
-    "zebouski/adf": {
-      "default_branch": "master",
-      "sha": "f1da671b1c05ef4f94d0ef4d9cf4988006629044",
-      "branches": {
-        "master": "f1da671b1c05ef4f94d0ef4d9cf4988006629044"
-      }
-    },
-    "marcelinevq/adf": {
-      "default_branch": "master",
-      "sha": "b3cacbaa52c12a8e2d5d671cd1e348d45eae3489",
-      "branches": {
-        "master": "b3cacbaa52c12a8e2d5d671cd1e348d45eae3489"
-      }
-    },
-    "whtmst/adf": {
-      "default_branch": "master",
-      "sha": "2d9051dc46023a32bc88d6343edda4ad159f08ae",
-      "branches": {
-        "master": "2d9051dc46023a32bc88d6343edda4ad159f08ae"
-      }
-    },
-    "kameleonuk/adf": {
-      "default_branch": "master",
-      "sha": "d3c3869393e2dd394348a220c11ec16c37cf4a18",
-      "branches": {
-        "master": "d3c3869393e2dd394348a220c11ec16c37cf4a18"
-      }
-    },
-    "pepopo978/adf": {
-      "default_branch": "master",
-      "sha": "389feb7da2854eceeb79b2162f88bd6b17cb4e7e",
-      "branches": {
-        "master": "389feb7da2854eceeb79b2162f88bd6b17cb4e7e"
-      }
-    },
-    "melbaa/adf": {
-      "default_branch": "master",
-      "sha": "b26d774db501a687461ead891985fcc85dee606c",
-      "branches": {
-        "master": "b26d774db501a687461ead891985fcc85dee606c"
-      }
-    },
-    "davidbecht/autolock": {
-      "default_branch": "main",
-      "sha": "4b1f63a28c3e1e335fcc046efc3682fa8adf3cff",
-      "branches": {
-        "main": "4b1f63a28c3e1e335fcc046efc3682fa8adf3cff"
-      }
-    },
-    "marcelinevq/automarker": {
-      "default_branch": "master",
-      "sha": "cd66b7ae08da2a6258f53778a73689aca4ec027b",
-      "branches": {
-        "master": "cd66b7ae08da2a6258f53778a73689aca4ec027b"
-      }
-    },
-    "jesmyrna/stonewall-inn---automarker": {
-      "default_branch": "master",
-      "sha": "98656f5a09f912af429544fced6232d9a42c20e5",
-      "branches": {
-        "master": "98656f5a09f912af429544fced6232d9a42c20e5"
-      }
-    },
-    "therealfayz/automarker": {
-      "default_branch": "master",
-      "sha": "4b59021b4039735565ff0c1812960a63e0a92ed2",
-      "branches": {
-        "master": "4b59021b4039735565ff0c1812960a63e0a92ed2"
-      }
-    },
-    "jrc13245/automarker": {
-      "default_branch": "master",
-      "sha": "6a194f1f11339bede0db8e0464b25c08db626cae",
-      "branches": {
-        "master": "6a194f1f11339bede0db8e0464b25c08db626cae"
-      }
-    },
-    "pepopo978/cursive": {
-      "default_branch": "master",
-      "sha": "e8d46dff3de8ae14fca72c68766862e32892c6c1",
-      "branches": {
-        "master": "e8d46dff3de8ae14fca72c68766862e32892c6c1"
-      }
-    },
-    "wayoff333/cursive": {
-      "default_branch": "master",
-      "sha": "fb83abb6f563682e33075fc7f35cb404723616da",
-      "branches": {
-        "master": "fb83abb6f563682e33075fc7f35cb404723616da"
-      },
-      "latest_tag": "1.3"
-    },
-    "taeko-ar/cursive-3.3.5a": {
-      "default_branch": "master",
-      "sha": "ab73680c1e91e7e2275a4efa3d9972640682b967",
-      "branches": {
-        "master": "ab73680c1e91e7e2275a4efa3d9972640682b967"
-      }
-    },
-    "razzeee/cursive": {
-      "default_branch": "master",
-      "sha": "4daa3bc25b07142aed8d2900a74d77b6cefa9f2e",
-      "branches": {
-        "master": "4daa3bc25b07142aed8d2900a74d77b6cefa9f2e"
-      }
-    },
-    "bretharte89/cursive": {
-      "default_branch": "master",
-      "sha": "e8d46dff3de8ae14fca72c68766862e32892c6c1",
-      "branches": {
-        "master": "e8d46dff3de8ae14fca72c68766862e32892c6c1"
-      }
-    },
-    "evannnn1996/cursive": {
-      "default_branch": "master",
-      "sha": "e8d46dff3de8ae14fca72c68766862e32892c6c1",
-      "branches": {
-        "master": "e8d46dff3de8ae14fca72c68766862e32892c6c1"
-      }
-    },
-    "uss-enterprise-guild/cursive": {
-      "default_branch": "master",
-      "sha": "a0c99691b7aa8928996d0f8b913494b2aa06c863",
-      "branches": {
-        "master": "a0c99691b7aa8928996d0f8b913494b2aa06c863"
-      }
-    },
-    "jmiecz/cursive": {
-      "default_branch": "master",
-      "sha": "5eabc4f34105689a349c0589009c1a2f7f0e4eb5",
-      "branches": {
-        "master": "5eabc4f34105689a349c0589009c1a2f7f0e4eb5"
-      }
-    },
-    "drepetsky/cursive": {
-      "default_branch": "master",
-      "sha": "f321bb678b757a3a619d5466b8a0906ec8f91234",
+      "sha": "bda817859bd0c0fc4f87a9d830248c61531ad087",
       "branches": {
-        "master": "f321bb678b757a3a619d5466b8a0906ec8f91234"
+        "main": "bda817859bd0c0fc4f87a9d830248c61531ad087"
       }
     },
     "freohr/cursive": {
@@ -12171,1996 +4534,62 @@
         "master": "5eabc4f34105689a349c0589009c1a2f7f0e4eb5"
       }
     },
-    "szalor/cursive": {
+    "freohr/mopgeartooltips": {
       "default_branch": "master",
-      "sha": "648328399160841612f608e310bc6547edd54b5b",
+      "sha": "fc9000fab3f5576db2740169652caaa79674fe1f",
       "branches": {
-        "master": "648328399160841612f608e310bc6547edd54b5b"
+        "master": "fc9000fab3f5576db2740169652caaa79674fe1f"
       }
     },
-    "flaykz/cursiverevamp": {
-      "default_branch": "master",
-      "sha": "5eabc4f34105689a349c0589009c1a2f7f0e4eb5",
+    "frontmage/consoleexperienceclassic": {
+      "default_branch": "main",
+      "sha": "96c65e3399a80e84dbaeb7678599a1cd3d3d4d67",
       "branches": {
-        "master": "5eabc4f34105689a349c0589009c1a2f7f0e4eb5"
-      }
-    },
-    "zanthor/cursive": {
-      "default_branch": "master",
-      "sha": "7277850f149efd3a9bc343a1e52eb496702dc64f",
-      "branches": {
-        "master": "7277850f149efd3a9bc343a1e52eb496702dc64f"
-      }
-    },
-    "loogosh/cursive": {
-      "default_branch": "master",
-      "sha": "e734f9bac791550e73af4b6bc0412956a0f51b69",
-      "branches": {
-        "master": "e734f9bac791550e73af4b6bc0412956a0f51b69"
-      }
-    },
-    "gruksgruks/cursive": {
-      "default_branch": "master",
-      "sha": "f7c0bb9f51e34aed4a2a7aa1b9f3e46de4be2b30",
-      "branches": {
-        "master": "f7c0bb9f51e34aed4a2a7aa1b9f3e46de4be2b30"
-      }
-    },
-    "eickhardt/cursive": {
-      "default_branch": "master",
-      "sha": "f077efeb9a500d82209fa1bb2a31f1f7009e7263",
-      "branches": {
-        "master": "f077efeb9a500d82209fa1bb2a31f1f7009e7263"
-      }
-    },
-    "ruskemiahahn/cursive": {
-      "default_branch": "master",
-      "sha": "2174684775cf149112b0d52912b88165657de759",
-      "branches": {
-        "master": "2174684775cf149112b0d52912b88165657de759"
-      }
-    },
-    "khiu/cursive": {
-      "default_branch": "master",
-      "sha": "58a8133beff0485ea6786749d22dde25a47d3053",
-      "branches": {
-        "master": "58a8133beff0485ea6786749d22dde25a47d3053"
-      }
-    },
-    "lythandrawow/lythcursive": {
-      "default_branch": "master",
-      "sha": "74f5c80e228010e5b134a8319bd383a384be0d93",
-      "branches": {
-        "master": "74f5c80e228010e5b134a8319bd383a384be0d93"
-      }
-    },
-    "commandersouza/cursive": {
-      "default_branch": "master",
-      "sha": "3bb9fff354fedb136d6cae46e22e81514d0e2e61",
-      "branches": {
-        "master": "3bb9fff354fedb136d6cae46e22e81514d0e2e61"
-      }
-    },
-    "plokertonne/cursive": {
-      "default_branch": "master",
-      "sha": "dc4fc8b794f386e92c0173e6b39341927f6af636",
-      "branches": {
-        "master": "dc4fc8b794f386e92c0173e6b39341927f6af636"
-      }
-    },
-    "perks/cursive": {
-      "default_branch": "master",
-      "sha": "f2b06221d790d3b6748a17a96646f406df7e25ca",
-      "branches": {
-        "master": "f2b06221d790d3b6748a17a96646f406df7e25ca"
-      }
-    },
-    "vargv666/cursive": {
-      "default_branch": "master",
-      "sha": "e4269c043c445bd6b2c0d5fe63ba80207f17bea6",
-      "branches": {
-        "master": "e4269c043c445bd6b2c0d5fe63ba80207f17bea6"
-      }
-    },
-    "waldnercharles/cursive": {
-      "default_branch": "master",
-      "sha": "ef47b8b34ff49b882450f8271b9bbd5fddf4bd54",
-      "branches": {
-        "master": "ef47b8b34ff49b882450f8271b9bbd5fddf4bd54"
-      }
-    },
-    "kirchlive/cursive-raid": {
-      "default_branch": "master",
-      "sha": "3abd16a5a6c3984be2affeac44c7366dd19e2bce",
-      "branches": {
-        "master": "3abd16a5a6c3984be2affeac44c7366dd19e2bce"
+        "main": "96c65e3399a80e84dbaeb7678599a1cd3d3d4d67"
       },
-      "latest_tag": "v4.0"
+      "latest_tag": "v0.17.2"
     },
-    "marcelinevq/decursive": {
+    "frostshock/ghost": {
       "default_branch": "master",
-      "sha": "44ea26bdcb2e9feded63a42809ce97c6b8cdcd2a",
+      "sha": "e6bca7fc4368b28f0d4b0a178823a6cf318726d0",
       "branches": {
-        "master": "44ea26bdcb2e9feded63a42809ce97c6b8cdcd2a"
-      }
-    },
-    "sandworlds-mmo/sw-decursive2": {
-      "default_branch": "master",
-      "sha": "bc6df9e9b5e3f643b3857d5b9fba8127ab4f8163",
-      "branches": {
-        "master": "bc6df9e9b5e3f643b3857d5b9fba8127ab4f8163"
-      }
-    },
-    "apgm82/decursive": {
-      "default_branch": "superwow",
-      "sha": "953237c7d35d102b23a083b15cc2f32d8ba079d6",
-      "branches": {
-        "superwow": "953237c7d35d102b23a083b15cc2f32d8ba079d6"
-      }
-    },
-    "orange-pig/decursive": {
-      "default_branch": "master",
-      "sha": "53e3ff5110f7c8ffe3401093d8779cc7481f2ef3",
-      "branches": {
-        "master": "53e3ff5110f7c8ffe3401093d8779cc7481f2ef3"
-      }
-    },
-    "otari98/decursive": {
-      "default_branch": "master",
-      "sha": "bc6df9e9b5e3f643b3857d5b9fba8127ab4f8163",
-      "branches": {
-        "master": "bc6df9e9b5e3f643b3857d5b9fba8127ab4f8163"
-      }
-    },
-    "michewarr/decursive": {
-      "default_branch": "master",
-      "sha": "70e984187af6ce00466265a4864adee0ae4d0008",
-      "branches": {
-        "master": "70e984187af6ce00466265a4864adee0ae4d0008"
-      }
-    },
-    "whtmst/decursive": {
-      "default_branch": "master",
-      "sha": "bc6df9e9b5e3f643b3857d5b9fba8127ab4f8163",
-      "branches": {
-        "master": "bc6df9e9b5e3f643b3857d5b9fba8127ab4f8163"
-      }
-    },
-    "sei444/decursive": {
-      "default_branch": "master",
-      "sha": "9891d3378ce44bfdfa6b5f7f085536a4fc960494",
-      "branches": {
-        "master": "9891d3378ce44bfdfa6b5f7f085536a4fc960494"
-      }
-    },
-    "wormuz/decursive": {
-      "default_branch": "master",
-      "sha": "54d015b83256ea2b28e802097696a592c6fb7ba4",
-      "branches": {
-        "master": "54d015b83256ea2b28e802097696a592c6fb7ba4"
-      }
-    },
-    "shikulja/decursive": {
-      "default_branch": "master",
-      "sha": "9164fa25dc9eca70dae86321f226ddb34714f2f5",
-      "branches": {
-        "master": "9164fa25dc9eca70dae86321f226ddb34714f2f5"
-      }
-    },
-    "gashole/druidmanabar": {
-      "default_branch": "master",
-      "sha": "cf9514e4b22438223791073108b5610b1528e462",
-      "branches": {
-        "master": "cf9514e4b22438223791073108b5610b1528e462"
-      }
-    },
-    "zmarotrix/druidmanabar": {
-      "default_branch": "master",
-      "sha": "58ad3aa7fe09da1a3959cdfba6abb85afebbcfbc",
-      "branches": {
-        "master": "58ad3aa7fe09da1a3959cdfba6abb85afebbcfbc"
-      }
-    },
-    "kluy18/druidmanabar": {
-      "default_branch": "master",
-      "sha": "50170223a7dfa38e15c303fbf668b256f9ca9b12",
-      "branches": {
-        "master": "50170223a7dfa38e15c303fbf668b256f9ca9b12"
-      }
-    },
-    "oldmanalpha/fasttot": {
-      "default_branch": "main",
-      "sha": "a001f678d24ac14146c8ee20f73dd54a1fcdfde9",
-      "branches": {
-        "main": "a001f678d24ac14146c8ee20f73dd54a1fcdfde9"
+        "master": "e6bca7fc4368b28f0d4b0a178823a6cf318726d0"
       },
-      "latest_tag": "v1.0"
+      "latest_tag": "3745561"
     },
-    "bretharte89/fasttot": {
+    "frostshock/killcounter": {
       "default_branch": "main",
-      "sha": "a001f678d24ac14146c8ee20f73dd54a1fcdfde9",
+      "sha": "1a938c71cca7700acff98b513ab49c8ba0c9dac2",
       "branches": {
-        "main": "a001f678d24ac14146c8ee20f73dd54a1fcdfde9"
+        "main": "1a938c71cca7700acff98b513ab49c8ba0c9dac2"
       }
     },
-    "refaim/friend-o-tron": {
+    "frostshock/mobhealth": {
       "default_branch": "master",
-      "sha": "70b9e118d59bb25224b3b386e2e03c7665d07089",
+      "sha": "d922aa3c1c9a17405e09b9b77aebeb1f51a6b39b",
       "branches": {
-        "master": "70b9e118d59bb25224b3b386e2e03c7665d07089"
+        "master": "d922aa3c1c9a17405e09b9b77aebeb1f51a6b39b"
       }
     },
-    "freadblangks/friend-o-tron": {
+    "fsuhas/autolfm": {
       "default_branch": "master",
-      "sha": "8eee8885625c45dcc3bffcce7973d48a01378510",
+      "sha": "168f9e2966a5ddb980be05433e45bf648363b6bb",
       "branches": {
-        "master": "8eee8885625c45dcc3bffcce7973d48a01378510"
+        "master": "168f9e2966a5ddb980be05433e45bf648363b6bb"
       }
     },
-    "mrdoufuru/gcdisplay": {
+    "fsuhas/brainsaver": {
       "default_branch": "master",
-      "sha": "3f1b6e973508d1a960f16903074e591e834a741d",
+      "sha": "5d8579a122613b9f209a2278a09212ce73d9420d",
       "branches": {
-        "master": "3f1b6e973508d1a960f16903074e591e834a741d"
+        "master": "5d8579a122613b9f209a2278a09212ce73d9420d"
       }
     },
-    "bretharte89/gcdisplay": {
-      "default_branch": "master",
-      "sha": "3f1b6e973508d1a960f16903074e591e834a741d",
-      "branches": {
-        "master": "3f1b6e973508d1a960f16903074e591e834a741d"
-      }
-    },
-    "profiler781/iwinenhanced": {
+    "fsuhas/bsalert-tw": {
       "default_branch": "main",
-      "sha": "e5908a2ea43c6a4bcc0ab7cb1759b95aeca2839d",
+      "sha": "3104b532b0f0ac3d262be3398655adb0b115b5dc",
       "branches": {
-        "main": "e5908a2ea43c6a4bcc0ab7cb1759b95aeca2839d"
-      }
-    },
-    "noravar/iwinenhanced": {
-      "default_branch": "main",
-      "sha": "b6c4c558fb37c658b2582819aa4fd1097ed36d7f",
-      "branches": {
-        "main": "b6c4c558fb37c658b2582819aa4fd1097ed36d7f"
-      }
-    },
-    "bretharte89/iwinenhanced": {
-      "default_branch": "main",
-      "sha": "e5908a2ea43c6a4bcc0ab7cb1759b95aeca2839d",
-      "branches": {
-        "main": "e5908a2ea43c6a4bcc0ab7cb1759b95aeca2839d"
-      }
-    },
-    "jrc13245/iwinenhanced": {
-      "default_branch": "main",
-      "sha": "9f6bdc0af04d4a396ae22f9262882e8418df04b6",
-      "branches": {
-        "main": "9f6bdc0af04d4a396ae22f9262882e8418df04b6"
-      }
-    },
-    "bapiop/iwinenhanced": {
-      "default_branch": "main",
-      "sha": "f7c58df2d84efd2354a42a285383bdc87e71459e",
-      "branches": {
-        "main": "f7c58df2d84efd2354a42a285383bdc87e71459e"
-      }
-    },
-    "gensoo/iwinenhanced": {
-      "default_branch": "main",
-      "sha": "0f238ab4adf57827cbc3787ec767b44d50730a3f",
-      "branches": {
-        "main": "0f238ab4adf57827cbc3787ec767b44d50730a3f"
-      }
-    },
-    "ageous27/jankyplates": {
-      "default_branch": "main",
-      "sha": "c40a9dd6f35eae609071e0d4a5a0fc81a12d706c",
-      "branches": {
-        "main": "c40a9dd6f35eae609071e0d4a5a0fc81a12d706c"
-      }
-    },
-    "carravan/lateral": {
-      "default_branch": "main",
-      "sha": "2f36500c9c3c5804cd790f37785b343f424818a1",
-      "branches": {
-        "main": "2f36500c9c3c5804cd790f37785b343f424818a1"
-      }
-    },
-    "pepopo978/magehud": {
-      "default_branch": "main",
-      "sha": "45aaf4fb03eb9909b31e9ea80f41f7d2cb000e28",
-      "branches": {
-        "main": "45aaf4fb03eb9909b31e9ea80f41f7d2cb000e28"
-      }
-    },
-    "commandersouza/magehud": {
-      "default_branch": "main",
-      "sha": "bbe97d933fb43811beb3010e57d6751137042d52",
-      "branches": {
-        "main": "bbe97d933fb43811beb3010e57d6751137042d52"
-      }
-    },
-    "bugranger/magehud": {
-      "default_branch": "main",
-      "sha": "45aaf4fb03eb9909b31e9ea80f41f7d2cb000e28",
-      "branches": {
-        "main": "45aaf4fb03eb9909b31e9ea80f41f7d2cb000e28"
-      }
-    },
-    "monomode/turtlewow--magehud": {
-      "default_branch": "main",
-      "sha": "45aaf4fb03eb9909b31e9ea80f41f7d2cb000e28",
-      "branches": {
-        "main": "45aaf4fb03eb9909b31e9ea80f41f7d2cb000e28"
-      }
-    },
-    "tubtubs/magehud": {
-      "default_branch": "main",
-      "sha": "45aaf4fb03eb9909b31e9ea80f41f7d2cb000e28",
-      "branches": {
-        "main": "45aaf4fb03eb9909b31e9ea80f41f7d2cb000e28"
-      }
-    },
-    "laytya/magehud": {
-      "default_branch": "main",
-      "sha": "b707cccc8e8ac6e053ddffcd812ae94a9fe17aa0",
-      "branches": {
-        "main": "b707cccc8e8ac6e053ddffcd812ae94a9fe17aa0"
-      }
-    },
-    "shikulja/magehud": {
-      "default_branch": "main",
-      "sha": "acb108b45963c79ec2a4bc710383ff8980a0ac7f",
-      "branches": {
-        "main": "acb108b45963c79ec2a4bc710383ff8980a0ac7f"
-      }
-    },
-    "trangoul/monkeyspeed": {
-      "default_branch": "main",
-      "sha": "0f87c5d4e1916d0d055146106f58fe457867be1b",
-      "branches": {
-        "main": "0f87c5d4e1916d0d055146106f58fe457867be1b"
-      }
-    },
-    "dromida/monkeyspeed": {
-      "default_branch": "main",
-      "sha": "f2e45caf16b40e24e971b0bda81d466f381ab5c1",
-      "branches": {
-        "main": "f2e45caf16b40e24e971b0bda81d466f381ab5c1"
-      }
-    },
-    "shellyoung/ocb-superwow": {
-      "default_branch": "main",
-      "sha": "4a0d93c5be8dce813dfccf6c167344441f2fabe9",
-      "branches": {
-        "main": "4a0d93c5be8dce813dfccf6c167344441f2fabe9"
-      },
-      "latest_tag": "3.8.3"
-    },
-    "otari98/overhead": {
-      "default_branch": "master",
-      "sha": "f3d3a9eea8bb5c31fd0e540f414bb8a266d1cd38",
-      "branches": {
-        "master": "f3d3a9eea8bb5c31fd0e540f414bb8a266d1cd38"
-      }
-    },
-    "amonra/overhead": {
-      "default_branch": "master",
-      "sha": "bd88289332d677080fa9ee15e1eadfc2c9c1fd04",
-      "branches": {
-        "master": "bd88289332d677080fa9ee15e1eadfc2c9c1fd04"
-      }
-    },
-    "bombg/pfui-bettertotems": {
-      "default_branch": "main",
-      "sha": "4bcb23338570476c97db89590a70d102b0438b09",
-      "branches": {
-        "main": "4bcb23338570476c97db89590a70d102b0438b09"
-      }
-    },
-    "roby-brok/pfui-bettertotems": {
-      "default_branch": "main",
-      "sha": "9daab8d844a493b4f5435d1151cb276bc21c8de0",
-      "branches": {
-        "main": "9daab8d844a493b4f5435d1151cb276bc21c8de0"
-      }
-    },
-    "oldmanalpha/puppeteer": {
-      "default_branch": "main",
-      "sha": "7fa9db6cc1032852733c0dbf77693c881719dbfd",
-      "branches": {
-        "main": "7fa9db6cc1032852733c0dbf77693c881719dbfd"
-      },
-      "latest_tag": "v1.1.3"
-    },
-    "skrymsli/puppeteer": {
-      "default_branch": "main",
-      "sha": "2d3fdc5bb2c70fc02bc5f1c4f7d832a14f70d792",
-      "branches": {
-        "main": "2d3fdc5bb2c70fc02bc5f1c4f7d832a14f70d792"
-      }
-    },
-    "fey/puppeteer": {
-      "default_branch": "main",
-      "sha": "7fa9db6cc1032852733c0dbf77693c881719dbfd",
-      "branches": {
-        "main": "7fa9db6cc1032852733c0dbf77693c881719dbfd"
-      },
-      "latest_tag": "v1.1.3"
-    },
-    "lioryx/puppeteer": {
-      "default_branch": "main",
-      "sha": "fe50882bd521475217325d2984dd5ba1de3df312",
-      "branches": {
-        "main": "fe50882bd521475217325d2984dd5ba1de3df312"
-      }
-    },
-    "esliwka/puppeteer": {
-      "default_branch": "main",
-      "sha": "7fa9db6cc1032852733c0dbf77693c881719dbfd",
-      "branches": {
-        "main": "7fa9db6cc1032852733c0dbf77693c881719dbfd"
-      }
-    },
-    "veritania/puppeteer": {
-      "default_branch": "main",
-      "sha": "7fa9db6cc1032852733c0dbf77693c881719dbfd",
-      "branches": {
-        "main": "7fa9db6cc1032852733c0dbf77693c881719dbfd"
-      }
-    },
-    "razzeee/puppeteer": {
-      "default_branch": "main",
-      "sha": "aa732a6c44f0dbba3c0803bc70243bf0fdb23060",
-      "branches": {
-        "main": "aa732a6c44f0dbba3c0803bc70243bf0fdb23060"
-      }
-    },
-    "bretharte89/puppeteer": {
-      "default_branch": "main",
-      "sha": "aa732a6c44f0dbba3c0803bc70243bf0fdb23060",
-      "branches": {
-        "main": "aa732a6c44f0dbba3c0803bc70243bf0fdb23060"
-      }
-    },
-    "urarchieeminy/puppeteer": {
-      "default_branch": "main",
-      "sha": "c190322baee43cf3b33db91076f52c1662ee5cee",
-      "branches": {
-        "main": "c190322baee43cf3b33db91076f52c1662ee5cee"
-      }
-    },
-    "zanthor/puppeteer": {
-      "default_branch": "main",
-      "sha": "2211d8285e97d1488525088c13ddaed8d8e278b6",
-      "branches": {
-        "main": "2211d8285e97d1488525088c13ddaed8d8e278b6"
-      }
-    },
-    "uc9089/puppeteer": {
-      "default_branch": "main",
-      "sha": "d8768073072c303bf084a9597a9a6c81ddddfe0d",
-      "branches": {
-        "main": "d8768073072c303bf084a9597a9a6c81ddddfe0d"
-      }
-    },
-    "redcloak/puppeteer": {
-      "default_branch": "main",
-      "sha": "a79777ffb123ec4f732e8d9f468d8e80abce715f",
-      "branches": {
-        "main": "a79777ffb123ec4f732e8d9f468d8e80abce715f"
-      }
-    },
-    "whtmst/puppeteer": {
-      "default_branch": "main",
-      "sha": "1d1a7938bc37aae4cb8f3e6e8db02bb2e0814f98",
-      "branches": {
-        "main": "1d1a7938bc37aae4cb8f3e6e8db02bb2e0814f98"
-      }
-    },
-    "ziims/puppeteer": {
-      "default_branch": "main",
-      "sha": "96396fdefee7fe1451b5899c900359cbf3562f6a",
-      "branches": {
-        "main": "96396fdefee7fe1451b5899c900359cbf3562f6a"
-      }
-    },
-    "seset/puppeteer": {
-      "default_branch": "main",
-      "sha": "899408c4e97ea19165ea0c049e70046966f3ad25",
-      "branches": {
-        "main": "899408c4e97ea19165ea0c049e70046966f3ad25"
-      }
-    },
-    "samahee/puppeteer": {
-      "default_branch": "main",
-      "sha": "119a2381c6af3da4014ec2b50b9a33c7d56d02e7",
-      "branches": {
-        "main": "119a2381c6af3da4014ec2b50b9a33c7d56d02e7"
-      }
-    },
-    "michewarr/puppeteer": {
-      "default_branch": "main",
-      "sha": "406330c255118b37956cb31b4b5815b36d7ce9b4",
-      "branches": {
-        "main": "406330c255118b37956cb31b4b5815b36d7ce9b4"
-      }
-    },
-    "taeko-ar/quickturtledblookup": {
-      "default_branch": "master",
-      "sha": "3b5923f304cc31a2c20a1105780e2af4fd68dd68",
-      "branches": {
-        "master": "3b5923f304cc31a2c20a1105780e2af4fd68dd68"
-      }
-    },
-    "otari98/rinse": {
-      "default_branch": "master",
-      "sha": "7fc044b901ecffd2724abe21b6502a8e419d6dc2",
-      "branches": {
-        "master": "7fc044b901ecffd2724abe21b6502a8e419d6dc2"
-      }
-    },
-    "marcelinevq/rinse": {
-      "default_branch": "master",
-      "sha": "c1b02b81d004b6b2931e5bbc5f379ad41ce6a246",
-      "branches": {
-        "master": "c1b02b81d004b6b2931e5bbc5f379ad41ce6a246"
-      }
-    },
-    "dauls/rinse-v-": {
-      "default_branch": "master",
-      "sha": "2bc316755635266dffc3f4975dff88a9a06035af",
-      "branches": {
-        "master": "2bc316755635266dffc3f4975dff88a9a06035af"
-      }
-    },
-    "evannnn1996/rinse": {
-      "default_branch": "master",
-      "sha": "857fad999ebac1286ddc965420e4a41d831ff305",
-      "branches": {
-        "master": "857fad999ebac1286ddc965420e4a41d831ff305"
-      }
-    },
-    "al3xc1985/rinse": {
-      "default_branch": "master",
-      "sha": "edfefd858cbf6f6f36e88f8a45c89474dddebdbd",
-      "branches": {
-        "master": "edfefd858cbf6f6f36e88f8a45c89474dddebdbd"
-      }
-    },
-    "tubtubs/rinse": {
-      "default_branch": "master",
-      "sha": "23c5643b37cd3f90554d074bc2ca6e0364a55f3f",
-      "branches": {
-        "master": "23c5643b37cd3f90554d074bc2ca6e0364a55f3f"
-      }
-    },
-    "verge20/rinse": {
-      "default_branch": "master",
-      "sha": "2c830e52a7b5c5bac26657cd00c32f18645daede",
-      "branches": {
-        "master": "2c830e52a7b5c5bac26657cd00c32f18645daede"
-      }
-    },
-    "mats391/rinse": {
-      "default_branch": "master",
-      "sha": "c14b56ab2bffe828a8994e71b3064cebbdeb3303",
-      "branches": {
-        "master": "c14b56ab2bffe828a8994e71b3064cebbdeb3303"
-      }
-    },
-    "whtmst/rinse": {
-      "default_branch": "master",
-      "sha": "3503370e8e8b6d30ab20a40926bcf57f96d95160",
-      "branches": {
-        "master": "3503370e8e8b6d30ab20a40926bcf57f96d95160"
-      }
-    },
-    "nikki1993/rinse": {
-      "default_branch": "master",
-      "sha": "3e178040e50e4dc584219cdb1cba901dccfae390",
-      "branches": {
-        "master": "3e178040e50e4dc584219cdb1cba901dccfae390"
-      }
-    },
-    "paenthy/rinse": {
-      "default_branch": "master",
-      "sha": "4319e2e2c58c7e6a66ab61f1eabd8433c57b89a5",
-      "branches": {
-        "master": "4319e2e2c58c7e6a66ab61f1eabd8433c57b89a5"
-      }
-    },
-    "shagu/shagudps": {
-      "default_branch": "master",
-      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
-      "branches": {
-        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
-      }
-    },
-    "emyrk/shagudps": {
-      "default_branch": "master",
-      "sha": "07d74490ddfb2e71e0b114780d17ba52123ea421",
-      "branches": {
-        "master": "07d74490ddfb2e71e0b114780d17ba52123ea421"
-      }
-    },
-    "nelethor/shagudps": {
-      "default_branch": "master",
-      "sha": "fbf851affe40cd38a4cb6d9e000c5d5defe31c04",
-      "branches": {
-        "master": "fbf851affe40cd38a4cb6d9e000c5d5defe31c04"
-      }
-    },
-    "evannnn1996/shagudps": {
-      "default_branch": "master",
-      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
-      "branches": {
-        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
-      }
-    },
-    "96rex/shagudps": {
-      "default_branch": "master",
-      "sha": "cbcba27d2e01d10072a29eb5e63639c6a838f689",
-      "branches": {
-        "master": "cbcba27d2e01d10072a29eb5e63639c6a838f689"
-      }
-    },
-    "dcv-2142/shagudps": {
-      "default_branch": "master",
-      "sha": "ddfa91c265a6fc441fbbb7fba5ed09193e12380f",
-      "branches": {
-        "master": "ddfa91c265a6fc441fbbb7fba5ed09193e12380f"
-      }
-    },
-    "deceius/shagudps": {
-      "default_branch": "master",
-      "sha": "88b3aab0afc175a211130d895cedd7e7fae28b4a",
-      "branches": {
-        "master": "88b3aab0afc175a211130d895cedd7e7fae28b4a"
-      }
-    },
-    "grimwow/shagudps": {
-      "default_branch": "master",
-      "sha": "0d297a3fda7c2dca37ed8894c9d3cf99e542d39d",
-      "branches": {
-        "master": "0d297a3fda7c2dca37ed8894c9d3cf99e542d39d"
-      },
-      "latest_tag": "0.0.1"
-    },
-    "gabcinder2004/shagudps": {
-      "default_branch": "master",
-      "sha": "60dd0f24d953ee04676da5a61d5f17c67c01491f",
-      "branches": {
-        "master": "60dd0f24d953ee04676da5a61d5f17c67c01491f"
-      }
-    },
-    "theoix/shagudps": {
-      "default_branch": "master",
-      "sha": "1408a70005374f4d5022f828db4f21a2f5e41379",
-      "branches": {
-        "master": "1408a70005374f4d5022f828db4f21a2f5e41379"
-      }
-    },
-    "monomode/shagudps": {
-      "default_branch": "master",
-      "sha": "1d32cf9d420a7c793ec022c558941f4532a6c33d",
-      "branches": {
-        "master": "1d32cf9d420a7c793ec022c558941f4532a6c33d"
-      }
-    },
-    "arthur-helias/shagudps": {
-      "default_branch": "master",
-      "sha": "45b270500f2228d012b03fc5130d8961e862be69",
-      "branches": {
-        "master": "45b270500f2228d012b03fc5130d8961e862be69"
-      }
-    },
-    "macumbafeh/shagudps": {
-      "default_branch": "master",
-      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
-      "branches": {
-        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
-      }
-    },
-    "otari98/shagudps": {
-      "default_branch": "master",
-      "sha": "922934eed916ad0e6b37dd0ac1dd9670eeb16453",
-      "branches": {
-        "master": "922934eed916ad0e6b37dd0ac1dd9670eeb16453"
-      }
-    },
-    "amonra/shagudps": {
-      "default_branch": "master",
-      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
-      "branches": {
-        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
-      }
-    },
-    "dwbclz/shagudps": {
-      "default_branch": "master",
-      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
-      "branches": {
-        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
-      }
-    },
-    "jiangxt316/shagudps": {
-      "default_branch": "master",
-      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
-      "branches": {
-        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
-      }
-    },
-    "sandworlds-mmo/shagudps": {
-      "default_branch": "master",
-      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
-      "branches": {
-        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
-      }
-    },
-    "shigemunekurogane/shagudps": {
-      "default_branch": "master",
-      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
-      "branches": {
-        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
-      }
-    },
-    "xinleibird/shagudps": {
-      "default_branch": "master",
-      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
-      "branches": {
-        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
-      }
-    },
-    "yani9o/shagudps": {
-      "default_branch": "master",
-      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
-      "branches": {
-        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
-      }
-    },
-    "zyyysxd/shagudps": {
-      "default_branch": "master",
-      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
-      "branches": {
-        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
-      }
-    },
-    "dbulatovicx32/shagudps": {
-      "default_branch": "master",
-      "sha": "9510167d9a3a59fb06a154c653af68bbf83b582a",
-      "branches": {
-        "master": "9510167d9a3a59fb06a154c653af68bbf83b582a"
-      }
-    },
-    "commandersouza/shagudps": {
-      "default_branch": "master",
-      "sha": "a1f3e071b9bf0437ee60530bf19a0dcfd96b939c",
-      "branches": {
-        "master": "a1f3e071b9bf0437ee60530bf19a0dcfd96b939c"
-      }
-    },
-    "beardedrasta/shagudps": {
-      "default_branch": "master",
-      "sha": "8450a27230b05b3d3cc7a31bab51ab147e50e8ac",
-      "branches": {
-        "master": "8450a27230b05b3d3cc7a31bab51ab147e50e8ac"
-      }
-    },
-    "tperraut/shagudps": {
-      "default_branch": "master",
-      "sha": "ac95a4759dc7ce259dccb0b3ee11166204217d32",
-      "branches": {
-        "master": "ac95a4759dc7ce259dccb0b3ee11166204217d32"
-      }
-    },
-    "wanliqiaoxi/shagudps": {
-      "default_branch": "master",
-      "sha": "b6170c70c2448ad2c6d598981be26b724cdd599c",
-      "branches": {
-        "master": "b6170c70c2448ad2c6d598981be26b724cdd599c"
-      }
-    },
-    "empty1021/shagudps": {
-      "default_branch": "master",
-      "sha": "2268b73f908fdfa8b6272ae05c66e961f6671576",
-      "branches": {
-        "master": "2268b73f908fdfa8b6272ae05c66e961f6671576"
-      }
-    },
-    "shagu/shaguplates": {
-      "default_branch": "master",
-      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
-      "branches": {
-        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
-      }
-    },
-    "redbu11dev/shaguplates-extra": {
-      "default_branch": "master",
-      "sha": "0567d1f849418ba1a3962abf02f484e676f6cc04",
-      "branches": {
-        "master": "0567d1f849418ba1a3962abf02f484e676f6cc04"
-      }
-    },
-    "marcelinevq/shaguplatesx": {
-      "default_branch": "master",
-      "sha": "86cc312adece44b24378fe9c10854f7c7c4f6cd7",
-      "branches": {
-        "master": "86cc312adece44b24378fe9c10854f7c7c4f6cd7"
-      }
-    },
-    "paokkerkir/shaguplates": {
-      "default_branch": "master",
-      "sha": "32799951996277b8be5eed18d6e31546fefe6efa",
-      "branches": {
-        "master": "32799951996277b8be5eed18d6e31546fefe6efa"
-      }
-    },
-    "sandworlds-mmo/shaguplates": {
-      "default_branch": "master",
-      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
-      "branches": {
-        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
-      }
-    },
-    "hellowind777/shaguplates": {
-      "default_branch": "master",
-      "sha": "0f6a1530780552905a0237e295c37370b10898db",
-      "branches": {
-        "master": "0f6a1530780552905a0237e295c37370b10898db"
-      }
-    },
-    "eqomdx/shaguplates-fixes": {
-      "default_branch": "master",
-      "sha": "fcb999672bb3b7581e91936163df8a3782f326ec",
-      "branches": {
-        "master": "fcb999672bb3b7581e91936163df8a3782f326ec"
-      }
-    },
-    "tuxpainter/shaguplates": {
-      "default_branch": "ash-bashdev",
-      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
-      "branches": {
-        "ash-bashdev": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
-      }
-    },
-    "otari98/shaguplates": {
-      "default_branch": "master",
-      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
-      "branches": {
-        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
-      }
-    },
-    "macumbafeh/shaguplates": {
-      "default_branch": "master",
-      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
-      "branches": {
-        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
-      }
-    },
-    "michewarr/shaguplates": {
-      "default_branch": "master",
-      "sha": "0fc82b4e7892d719d3b651ef35bad426ae426e64",
-      "branches": {
-        "master": "0fc82b4e7892d719d3b651ef35bad426ae426e64"
-      }
-    },
-    "amonra/shaguplates": {
-      "default_branch": "master",
-      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
-      "branches": {
-        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
-      }
-    },
-    "dvmanlosa/shaguplates": {
-      "default_branch": "master",
-      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
-      "branches": {
-        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
-      }
-    },
-    "dwbclz/shaguplates": {
-      "default_branch": "master",
-      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
-      "branches": {
-        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
-      }
-    },
-    "hippoom/shaguplates": {
-      "default_branch": "master",
-      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
-      "branches": {
-        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
-      }
-    },
-    "jiangxt316/shaguplates": {
-      "default_branch": "master",
-      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
-      "branches": {
-        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
-      }
-    },
-    "koraykarakus/shaguplates": {
-      "default_branch": "master",
-      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
-      "branches": {
-        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
-      }
-    },
-    "ravenofseven/shaguplates": {
-      "default_branch": "master",
-      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
-      "branches": {
-        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
-      }
-    },
-    "flyinbed/shaguplates": {
-      "default_branch": "master",
-      "sha": "7f88d9a12a3d1d0df2a68d3ba94d90490d67ecd5",
-      "branches": {
-        "master": "7f88d9a12a3d1d0df2a68d3ba94d90490d67ecd5"
-      }
-    },
-    "shikulja/shaguplates": {
-      "default_branch": "master",
-      "sha": "ae9834da2c39272a859af8e6d90c82ecb04770bb",
-      "branches": {
-        "master": "ae9834da2c39272a859af8e6d90c82ecb04770bb"
-      }
-    },
-    "skllskll/shaguplates": {
-      "default_branch": "master",
-      "sha": "0f9f598489c3abf4bb06fe1cb07748b5e3d77c43",
-      "branches": {
-        "master": "0f9f598489c3abf4bb06fe1cb07748b5e3d77c43"
-      }
-    },
-    "shagu/shaguscan": {
-      "default_branch": "master",
-      "sha": "93de72eef2527cae356d28274afed8f819dc45c1",
-      "branches": {
-        "master": "93de72eef2527cae356d28274afed8f819dc45c1"
-      }
-    },
-    "the-kludge-bureau/shaguscan": {
-      "default_branch": "main",
-      "sha": "93de72eef2527cae356d28274afed8f819dc45c1",
-      "branches": {
-        "main": "93de72eef2527cae356d28274afed8f819dc45c1"
-      }
-    },
-    "helix-dev0/shaguscan": {
-      "default_branch": "master",
-      "sha": "9c81161e29d28b2e7191b532b2437c5ffd8bf803",
-      "branches": {
-        "master": "9c81161e29d28b2e7191b532b2437c5ffd8bf803"
-      },
-      "latest_tag": "v1.0.1"
-    },
-    "qrospars/shaguscanlongrange": {
-      "default_branch": "master",
-      "sha": "6b256283f02e0316b67ab42cd387028871101080",
-      "branches": {
-        "master": "6b256283f02e0316b67ab42cd387028871101080"
-      }
-    },
-    "therealfayz/shaguscan": {
-      "default_branch": "master",
-      "sha": "7c7618953aca8fed69fef2755dc9b48f0170a24b",
-      "branches": {
-        "master": "7c7618953aca8fed69fef2755dc9b48f0170a24b"
-      }
-    },
-    "whtmst/shaguscan": {
-      "default_branch": "master",
-      "sha": "8d5b3f6fb6cc49863ade987fbbb26c31e46d7080",
-      "branches": {
-        "master": "8d5b3f6fb6cc49863ade987fbbb26c31e46d7080"
-      }
-    },
-    "kaneha/shaguscan": {
-      "default_branch": "master",
-      "sha": "052d2d7d5bcfeb02109478314af67047f75f6d21",
-      "branches": {
-        "master": "052d2d7d5bcfeb02109478314af67047f75f6d21"
-      }
-    },
-    "amonra/shaguscan": {
-      "default_branch": "master",
-      "sha": "93de72eef2527cae356d28274afed8f819dc45c1",
-      "branches": {
-        "master": "93de72eef2527cae356d28274afed8f819dc45c1"
-      }
-    },
-    "dwbclz/shaguscan": {
-      "default_branch": "master",
-      "sha": "93de72eef2527cae356d28274afed8f819dc45c1",
-      "branches": {
-        "master": "93de72eef2527cae356d28274afed8f819dc45c1"
-      }
-    },
-    "jiangxt316/shaguscan": {
-      "default_branch": "master",
-      "sha": "93de72eef2527cae356d28274afed8f819dc45c1",
-      "branches": {
-        "master": "93de72eef2527cae356d28274afed8f819dc45c1"
-      }
-    },
-    "max-bruhn/shaguscan": {
-      "default_branch": "master",
-      "sha": "93de72eef2527cae356d28274afed8f819dc45c1",
-      "branches": {
-        "master": "93de72eef2527cae356d28274afed8f819dc45c1"
-      }
-    },
-    "jembawow/shaguscan": {
-      "default_branch": "master",
-      "sha": "60d7257f10db5cdfc53d15533bd4ce54f4f5eb40",
-      "branches": {
-        "master": "60d7257f10db5cdfc53d15533bd4ce54f4f5eb40"
-      }
-    },
-    "shikulja/shaguscan": {
-      "default_branch": "master",
-      "sha": "94f113b74e7432f8562f23da413f628d098852aa",
-      "branches": {
-        "master": "94f113b74e7432f8562f23da413f628d098852aa"
-      }
-    },
-    "shagu/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "paokkerkir/shagutweaks": {
-      "default_branch": "master",
-      "sha": "1d87df1b430473909d79da48108d5d9705394d84",
-      "branches": {
-        "master": "1d87df1b430473909d79da48108d5d9705394d84"
-      }
-    },
-    "otari98/shagutweaks": {
-      "default_branch": "master",
-      "sha": "2a812837ece04b15f15e3a330023b207ff2ba66c",
-      "branches": {
-        "master": "2a812837ece04b15f15e3a330023b207ff2ba66c"
-      }
-    },
-    "oldmanalpha/shagutweaks": {
-      "default_branch": "master",
-      "sha": "470e68a239b65d4001fe7d1b145a563413391217",
-      "branches": {
-        "master": "470e68a239b65d4001fe7d1b145a563413391217"
-      }
-    },
-    "deceius/shagutweaks": {
-      "default_branch": "master",
-      "sha": "1ee005adeadc311618695c16cfac9de9f51c2288",
-      "branches": {
-        "master": "1ee005adeadc311618695c16cfac9de9f51c2288"
-      }
-    },
-    "uss-enterprise-guild/shagutweaks": {
-      "default_branch": "master",
-      "sha": "12bb66452a3b9c2cc17b0bcdd41373839469a03f",
-      "branches": {
-        "master": "12bb66452a3b9c2cc17b0bcdd41373839469a03f"
-      }
-    },
-    "sandworlds-mmo/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "hellowind777/shagutweaks": {
-      "default_branch": "master",
-      "sha": "61144334e98c0fff3f457f068818e1c4d4818dd5",
-      "branches": {
-        "master": "61144334e98c0fff3f457f068818e1c4d4818dd5"
-      }
-    },
-    "balakethelock/shagutweaks": {
-      "default_branch": "master",
-      "sha": "c0f7a296f3f7d713a9bf134b059f75a401548c18",
-      "branches": {
-        "master": "c0f7a296f3f7d713a9bf134b059f75a401548c18"
-      }
-    },
-    "refaim/shagutweaks": {
-      "default_branch": "master",
-      "sha": "0a4b2b4ff44efc2ccdd646d28509f3b2fdd195a2",
-      "branches": {
-        "master": "0a4b2b4ff44efc2ccdd646d28509f3b2fdd195a2"
-      }
-    },
-    "karstenbade/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "ziin/shagutweaks": {
-      "default_branch": "master",
-      "sha": "61122caa8cc747c658d601258310f0433cbb071b",
-      "branches": {
-        "master": "61122caa8cc747c658d601258310f0433cbb071b"
-      }
-    },
-    "wow-br/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "lich906/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "dbfblackbull/shagutweaks": {
-      "default_branch": "master",
-      "sha": "ae86e6657055a7933a89e6426aae2c0b99a6046c",
-      "branches": {
-        "master": "ae86e6657055a7933a89e6426aae2c0b99a6046c"
-      }
-    },
-    "flyinbed/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "gashole/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "amonra/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "dwbclz/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "jiangxt316/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "nidski-wow/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "panzier32564-cmd/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "ravenofseven/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "shigemunekurogane/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "yani9o/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "zyyysxd/shagutweaks": {
-      "default_branch": "master",
-      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
-      "branches": {
-        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
-      }
-    },
-    "macumbafeh/shagutweaks": {
-      "default_branch": "master",
-      "sha": "5601835de65a651c8d3df9f7c935d54213b4d7c4",
-      "branches": {
-        "master": "5601835de65a651c8d3df9f7c935d54213b4d7c4"
-      }
-    },
-    "alchem1ster/shagutweaks": {
-      "default_branch": "master",
-      "sha": "b6c0a4268540745f334c06d6418101537b97eef2",
-      "branches": {
-        "master": "b6c0a4268540745f334c06d6418101537b97eef2"
-      }
-    },
-    "paenthy/shagutweaks": {
-      "default_branch": "master",
-      "sha": "4bff740eb3940830e7c874a42291c61813b39d34",
-      "branches": {
-        "master": "4bff740eb3940830e7c874a42291c61813b39d34"
-      }
-    },
-    "deadliftchic/shagutweaks": {
-      "default_branch": "master",
-      "sha": "b6c0a4268540745f334c06d6418101537b97eef2",
-      "branches": {
-        "master": "b6c0a4268540745f334c06d6418101537b97eef2"
-      }
-    },
-    "deicpro/shagutweaks": {
-      "default_branch": "master",
-      "sha": "0086ce9048d04466fde9062521abf0e8c596db52",
-      "branches": {
-        "master": "0086ce9048d04466fde9062521abf0e8c596db52"
-      }
-    },
-    "omegazeroxiii/shagutweaks": {
-      "default_branch": "master",
-      "sha": "0dca3ad512b0683b2602d56318857001620b7b40",
-      "branches": {
-        "master": "0dca3ad512b0683b2602d56318857001620b7b40"
-      }
-    },
-    "txuscolchonero/shagutweaks": {
-      "default_branch": "master",
-      "sha": "0dca3ad512b0683b2602d56318857001620b7b40",
-      "branches": {
-        "master": "0dca3ad512b0683b2602d56318857001620b7b40"
-      }
-    },
-    "waverion/shagutweaks": {
-      "default_branch": "master",
-      "sha": "568188aaee25cf4114fdd316f31098d207ba09f4",
-      "branches": {
-        "master": "568188aaee25cf4114fdd316f31098d207ba09f4"
-      }
-    },
-    "jembawow/shagutweaks": {
-      "default_branch": "master",
-      "sha": "c77d600d2d22a5b9c86acfa9ee801a1ee933c039",
-      "branches": {
-        "master": "c77d600d2d22a5b9c86acfa9ee801a1ee933c039"
-      }
-    },
-    "likesc/shagutweaks": {
-      "default_branch": "strip",
-      "sha": "ef522984fad9671bb2beb504eba9d1043d084750",
-      "branches": {
-        "strip": "ef522984fad9671bb2beb504eba9d1043d084750"
-      }
-    },
-    "ifelsethen/shagutweaks": {
-      "default_branch": "master",
-      "sha": "cf8169736f2d5584c959d3c32dd1e1e3fa1a0e3b",
-      "branches": {
-        "master": "cf8169736f2d5584c959d3c32dd1e1e3fa1a0e3b"
-      }
-    },
-    "chad90b/shagutweaks": {
-      "default_branch": "master",
-      "sha": "a7e79580eb57f2099780b11599e5489e5ea44afd",
-      "branches": {
-        "master": "a7e79580eb57f2099780b11599e5489e5ea44afd"
-      }
-    },
-    "brightlee1983/shagutweaks": {
-      "default_branch": "master",
-      "sha": "5014a47bac39e25c3caee512b940298436049f9b",
-      "branches": {
-        "master": "5014a47bac39e25c3caee512b940298436049f9b"
-      }
-    },
-    "pepopo978/simpleactionsets": {
-      "default_branch": "master",
-      "sha": "e2486ad2169333c1e69f18815224fb7962269ca0",
-      "branches": {
-        "master": "e2486ad2169333c1e69f18815224fb7962269ca0"
-      }
-    },
-    "lioryx/simpleactionsets": {
-      "default_branch": "master",
-      "sha": "a51baa1d0b2bd85313596e0fe593ccef4578b0a8",
-      "branches": {
-        "master": "a51baa1d0b2bd85313596e0fe593ccef4578b0a8"
-      }
-    },
-    "evannnn1996/simpleactionsets": {
-      "default_branch": "master",
-      "sha": "491464068d0d93ac48dce5b5cca2a9333541ead0",
-      "branches": {
-        "master": "491464068d0d93ac48dce5b5cca2a9333541ead0"
-      }
-    },
-    "mcpewpew/simpleactionsets": {
-      "default_branch": "master",
-      "sha": "081327a9ed780038ad8ef90a7f699b7a37d31a3c",
-      "branches": {
-        "master": "081327a9ed780038ad8ef90a7f699b7a37d31a3c"
-      }
-    },
-    "diginfotek/simpleactionsets": {
-      "default_branch": "master",
-      "sha": "0a11689e189d0a2d7f5988d7cc477ab922027f5c",
-      "branches": {
-        "master": "0a11689e189d0a2d7f5988d7cc477ab922027f5c"
-      }
-    },
-    "refaim/soloraidtargeticons": {
-      "default_branch": "master",
-      "sha": "6bfda6cb0a7ba487eb674c15fc67fd6cec599297",
-      "branches": {
-        "master": "6bfda6cb0a7ba487eb674c15fc67fd6cec599297"
-      }
-    },
-    "jrc13245/soloraidtargeticons": {
-      "default_branch": "master",
-      "sha": "37e05530cea74335c23c0cec087af8935f2d316a",
-      "branches": {
-        "master": "37e05530cea74335c23c0cec087af8935f2d316a"
-      }
-    },
-    "arcitec/soloraidtargeticons": {
-      "default_branch": "master",
-      "sha": "8b961e36dc3d9f239837b5912597ab0334a7c7b8",
-      "branches": {
-        "master": "8b961e36dc3d9f239837b5912597ab0334a7c7b8"
-      }
-    },
-    "chad90b/soloraidtargeticons": {
-      "default_branch": "master",
-      "sha": "8f4312c96d7b61e0a34278617633c6d183ee9f5a",
-      "branches": {
-        "master": "8f4312c96d7b61e0a34278617633c6d183ee9f5a"
-      }
-    },
-    "sorgis-sorgis/sorgis_raid_marks": {
-      "default_branch": "master",
-      "sha": "eb3433adb40ffc20b019d36327973767f42e5de6",
-      "branches": {
-        "master": "eb3433adb40ffc20b019d36327973767f42e5de6"
-      },
-      "latest_tag": "1.2.0"
-    },
-    "marcelinevq/sorgis_raid_marks": {
-      "default_branch": "master",
-      "sha": "080b75b1572e777384a7331cfe7c4174a92eb8b0",
-      "branches": {
-        "master": "080b75b1572e777384a7331cfe7c4174a92eb8b0"
-      }
-    },
-    "pepopo978/sorgis_raid_marks": {
-      "default_branch": "master",
-      "sha": "ccaf9725161db0dd7b5a71c4e1c1cce109645027",
-      "branches": {
-        "master": "ccaf9725161db0dd7b5a71c4e1c1cce109645027"
-      }
-    },
-    "marcelinevq/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "3dc83fce3b59ec473f1637c86ffb13f6facf2fbe",
-      "branches": {
-        "master": "3dc83fce3b59ec473f1637c86ffb13f6facf2fbe"
-      }
-    },
-    "al3xc1985/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "3dc83fce3b59ec473f1637c86ffb13f6facf2fbe",
-      "branches": {
-        "master": "3dc83fce3b59ec473f1637c86ffb13f6facf2fbe"
-      }
-    },
-    "bretharte89/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "3dc83fce3b59ec473f1637c86ffb13f6facf2fbe",
-      "branches": {
-        "master": "3dc83fce3b59ec473f1637c86ffb13f6facf2fbe"
-      }
-    },
-    "theoix/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "443e469a64956f5f753ff1ad71886ab06eaf11a8",
-      "branches": {
-        "master": "443e469a64956f5f753ff1ad71886ab06eaf11a8"
-      }
-    },
-    "leyki/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "9e622a5a5584e74400b7fffe9281800792fd3b6b",
-      "branches": {
-        "master": "9e622a5a5584e74400b7fffe9281800792fd3b6b"
-      }
-    },
-    "otari98/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "e39cc853ca6b6b0de757b9e85620af2339aa0806",
-      "branches": {
-        "master": "e39cc853ca6b6b0de757b9e85620af2339aa0806"
-      }
-    },
-    "zanthor/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "e39cc853ca6b6b0de757b9e85620af2339aa0806",
-      "branches": {
-        "master": "e39cc853ca6b6b0de757b9e85620af2339aa0806"
-      }
-    },
-    "thrunk112/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "369b4b553698f9f9c887f96b326bd7f11ffcc74f",
-      "branches": {
-        "master": "369b4b553698f9f9c887f96b326bd7f11ffcc74f"
-      }
-    },
-    "balakethelock/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "ee0f7d49b0569b7bd4bc7675ae575bc7fdca6b8d",
-      "branches": {
-        "master": "ee0f7d49b0569b7bd4bc7675ae575bc7fdca6b8d"
-      },
-      "latest_tag": "4.2.0"
-    },
-    "bahamutxd/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "dd52f91a81f565adb367b51df7011b642d6836a4",
-      "branches": {
-        "master": "dd52f91a81f565adb367b51df7011b642d6836a4"
-      }
-    },
-    "profiler781/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "ae44ba82c7994a507d129ba5327d90df9c212873",
-      "branches": {
-        "master": "ae44ba82c7994a507d129ba5327d90df9c212873"
-      }
-    },
-    "flyinbed/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "ee0f7d49b0569b7bd4bc7675ae575bc7fdca6b8d",
-      "branches": {
-        "master": "ee0f7d49b0569b7bd4bc7675ae575bc7fdca6b8d"
-      }
-    },
-    "kluy18/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "fbbccf7e277c6ef9578927764d06dbccd2748808",
-      "branches": {
-        "master": "fbbccf7e277c6ef9578927764d06dbccd2748808"
-      }
-    },
-    "tperraut/sp_swingtimer": {
-      "default_branch": "master",
-      "sha": "33f79c2ef27c5e8593b84531ee97212b4429d48d",
-      "branches": {
-        "master": "33f79c2ef27c5e8593b84531ee97212b4429d48d"
-      },
-      "latest_tag": "4.2.0"
-    },
-    "marcelinevq/spiritlinker": {
-      "default_branch": "master",
-      "sha": "750d6d168dc601361c3a5a70956114a0dd095834",
-      "branches": {
-        "master": "750d6d168dc601361c3a5a70956114a0dd095834"
-      }
-    },
-    "perks/sundernp": {
-      "default_branch": "main",
-      "sha": "606d69cdf80ee3d139256585773da6d7f078fbfd",
-      "branches": {
-        "main": "606d69cdf80ee3d139256585773da6d7f078fbfd"
-      }
-    },
-    "balakethelock/superapi": {
-      "default_branch": "master",
-      "sha": "901322dc88890a2ea10610b8228fb43c9c2a3610",
-      "branches": {
-        "master": "901322dc88890a2ea10610b8228fb43c9c2a3610"
-      }
-    },
-    "laytya/superapi": {
-      "default_branch": "master",
-      "sha": "025fc8977080e21caa11338892e8e08e808d30fd",
-      "branches": {
-        "master": "025fc8977080e21caa11338892e8e08e808d30fd"
-      }
-    },
-    "otari98/superapi": {
-      "default_branch": "master",
-      "sha": "901322dc88890a2ea10610b8228fb43c9c2a3610",
-      "branches": {
-        "master": "901322dc88890a2ea10610b8228fb43c9c2a3610"
-      }
-    },
-    "evannnn1996/superapi": {
-      "default_branch": "master",
-      "sha": "f08fb758a7b97357696086a4c9c7cee7acc9a6fa",
-      "branches": {
-        "master": "f08fb758a7b97357696086a4c9c7cee7acc9a6fa"
-      }
-    },
-    "balakethelock/superapi_castlib": {
-      "default_branch": "master",
-      "sha": "4a354bf11fe9c150328301b3db4fcc4de9379170",
-      "branches": {
-        "master": "4a354bf11fe9c150328301b3db4fcc4de9379170"
-      }
-    },
-    "gescht/superapi_castlib": {
-      "default_branch": "master",
-      "sha": "5b1fa1dec778b4bf7565680835d4cf71012cad36",
-      "branches": {
-        "master": "5b1fa1dec778b4bf7565680835d4cf71012cad36"
-      }
-    },
-    "jrc13245/supercleveroidmacros": {
-      "default_branch": "main",
-      "sha": "3a196c484f84dc7b4fbce1b327f117890d24d96d",
-      "branches": {
-        "main": "3a196c484f84dc7b4fbce1b327f117890d24d96d"
-      }
-    },
-    "brues-code/supercleveroidmacros": {
-      "default_branch": "main",
-      "sha": "61bab6c734e646f67a9252bca57841059c5cdb0e",
-      "branches": {
-        "main": "61bab6c734e646f67a9252bca57841059c5cdb0e"
-      },
-      "latest_tag": "v3.1.10"
-    },
-    "eqomdx/supercleveroidmacros": {
-      "default_branch": "main",
-      "sha": "102c5a5a4c4a6dd191516ebae55f29b25d283079",
-      "branches": {
-        "main": "102c5a5a4c4a6dd191516ebae55f29b25d283079"
-      }
-    },
-    "twisniowski/supercleveroidmacros": {
-      "default_branch": "main",
-      "sha": "7335e71e5ea53a553b4fdf0e3a800367e48c8960",
-      "branches": {
-        "main": "7335e71e5ea53a553b4fdf0e3a800367e48c8960"
-      }
-    },
-    "hippoom/supercleveroidmacros": {
-      "default_branch": "main",
-      "sha": "4c61394e00dcbf492263c5d018743cf87a4f05ee",
-      "branches": {
-        "main": "4c61394e00dcbf492263c5d018743cf87a4f05ee"
-      }
-    },
-    "arimbaud-x/lazyscript": {
-      "default_branch": "superlazyscript",
-      "sha": "2f84c274793f4fcd62831b4a5b2a8ca1e4a6508e",
-      "branches": {
-        "superlazyscript": "2f84c274793f4fcd62831b4a5b2a8ca1e4a6508e"
-      }
-    },
-    "elboaf/supertotem": {
-      "default_branch": "main",
-      "sha": "936405bfe7931e7368f39e3e14e3c9cb807127ce",
-      "branches": {
-        "main": "936405bfe7931e7368f39e3e14e3c9cb807127ce"
-      }
-    },
-    "akzkak/supertotem": {
-      "default_branch": "main",
-      "sha": "1cae895d69190037fe121b9fc5e88081adbf18e0",
-      "branches": {
-        "main": "1cae895d69190037fe121b9fc5e88081adbf18e0"
-      }
-    },
-    "bretharte89/supertotem": {
-      "default_branch": "main",
-      "sha": "936405bfe7931e7368f39e3e14e3c9cb807127ce",
-      "branches": {
-        "main": "936405bfe7931e7368f39e3e14e3c9cb807127ce"
-      }
-    },
-    "pepopo978/superwowcombatlogger": {
-      "default_branch": "master",
-      "sha": "c67e198a8a0921747ed4d487d25aa25eb4317779",
-      "branches": {
-        "master": "c67e198a8a0921747ed4d487d25aa25eb4317779"
-      }
-    },
-    "thaodan/superwowcombatlogger": {
-      "default_branch": "master",
-      "sha": "388e02c6f8cf4b0300e29605721979f970209fa3",
-      "branches": {
-        "master": "388e02c6f8cf4b0300e29605721979f970209fa3"
-      }
-    },
-    "uss-enterprise-guild/1701-captainslog": {
-      "default_branch": "master",
-      "sha": "292c945dd1a35606f1ad35055ba2920295684760",
-      "branches": {
-        "master": "292c945dd1a35606f1ad35055ba2920295684760"
-      }
-    },
-    "bretharte89/superwowcombatlogger": {
-      "default_branch": "master",
-      "sha": "c67e198a8a0921747ed4d487d25aa25eb4317779",
-      "branches": {
-        "master": "c67e198a8a0921747ed4d487d25aa25eb4317779"
-      }
-    },
-    "emyrk/superwowcombatlogger": {
-      "default_branch": "master",
-      "sha": "62896992fc5ff5d13d018cc8e7ecaa0fe520aa74",
-      "branches": {
-        "master": "62896992fc5ff5d13d018cc8e7ecaa0fe520aa74"
-      }
-    },
-    "zanthor/superwowcombatlogger": {
-      "default_branch": "master",
-      "sha": "9ed071de10085dafa8b5b75a0f51fdeb14652886",
-      "branches": {
-        "master": "9ed071de10085dafa8b5b75a0f51fdeb14652886"
-      }
-    },
-    "marcelinevq/advancedlogger": {
-      "default_branch": "master",
-      "sha": "3b540eaf5842847b4651c4758054cde5789442f6",
-      "branches": {
-        "master": "3b540eaf5842847b4651c4758054cde5789442f6"
-      }
-    },
-    "whtmst/superwowcombatlogger": {
-      "default_branch": "master",
-      "sha": "1b3cd0c459d7d79d5e91c4db30ad206083920963",
-      "branches": {
-        "master": "1b3cd0c459d7d79d5e91c4db30ad206083920963"
-      }
-    },
-    "kameleonuk/superwowcombatlogger": {
-      "default_branch": "master",
-      "sha": "4cb2407199bcf140414dd9238a8dc1dc3601495d",
-      "branches": {
-        "master": "4cb2407199bcf140414dd9238a8dc1dc3601495d"
-      }
-    },
-    "danitot/superwowcombatlogger": {
-      "default_branch": "master",
-      "sha": "81d41b9204411fb09127ae4477915799b553542f",
-      "branches": {
-        "master": "81d41b9204411fb09127ae4477915799b553542f"
-      }
-    },
-    "melbaa/superwowcombatlogger": {
-      "default_branch": "master",
-      "sha": "a91b4f03c1e020ef244b1d0d86546ca1da4c68b3",
-      "branches": {
-        "master": "a91b4f03c1e020ef244b1d0d86546ca1da4c68b3"
-      }
-    },
-    "vargv666/superwowcombatlogger": {
-      "default_branch": "master",
-      "sha": "dc2ba8231ae73aade5d6fdaabcf3bc727c3eaa5f",
-      "branches": {
-        "master": "dc2ba8231ae73aade5d6fdaabcf3bc727c3eaa5f"
-      }
-    },
-    "marcelinevq/tankalyze": {
-      "default_branch": "master",
-      "sha": "99cc74be8dd4e1292f57d45365657bc7849398f4",
-      "branches": {
-        "master": "99cc74be8dd4e1292f57d45365657bc7849398f4"
-      }
-    },
-    "twapegg/tankalyze": {
-      "default_branch": "master",
-      "sha": "c5a1d327e05c7db8206b376b1353a597c720441c",
-      "branches": {
-        "master": "c5a1d327e05c7db8206b376b1353a597c720441c"
-      }
-    },
-    "marcelinevq/tankplates": {
-      "default_branch": "master",
-      "sha": "8f5c98fed26d3a90e0653db96a64fa9852fc055c",
-      "branches": {
-        "master": "8f5c98fed26d3a90e0653db96a64fa9852fc055c"
-      }
-    },
-    "daemonp/tankplates": {
-      "default_branch": "master",
-      "sha": "e2f9ba304f4ec82ae76fbd46cc935b433cadc782",
-      "branches": {
-        "master": "e2f9ba304f4ec82ae76fbd46cc935b433cadc782"
-      },
-      "latest_tag": "v1.4.2"
-    },
-    "thrunk112/tankplates": {
-      "default_branch": "master",
-      "sha": "8f5c98fed26d3a90e0653db96a64fa9852fc055c",
-      "branches": {
-        "master": "8f5c98fed26d3a90e0653db96a64fa9852fc055c"
-      }
-    },
-    "gescht/tankplates": {
-      "default_branch": "master",
-      "sha": "f2f1f8b5f12449c25696a2ab9371a63b4c105eea",
-      "branches": {
-        "master": "f2f1f8b5f12449c25696a2ab9371a63b4c105eea"
-      }
-    },
-    "al3xc1985/tankplates": {
-      "default_branch": "master",
-      "sha": "8f5c98fed26d3a90e0653db96a64fa9852fc055c",
-      "branches": {
-        "master": "8f5c98fed26d3a90e0653db96a64fa9852fc055c"
-      }
-    },
-    "shikulja/tankplates": {
-      "default_branch": "master",
-      "sha": "c271b882b6f39f7f2f68d5f5403e17b5e2226767",
-      "branches": {
-        "master": "c271b882b6f39f7f2f68d5f5403e17b5e2226767"
-      }
-    },
-    "marcelinevq/tattler": {
-      "default_branch": "master",
-      "sha": "61ec222b47ce8268510aac8e49e9808c8cd20229",
-      "branches": {
-        "master": "61ec222b47ce8268510aac8e49e9808c8cd20229"
-      }
-    },
-    "bang1726528/tattler": {
-      "default_branch": "master",
-      "sha": "d8dc4bbf8c332ebd93a853e35be37528d14f1817",
-      "branches": {
-        "master": "d8dc4bbf8c332ebd93a853e35be37528d14f1817"
-      }
-    },
-    "marcelinevq/tracktarget": {
-      "default_branch": "master",
-      "sha": "f5b28a96cfef537f52c34f73212053646e699208",
-      "branches": {
-        "master": "f5b28a96cfef537f52c34f73212053646e699208"
-      }
-    },
-    "marcelinevq/twister": {
-      "default_branch": "master",
-      "sha": "924829c3f4bfd9b405c3b316082d49f8ea6c673a",
-      "branches": {
-        "master": "924829c3f4bfd9b405c3b316082d49f8ea6c673a"
-      }
-    },
-    "bretharte89/twister": {
-      "default_branch": "master",
-      "sha": "924829c3f4bfd9b405c3b316082d49f8ea6c673a",
-      "branches": {
-        "master": "924829c3f4bfd9b405c3b316082d49f8ea6c673a"
-      }
-    },
-    "lanrutcon/abreathbeneath": {
-      "default_branch": "master",
-      "sha": "43efe7e36b4272c76e4b2f0b91e24c60e582d8f5",
-      "branches": {
-        "master": "43efe7e36b4272c76e4b2f0b91e24c60e582d8f5"
-      },
-      "latest_tag": "v1.0"
-    },
-    "siventt/actionbarprofiles": {
-      "default_branch": "master",
-      "sha": "b62477f279799808cdfa7398967c43437cff762d",
-      "branches": {
-        "master": "b62477f279799808cdfa7398967c43437cff762d"
-      }
-    },
-    "lexxoi/actionbarprofiles": {
-      "default_branch": "master",
-      "sha": "54d8c4f54322e955c4eb6c2fd0aaed1405db7e9f",
-      "branches": {
-        "master": "54d8c4f54322e955c4eb6c2fd0aaed1405db7e9f"
-      }
-    },
-    "otari98/actionbarprofiles": {
-      "default_branch": "master",
-      "sha": "b474c145e365466e3b00fc4375489dc7e95a108a",
-      "branches": {
-        "master": "b474c145e365466e3b00fc4375489dc7e95a108a"
-      }
-    },
-    "satan666/ag_unitframes_improved": {
-      "default_branch": "master",
-      "sha": "322a31397bd9cc56d0542629c7c42a01ac085915",
-      "branches": {
-        "master": "322a31397bd9cc56d0542629c7c42a01ac085915"
-      }
-    },
-    "melbaa/apd": {
-      "default_branch": "master",
-      "sha": "0ea3c1b2a1e55b8e1bee9bd21593bcdd5becad84",
-      "branches": {
-        "master": "0ea3c1b2a1e55b8e1bee9bd21593bcdd5becad84"
-      }
-    },
-    "mcpewpew/archud2": {
-      "default_branch": "master",
-      "sha": "06abb11870bce892fd34816e5e54dd1f0e64409c",
-      "branches": {
-        "master": "06abb11870bce892fd34816e5e54dd1f0e64409c"
-      }
-    },
-    "caestielle/beardleysdiabloorbsvanilla": {
-      "default_branch": "master",
-      "sha": "b66186fe9f5de999034bd78f307e50cb8a6a3152",
-      "branches": {
-        "master": "b66186fe9f5de999034bd78f307e50cb8a6a3152"
-      }
-    },
-    "brotalnia/blizzplates": {
-      "default_branch": "master",
-      "sha": "8aa50c0fe0d50aabeab39472abebb3f5f241672b",
-      "branches": {
-        "master": "8aa50c0fe0d50aabeab39472abebb3f5f241672b"
-      }
-    },
-    "humblekagu/blizzardplates": {
-      "default_branch": "master",
-      "sha": "3343df98b46d2dbeb6ca6577bf0713328d4cb3fc",
-      "branches": {
-        "master": "3343df98b46d2dbeb6ca6577bf0713328d4cb3fc"
-      }
-    },
-    "jacamo555/bongos": {
-      "default_branch": "main",
-      "sha": "00873e5dca5468f89c384e7d6d471fa0b74f6e73",
-      "branches": {
-        "main": "00873e5dca5468f89c384e7d6d471fa0b74f6e73"
-      }
-    },
-    "marcelinevq/bongos": {
-      "default_branch": "main",
-      "sha": "3365e3f6f199f8e48a042965809d161d3e3408cf",
-      "branches": {
-        "main": "3365e3f6f199f8e48a042965809d161d3e3408cf"
-      }
-    },
-    "hwesta2001/bongos_hw": {
-      "default_branch": "main",
-      "sha": "74ac638f9f71b6b64e5de6308e1e51dfc56d55d8",
-      "branches": {
-        "main": "74ac638f9f71b6b64e5de6308e1e51dfc56d55d8"
-      }
-    },
-    "ftkun/bongos": {
-      "default_branch": "main",
-      "sha": "c6062fd6c3ce5881abf4ec075742156487e3c136",
-      "branches": {
-        "main": "c6062fd6c3ce5881abf4ec075742156487e3c136"
-      }
-    },
-    "greegro2/bongos": {
-      "default_branch": "main",
-      "sha": "cb3b7af12165c647885e7ee5052cb397b0773784",
-      "branches": {
-        "main": "cb3b7af12165c647885e7ee5052cb397b0773784"
-      }
-    },
-    "increikesoul/bongos": {
-      "default_branch": "main",
-      "sha": "cb3b7af12165c647885e7ee5052cb397b0773784",
-      "branches": {
-        "main": "cb3b7af12165c647885e7ee5052cb397b0773784"
-      }
-    },
-    "phrxqt/combatplates": {
-      "default_branch": "main",
-      "sha": "79343791e4871feb3222d66b592292eede7260a8",
-      "branches": {
-        "main": "79343791e4871feb3222d66b592292eede7260a8"
-      },
-      "latest_tag": "v1.0"
-    },
-    "laytya/customnameplates": {
-      "default_branch": "master",
-      "sha": "5088926b4900cedcf90b34853b974112352b395f",
-      "branches": {
-        "master": "5088926b4900cedcf90b34853b974112352b395f"
-      },
-      "latest_tag": "1.70"
-    },
-    "retrospectx/cycircled": {
-      "default_branch": "master",
-      "sha": "67b8954972240dee686feb118de15fb42ac7e783",
-      "branches": {
-        "master": "67b8954972240dee686feb118de15fb42ac7e783"
-      }
-    },
-    "ennea/eui": {
-      "default_branch": "master",
-      "sha": "294d94545de5553422b3be45ca1fbb25d2f65cb0",
-      "branches": {
-        "master": "294d94545de5553422b3be45ca1fbb25d2f65cb0"
-      },
-      "latest_tag": "v1.0"
-    },
-    "cdnievas/fastbinding": {
-      "default_branch": "main",
-      "sha": "ee17faa82f4aa2faa1fade7d4219d23eee3520f3",
-      "branches": {
-        "main": "ee17faa82f4aa2faa1fade7d4219d23eee3520f3"
-      },
-      "latest_tag": "v1.1.1"
-    },
-    "terdong/fastbinding": {
-      "default_branch": "main",
-      "sha": "ffb36d68265b42330ecc2126b09d05fbf597951f",
-      "branches": {
-        "main": "ffb36d68265b42330ecc2126b09d05fbf597951f"
-      }
-    },
-    "niclaseriksen/feid": {
-      "default_branch": "main",
-      "sha": "70bf73a175b3f4f4d837b563fc4fcbdb6419bf4c",
-      "branches": {
-        "main": "70bf73a175b3f4f4d837b563fc4fcbdb6419bf4c"
-      }
-    },
-    "moiian/ffxivcrosshotbar": {
-      "default_branch": "main",
-      "sha": "7408d6b40d78bb28850cfe291d02836bfa95d14e",
-      "branches": {
-        "main": "7408d6b40d78bb28850cfe291d02836bfa95d14e"
-      },
-      "latest_tag": "FFXIVCrossHotbar_ver1.3"
-    },
-    "tarkusx/ffxivcrosshotbar": {
-      "default_branch": "main",
-      "sha": "7408d6b40d78bb28850cfe291d02836bfa95d14e",
-      "branches": {
-        "main": "7408d6b40d78bb28850cfe291d02836bfa95d14e"
-      }
-    },
-    "neimad-mp/framefade": {
-      "default_branch": "main",
-      "sha": "70e00676afb21fcb2be677bbb1bf1af8cf57cb24",
-      "branches": {
-        "main": "70e00676afb21fcb2be677bbb1bf1af8cf57cb24"
-      }
-    },
-    "spuxx1701/fulluitoggle": {
-      "default_branch": "master",
-      "sha": "944192f198880d7d8b3786652f58ff16e697d71e",
-      "branches": {
-        "master": "944192f198880d7d8b3786652f58ff16e697d71e"
-      }
-    },
-    "grenderg/gmr": {
-      "default_branch": "master",
-      "sha": "e7ffd2498de4b96e8f11593ebb75d738580f2dfb",
-      "branches": {
-        "master": "e7ffd2498de4b96e8f11593ebb75d738580f2dfb"
+        "main": "3104b532b0f0ac3d262be3398655adb0b115b5dc"
       }
     },
     "fsuhas/goblin-brain-saver": {
@@ -14170,238 +4599,181 @@
         "main": "2a5948a1f3b034e9cff785ab4e2bea50be8c7920"
       }
     },
-    "flyinbed/gryllsswingtimer": {
+    "fsuhas/lootblare-for-roolfor": {
       "default_branch": "main",
-      "sha": "96abc780c73662726c797b72dd813c4dbd5ef48b",
+      "sha": "3f2a2deec0affc69009b91042436355c36ed4a2e",
       "branches": {
-        "main": "96abc780c73662726c797b72dd813c4dbd5ef48b"
+        "main": "3f2a2deec0affc69009b91042436355c36ed4a2e"
       }
     },
-    "rankxuan/gryllsswingtimer": {
+    "fsuhas/mcp-tw": {
       "default_branch": "main",
-      "sha": "292d0d9a72293a4e8f0790711cf2ee2ca328017e",
+      "sha": "1f5dc1c2de08584fbf5cb6c2fd4bca9a8cc63aa6",
       "branches": {
-        "main": "292d0d9a72293a4e8f0790711cf2ee2ca328017e"
+        "main": "1f5dc1c2de08584fbf5cb6c2fd4bca9a8cc63aa6"
       }
     },
-    "vatichild/guda-plates": {
-      "default_branch": "main",
-      "sha": "e5204a4e8035257bbdb66234eab0494231443d5c",
+    "fsuhas/minimapbuttonbag-turtlewow": {
+      "default_branch": "master",
+      "sha": "65dd679c2ae9db41fb2afe54e3db227b1cf674ba",
       "branches": {
-        "main": "e5204a4e8035257bbdb66234eab0494231443d5c"
+        "master": "65dd679c2ae9db41fb2afe54e3db227b1cf674ba"
       },
-      "latest_tag": "1.3.5"
+      "latest_tag": "v0.508"
     },
-    "twapegg/gudaplates": {
+    "fsuhas/soundboard": {
       "default_branch": "main",
-      "sha": "7a00258f97a92d4fcfcc7ef062745fd9ac9bf533",
+      "sha": "643be948143f8cdc513bc73c8aba1fb3513c6782",
       "branches": {
-        "main": "7a00258f97a92d4fcfcc7ef062745fd9ac9bf533"
+        "main": "643be948143f8cdc513bc73c8aba1fb3513c6782"
+      }
+    },
+    "ftkun/aux-revamped-opaque": {
+      "default_branch": "master",
+      "sha": "ad976fb06112186baaf285ab72fadeec72d61a56",
+      "branches": {
+        "master": "ad976fb06112186baaf285ab72fadeec72d61a56"
+      }
+    },
+    "ftkun/bongos": {
+      "default_branch": "main",
+      "sha": "c6062fd6c3ce5881abf4ec075742156487e3c136",
+      "branches": {
+        "main": "c6062fd6c3ce5881abf4ec075742156487e3c136"
+      }
+    },
+    "ftkun/mouseoversounds": {
+      "default_branch": "main",
+      "sha": "e094b2ae6b4c84dba0d13fcd44c36677644e43e8",
+      "branches": {
+        "main": "e094b2ae6b4c84dba0d13fcd44c36677644e43e8"
+      }
+    },
+    "ftkun/sortbags-vanilla-class-reagents-sorting-": {
+      "default_branch": "master",
+      "sha": "99c3d064cd70319a698b0d56d8d50a853bc163db",
+      "branches": {
+        "master": "99c3d064cd70319a698b0d56d8d50a853bc163db"
+      }
+    },
+    "fu-blizz/roll-for-vanilla": {
+      "default_branch": "master",
+      "sha": "05b964006ec4b9dd35decc0581fd84ddf78cb343",
+      "branches": {
+        "master": "05b964006ec4b9dd35decc0581fd84ddf78cb343"
       },
-      "latest_tag": "1.3.5"
+      "latest_tag": "v4.6.5"
     },
-    "thezephyrsong/gudaplates": {
-      "default_branch": "main",
-      "sha": "ac0114987cf403345baed3d98ef1482e0cdcc1af",
-      "branches": {
-        "main": "ac0114987cf403345baed3d98ef1482e0cdcc1af"
-      }
-    },
-    "bretharte89/gudaplates": {
-      "default_branch": "main",
-      "sha": "e5204a4e8035257bbdb66234eab0494231443d5c",
-      "branches": {
-        "main": "e5204a4e8035257bbdb66234eab0494231443d5c"
-      }
-    },
-    "francisegan/gudaplates": {
-      "default_branch": "main",
-      "sha": "a51dc61ccfd1be21185882d61a8ac9cbe0138ac5",
-      "branches": {
-        "main": "a51dc61ccfd1be21185882d61a8ac9cbe0138ac5"
-      }
-    },
-    "sandelarma/gudaplates": {
-      "default_branch": "main",
-      "sha": "a51dc61ccfd1be21185882d61a8ac9cbe0138ac5",
-      "branches": {
-        "main": "a51dc61ccfd1be21185882d61a8ac9cbe0138ac5"
-      }
-    },
-    "yutsuku/hawkenplates": {
+    "fulzamoth/eepanels-v": {
       "default_branch": "master",
-      "sha": "91a53b63ad2139f3903f07a5170172766e8a1ce1",
+      "sha": "2f5af623720a1a308abe3fdff4b9fc0b01e468b9",
       "branches": {
-        "master": "91a53b63ad2139f3903f07a5170172766e8a1ce1"
-      }
-    },
-    "hitbutton/hbactionbars": {
-      "default_branch": "master",
-      "sha": "dc39f5a16a173d58f65a0e6c71ec8f526b667714",
-      "branches": {
-        "master": "dc39f5a16a173d58f65a0e6c71ec8f526b667714"
-      }
-    },
-    "sulpitz/hcspy": {
-      "default_branch": "master",
-      "sha": "840c80c2f6309aae1e8ba410ca4ec1351ab343f1",
-      "branches": {
-        "master": "840c80c2f6309aae1e8ba410ca4ec1351ab343f1"
-      }
-    },
-    "shikulja/hcspy": {
-      "default_branch": "master",
-      "sha": "840c80c2f6309aae1e8ba410ca4ec1351ab343f1",
-      "branches": {
-        "master": "840c80c2f6309aae1e8ba410ca4ec1351ab343f1"
-      }
-    },
-    "i2ichardt/healersmate": {
-      "default_branch": "main",
-      "sha": "8d4801947edaf07fa8f8dd0145f046c45cb5493b",
-      "branches": {
-        "main": "8d4801947edaf07fa8f8dd0145f046c45cb5493b"
+        "master": "2f5af623720a1a308abe3fdff4b9fc0b01e468b9"
       },
-      "latest_tag": "v1.3.0"
+      "latest_tag": "v1.0.0"
     },
-    "oldmanalpha/healersmate": {
-      "default_branch": "main",
-      "sha": "533636c4f63317d0cca7b576e315dddea27c8201",
+    "fusionpit/questframefixer": {
+      "default_branch": "master",
+      "sha": "6eef35fbfcc51039f7d1e3cff78061468abeb69e",
       "branches": {
-        "main": "533636c4f63317d0cca7b576e315dddea27c8201"
-      }
-    },
-    "uc9089/healersmate": {
-      "default_branch": "main",
-      "sha": "91a97eca12969b29bc4ebec13302debdea542bab",
-      "branches": {
-        "main": "91a97eca12969b29bc4ebec13302debdea542bab"
-      }
-    },
-    "bretharte89/healersmate": {
-      "default_branch": "main",
-      "sha": "533636c4f63317d0cca7b576e315dddea27c8201",
-      "branches": {
-        "main": "533636c4f63317d0cca7b576e315dddea27c8201"
-      }
-    },
-    "marcelinevq/healersmate": {
-      "default_branch": "main",
-      "sha": "75e77122fc8a30e3f2b58f264bed11865549cd7f",
-      "branches": {
-        "main": "75e77122fc8a30e3f2b58f264bed11865549cd7f"
-      }
-    },
-    "siand/healersmate": {
-      "default_branch": "main",
-      "sha": "4db32f472cc520c7ecd93e11dd02d3528e21b3ea",
-      "branches": {
-        "main": "4db32f472cc520c7ecd93e11dd02d3528e21b3ea"
+        "master": "6eef35fbfcc51039f7d1e3cff78061468abeb69e"
       },
-      "latest_tag": "v2.0.0-alpha4.1"
+      "latest_tag": "4.0.2"
     },
-    "hosq/hidenameplates": {
+    "gabcinder2004/battlescribe": {
       "default_branch": "master",
-      "sha": "c95fde46d944690e5db263a6310cb47c5898bf5a",
+      "sha": "e7c702ed8b38867acf60b796f9545d8153a77d87",
       "branches": {
-        "master": "c95fde46d944690e5db263a6310cb47c5898bf5a"
-      }
-    },
-    "jakiraelysium/hideui": {
-      "default_branch": "master",
-      "sha": "ef5f35ff875061d1a51a9081808b9fef870df6ae",
-      "branches": {
-        "master": "ef5f35ff875061d1a51a9081808b9fef870df6ae"
-      }
-    },
-    "stormhand81/immersion": {
-      "default_branch": "main",
-      "sha": "e87aa4b025da9b810866f64f769af1fb48e3ffe6",
-      "branches": {
-        "main": "e87aa4b025da9b810866f64f769af1fb48e3ffe6"
+        "master": "e7c702ed8b38867acf60b796f9545d8153a77d87"
       },
-      "latest_tag": "1.4"
+      "latest_tag": "v1.1"
     },
-    "al3xc1985/immersion": {
-      "default_branch": "main",
-      "sha": "e87aa4b025da9b810866f64f769af1fb48e3ffe6",
-      "branches": {
-        "main": "e87aa4b025da9b810866f64f769af1fb48e3ffe6"
-      }
-    },
-    "bretharte89/immersion": {
-      "default_branch": "main",
-      "sha": "e87aa4b025da9b810866f64f769af1fb48e3ffe6",
-      "branches": {
-        "main": "e87aa4b025da9b810866f64f769af1fb48e3ffe6"
-      }
-    },
-    "warlockbugs/impulse-booster": {
+    "gabcinder2004/bislist": {
       "default_branch": "master",
-      "sha": "79eb07d55179526a842d300300ffa20b40390e3a",
+      "sha": "cbfa05df370d78047fbc34c2a55e15d9ba0eee78",
       "branches": {
-        "master": "79eb07d55179526a842d300300ffa20b40390e3a"
+        "master": "cbfa05df370d78047fbc34c2a55e15d9ba0eee78"
       },
-      "latest_tag": "v3.1-final"
+      "latest_tag": "v1.1"
     },
-    "riqqqque/impulse-booster": {
+    "gabcinder2004/questtracker": {
       "default_branch": "master",
-      "sha": "c8ca66210b07a4a1bf1ed5ff5c877f36ae868b52",
+      "sha": "85697ea3837ef3b872e2dc3a0f33780a6e807188",
       "branches": {
-        "master": "c8ca66210b07a4a1bf1ed5ff5c877f36ae868b52"
-      },
-      "latest_tag": "v3.1.2"
-    },
-    "goldenpipes/impulse-booster": {
-      "default_branch": "master",
-      "sha": "82595b42848cbcfc64e546f4529b8408a7e1ba7c",
-      "branches": {
-        "master": "82595b42848cbcfc64e546f4529b8408a7e1ba7c"
-      },
-      "latest_tag": "v3.1-final"
-    },
-    "kirchlive/impulse-booster": {
-      "default_branch": "master",
-      "sha": "72985612600bb8ab6811883d4e99fd118ab3bed5",
-      "branches": {
-        "master": "72985612600bb8ab6811883d4e99fd118ab3bed5"
+        "master": "85697ea3837ef3b872e2dc3a0f33780a6e807188"
       }
     },
-    "pushxd/jim_toolbox": {
+    "gabcinder2004/shagudps": {
       "default_branch": "master",
-      "sha": "e37354207820a739a878892aa2d6cb0f3f897822",
+      "sha": "60dd0f24d953ee04676da5a61d5f17c67c01491f",
       "branches": {
-        "master": "e37354207820a739a878892aa2d6cb0f3f897822"
+        "master": "60dd0f24d953ee04676da5a61d5f17c67c01491f"
       }
     },
-    "road-block/killlog": {
+    "gabrielecimolino/swapper": {
       "default_branch": "master",
-      "sha": "4e7b4b36433a5b1d20c5336d1ef57965dbc183a1",
+      "sha": "d6b707fbfede36cd9e781ce54a1b07ff55fb9759",
       "branches": {
-        "master": "4e7b4b36433a5b1d20c5336d1ef57965dbc183a1"
-      },
-      "latest_tag": "2.6.3-11200"
-    },
-    "mcggithub/mcgui": {
-      "default_branch": "master",
-      "sha": "bdcdfd6b16f7ec69abcb999b7455cc36785c0485",
-      "branches": {
-        "master": "bdcdfd6b16f7ec69abcb999b7455cc36785c0485"
+        "master": "d6b707fbfede36cd9e781ce54a1b07ff55fb9759"
       }
     },
-    "zirtox1992/modui": {
+    "gabrin18/zui": {
+      "default_branch": "master",
+      "sha": "6a5709de4bc37577b824565db3fe3f1c048e7923",
+      "branches": {
+        "master": "6a5709de4bc37577b824565db3fe3f1c048e7923"
+      }
+    },
+    "gabrwagn/itemsofpower": {
+      "default_branch": "master",
+      "sha": "335e9cf79457e1c8893a37d620beb2e07bf8186f",
+      "branches": {
+        "master": "335e9cf79457e1c8893a37d620beb2e07bf8186f"
+      }
+    },
+    "gamer4eg/lazyscript": {
+      "default_branch": "master",
+      "sha": "65f990efce9fbdab9c9353f0ed15bfe743b35952",
+      "branches": {
+        "master": "65f990efce9fbdab9c9353f0ed15bfe743b35952"
+      }
+    },
+    "ganisen/rais_autoshot": {
+      "default_branch": "master",
+      "sha": "b2aca3d80423e71d661afb232a6f46611b10a237",
+      "branches": {
+        "master": "b2aca3d80423e71d661afb232a6f46611b10a237"
+      }
+    },
+    "garethfromwales/nerfedbuttons4wow": {
       "default_branch": "main",
-      "sha": "380bca707ebb05f06f580924ea281a36b553dfd2",
+      "sha": "59eb02ae49be594df6a234206c0d76079b199311",
       "branches": {
-        "main": "380bca707ebb05f06f580924ea281a36b553dfd2"
+        "main": "59eb02ae49be594df6a234206c0d76079b199311"
+      },
+      "latest_tag": "v1.7beta"
+    },
+    "gashole/aero": {
+      "default_branch": "master",
+      "sha": "f6304c8834f1c8a0289f5ce93e49b29aed0585dc",
+      "branches": {
+        "master": "f6304c8834f1c8a0289f5ce93e49b29aed0585dc"
       }
     },
-    "vargv666/modui": {
-      "default_branch": "main",
-      "sha": "380bca707ebb05f06f580924ea281a36b553dfd2",
+    "gashole/druidmanabar": {
+      "default_branch": "master",
+      "sha": "cf9514e4b22438223791073108b5610b1528e462",
       "branches": {
-        "main": "380bca707ebb05f06f580924ea281a36b553dfd2"
+        "master": "cf9514e4b22438223791073108b5610b1528e462"
       }
+    },
+    "gashole/focusframe": {
+      "default_branch": "master",
+      "sha": "e438b7efb358b20d3f1950b5b42910f1d20e6f75",
+      "branches": {
+        "master": "e438b7efb358b20d3f1950b5b42910f1d20e6f75"
+      },
+      "latest_tag": "0.5"
     },
     "gashole/modui-focusframe": {
       "default_branch": "master",
@@ -14417,184 +4789,537 @@
         "master": "8b6d6ce12345299da2676ddb81ab73ba0eb741bc"
       }
     },
-    "dogmax/moduicombattextstandalone": {
+    "gashole/shagutweaks-druidmanabar": {
       "default_branch": "main",
-      "sha": "0a92ff158429c04d55404e3350225618c9f56dee",
+      "sha": "9a661f54515f1c953417ab46a66c181be25e3352",
       "branches": {
-        "main": "0a92ff158429c04d55404e3350225618c9f56dee"
+        "main": "9a661f54515f1c953417ab46a66c181be25e3352"
       }
     },
-    "shirsig/mouseover": {
+    "gashole/timemanager": {
       "default_branch": "master",
-      "sha": "f93b536ad1036f4dced21aa7c1b600e52b58f7ff",
+      "sha": "4a2bd0af61745cf3d5f01166b470e33982759c56",
       "branches": {
-        "master": "f93b536ad1036f4dced21aa7c1b600e52b58f7ff"
+        "master": "4a2bd0af61745cf3d5f01166b470e33982759c56"
       }
     },
-    "laytya/niagara": {
+    "gbl/altoholic_vanilla": {
       "default_branch": "master",
-      "sha": "9c09951be42a8a7152a2c67eebc42077618eb39d",
+      "sha": "d4d5e8c0aa59a61f9cee07bc5444ba906fbde9bc",
       "branches": {
-        "master": "9c09951be42a8a7152a2c67eebc42077618eb39d"
+        "master": "d4d5e8c0aa59a61f9cee07bc5444ba906fbde9bc"
       },
-      "latest_tag": "v1.1"
+      "latest_tag": "gbl1.0.0"
     },
-    "macumbafeh/niagara": {
+    "gbl/autoreputationbar": {
       "default_branch": "master",
-      "sha": "9c09951be42a8a7152a2c67eebc42077618eb39d",
+      "sha": "9044eab904547cd5af101e7e8b29c9c21c8c4d60",
       "branches": {
-        "master": "9c09951be42a8a7152a2c67eebc42077618eb39d"
+        "master": "9044eab904547cd5af101e7e8b29c9c21c8c4d60"
+      }
+    },
+    "gbl/tradechat": {
+      "default_branch": "master",
+      "sha": "ef76057e10220d8138955c3e027a238d3b3825d9",
+      "branches": {
+        "master": "ef76057e10220d8138955c3e027a238d3b3825d9"
+      }
+    },
+    "geigerkind/buffcounter": {
+      "default_branch": "master",
+      "sha": "52101d1fc9570f5618ed0bb5c0c4f113cfeece75",
+      "branches": {
+        "master": "52101d1fc9570f5618ed0bb5c0c4f113cfeece75"
       },
-      "latest_tag": "v1.1"
+      "latest_tag": "b1"
     },
-    "chad90b/niagara": {
+    "geigerkind/debufflistcheck": {
       "default_branch": "master",
-      "sha": "9c09951be42a8a7152a2c67eebc42077618eb39d",
+      "sha": "fb4b5104094c3799a5c17d6bc585e386d293c936",
       "branches": {
-        "master": "9c09951be42a8a7152a2c67eebc42077618eb39d"
-      }
-    },
-    "wbb1977/perfectshot": {
-      "default_branch": "master",
-      "sha": "36e21f5ffb007f258b70b6874802a2f73576bd6c",
-      "branches": {
-        "master": "36e21f5ffb007f258b70b6874802a2f73576bd6c"
+        "master": "fb4b5104094c3799a5c17d6bc585e386d293c936"
       },
-      "latest_tag": "v10"
+      "latest_tag": "b1"
     },
-    "refaim/petxpbar": {
+    "geigerkind/expandassist": {
       "default_branch": "master",
-      "sha": "2a28c86848d4a6f8e6dd60d78d60d884e82c7493",
+      "sha": "c002b9b1bf403d4ecb8045a1283baa02ec0ebb69",
       "branches": {
-        "master": "2a28c86848d4a6f8e6dd60d78d60d884e82c7493"
-      }
-    },
-    "jrc13245/pfui-addonskinner": {
-      "default_branch": "main",
-      "sha": "f9873f69b656c9cb717febbb536beee51b7f910f",
-      "branches": {
-        "main": "f9873f69b656c9cb717febbb536beee51b7f910f"
-      }
-    },
-    "roby-brok/pfui-addonskinner": {
-      "default_branch": "main",
-      "sha": "73d1743e1096940fa8c4e039361bb047dff6877a",
-      "branches": {
-        "main": "73d1743e1096940fa8c4e039361bb047dff6877a"
-      }
-    },
-    "evannnn1996/pfui-addonskinner": {
-      "default_branch": "main",
-      "sha": "88fe8e3a533817c4a8c591c30454cecb02b18e14",
-      "branches": {
-        "main": "88fe8e3a533817c4a8c591c30454cecb02b18e14"
-      }
-    },
-    "bahamutxd/pfui-autoinvite": {
-      "default_branch": "main",
-      "sha": "e67988f1f28478c2df1163e3b8a2a1b50656ad0a",
-      "branches": {
-        "main": "e67988f1f28478c2df1163e3b8a2a1b50656ad0a"
-      }
-    },
-    "mr-rosh/pfui-custommedia": {
-      "default_branch": "main",
-      "sha": "701bee8b249fbe91050e6e3645bf810841704696",
-      "branches": {
-        "main": "701bee8b249fbe91050e6e3645bf810841704696"
-      }
-    },
-    "longpiggy/pfui-custommedia": {
-      "default_branch": "main",
-      "sha": "09e3d9c6a372c82c3a9fa039e6b421b5b4eb9476",
-      "branches": {
-        "main": "09e3d9c6a372c82c3a9fa039e6b421b5b4eb9476"
-      }
-    },
-    "shagu/pfui-eliteoverlay": {
-      "default_branch": "master",
-      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
-      "branches": {
-        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
-      }
-    },
-    "leperidot/pfui-eliteoverlay": {
-      "default_branch": "master",
-      "sha": "adf55dc12ddba6e5227da34949755985ecfad64b",
-      "branches": {
-        "master": "adf55dc12ddba6e5227da34949755985ecfad64b"
-      }
-    },
-    "smilewhenyoudie/pfui-eliteoverlay": {
-      "default_branch": "master",
-      "sha": "3fa612f93cc494fcd4caa15425bd2cf653c2610a",
-      "branches": {
-        "master": "3fa612f93cc494fcd4caa15425bd2cf653c2610a"
-      }
-    },
-    "arthur-helias/pfui-locationplus": {
-      "default_branch": "master",
-      "sha": "3f861f343bee8616c8ad80691cd349395af6fcc9",
-      "branches": {
-        "master": "3f861f343bee8616c8ad80691cd349395af6fcc9"
-      }
-    },
-    "arthur-helias/pfui-moredatatexts": {
-      "default_branch": "master",
-      "sha": "565d6f3b5d9c37e9892f21dc88e1c9f0940f573b",
-      "branches": {
-        "master": "565d6f3b5d9c37e9892f21dc88e1c9f0940f573b"
-      }
-    },
-    "wanliqiaoxi/pfui-rainbowhealthbar": {
-      "default_branch": "main",
-      "sha": "b119b56718c091d2d20d9e2fa1d8d2f0d88c32ad",
-      "branches": {
-        "main": "b119b56718c091d2d20d9e2fa1d8d2f0d88c32ad"
+        "master": "c002b9b1bf403d4ecb8045a1283baa02ec0ebb69"
       },
-      "latest_tag": "v1.1.1"
+      "latest_tag": "b1"
     },
-    "denniswg/quickbind": {
+    "geigerkind/ibdf": {
       "default_branch": "master",
-      "sha": "91e414ec9460db9a9ba4acb391a455b8ac814b3d",
+      "sha": "0dda784f22d7f405aab8ef1bf1ea8cd94023f861",
       "branches": {
-        "master": "91e414ec9460db9a9ba4acb391a455b8ac814b3d"
+        "master": "0dda784f22d7f405aab8ef1bf1ea8cd94023f861"
       }
     },
-    "kirchlive/shaguplates-extra": {
+    "geigerkind/onebuttonhunter": {
       "default_branch": "master",
-      "sha": "22def58171c521ccf825904d4ff70a51141a33a1",
+      "sha": "f1f5b440014059df63042df8584abc3bac809bfe",
       "branches": {
-        "master": "22def58171c521ccf825904d4ff70a51141a33a1"
-      }
-    },
-    "beardedrasta/simplebars": {
-      "default_branch": "main",
-      "sha": "fc0bb212cb23a8c976d84a08dbe8a29cab55a856",
-      "branches": {
-        "main": "fc0bb212cb23a8c976d84a08dbe8a29cab55a856"
-      }
-    },
-    "krekog/skelacustomnameplates": {
-      "default_branch": "main",
-      "sha": "8ee5ace1b67d6f88cc070c79dc19990e46277ca1",
-      "branches": {
-        "main": "8ee5ace1b67d6f88cc070c79dc19990e46277ca1"
-      }
-    },
-    "dyaxler/spartanui_vanilla": {
-      "default_branch": "master",
-      "sha": "0e19353f1b689e83bb658e16b494ea16384454a7",
-      "branches": {
-        "master": "0e19353f1b689e83bb658e16b494ea16384454a7"
+        "master": "f1f5b440014059df63042df8584abc3bac809bfe"
       },
-      "latest_tag": "0.9.6.3"
+      "latest_tag": "b1"
     },
-    "krekog/specialtalent": {
-      "default_branch": "main",
-      "sha": "12266488dc31939b1fa3845808f52a8cce1782ab",
+    "geigerkind/roguerota": {
+      "default_branch": "master",
+      "sha": "270af53189c0b14ca5320366f2b50b775687c065",
       "branches": {
-        "main": "12266488dc31939b1fa3845808f52a8cce1782ab"
+        "master": "270af53189c0b14ca5320366f2b50b775687c065"
+      },
+      "latest_tag": "b1"
+    },
+    "geigerkind/stopwatch": {
+      "default_branch": "master",
+      "sha": "d267430f855f4e9ff616d28564a7218628eacf5d",
+      "branches": {
+        "master": "d267430f855f4e9ff616d28564a7218628eacf5d"
+      },
+      "latest_tag": "b1"
+    },
+    "geopold/nugcombobar": {
+      "default_branch": "master",
+      "sha": "96638740c04f0532bf098a262006115bf2baeb7d",
+      "branches": {
+        "master": "96638740c04f0532bf098a262006115bf2baeb7d"
+      }
+    },
+    "gescht/blacklist": {
+      "default_branch": "master",
+      "sha": "12785fef160703218348fdc3d3da8ab96f0975c6",
+      "branches": {
+        "master": "12785fef160703218348fdc3d3da8ab96f0975c6"
+      }
+    },
+    "gescht/mobresist": {
+      "default_branch": "master",
+      "sha": "3029ca3d6cb0363fa3e320bd467a8a7ad69b3552",
+      "branches": {
+        "master": "3029ca3d6cb0363fa3e320bd467a8a7ad69b3552"
+      }
+    },
+    "gescht/pfui-fonts": {
+      "default_branch": "master",
+      "sha": "77900ec3b1fd0fa440e0b4c3a3f1d00dd5507854",
+      "branches": {
+        "master": "77900ec3b1fd0fa440e0b4c3a3f1d00dd5507854"
+      }
+    },
+    "gescht/superapi_castlib": {
+      "default_branch": "master",
+      "sha": "5b1fa1dec778b4bf7565680835d4cf71012cad36",
+      "branches": {
+        "master": "5b1fa1dec778b4bf7565680835d4cf71012cad36"
+      }
+    },
+    "gescht/tankplates": {
+      "default_branch": "master",
+      "sha": "f2f1f8b5f12449c25696a2ab9371a63b4c105eea",
+      "branches": {
+        "master": "f2f1f8b5f12449c25696a2ab9371a63b4c105eea"
+      }
+    },
+    "gescht/tomtom": {
+      "default_branch": "master",
+      "sha": "55085d3c5a420b659833e5afee2aba13bcce4d18",
+      "branches": {
+        "master": "55085d3c5a420b659833e5afee2aba13bcce4d18"
+      }
+    },
+    "ghbset/advancedtradeskillwindow2": {
+      "default_branch": "main",
+      "sha": "9f35415ce20fdea6b42e19b944c17547f2d93f31",
+      "branches": {
+        "main": "9f35415ce20fdea6b42e19b944c17547f2d93f31"
+      }
+    },
+    "ghbset/instancejournal": {
+      "default_branch": "master",
+      "sha": "77eade63939ecab01c32f2983913fbf801b7b8c2",
+      "branches": {
+        "master": "77eade63939ecab01c32f2983913fbf801b7b8c2"
+      }
+    },
+    "ghornn/resurrectionannouncepartyfix": {
+      "default_branch": "master",
+      "sha": "7d104e177c9c0574e7b314ca8f1027e5f26fcf0f",
+      "branches": {
+        "master": "7d104e177c9c0574e7b314ca8f1027e5f26fcf0f"
+      }
+    },
+    "gitgrom/itemtooltipicons": {
+      "default_branch": "master",
+      "sha": "40e4836d87a1e4f0ee59dc2314dc952cd4a3b77b",
+      "branches": {
+        "master": "40e4836d87a1e4f0ee59dc2314dc952cd4a3b77b"
+      }
+    },
+    "gitstrom/turtle-journal": {
+      "default_branch": "main",
+      "sha": "18200cfd061d7b180cae7cc92fd7783379c9d9a2",
+      "branches": {
+        "main": "18200cfd061d7b180cae7cc92fd7783379c9d9a2"
+      }
+    },
+    "goamania/mousehighlightcircle": {
+      "default_branch": "main",
+      "sha": "dced58f6a87b7a7ae7b15cfe098acb951f7b1a0e",
+      "branches": {
+        "main": "dced58f6a87b7a7ae7b15cfe098acb951f7b1a0e"
+      }
+    },
+    "goffauxs/salad_cthun": {
+      "default_branch": "master",
+      "sha": "45dd2bc43da9aafa8bbbd88b9103db10d942655c",
+      "branches": {
+        "master": "45dd2bc43da9aafa8bbbd88b9103db10d942655c"
+      }
+    },
+    "goldenpipes/eavesdrop": {
+      "default_branch": "master",
+      "sha": "c51fe464e66c60a3bf93142e134e42a0e58bd772",
+      "branches": {
+        "master": "c51fe464e66c60a3bf93142e134e42a0e58bd772"
+      },
+      "latest_tag": "1.4.1"
+    },
+    "goldenpipes/gfw_feedomatic": {
+      "default_branch": "master",
+      "sha": "cd56a92fb7e113e02fd978abd6c698148a6f2e87",
+      "branches": {
+        "master": "cd56a92fb7e113e02fd978abd6c698148a6f2e87"
+      }
+    },
+    "goldenpipes/impulse-booster": {
+      "default_branch": "master",
+      "sha": "82595b42848cbcfc64e546f4529b8408a7e1ba7c",
+      "branches": {
+        "master": "82595b42848cbcfc64e546f4529b8408a7e1ba7c"
+      },
+      "latest_tag": "v3.1-final"
+    },
+    "goldenpipes/mobinfo2": {
+      "default_branch": "master",
+      "sha": "9bac7af9ef86278b8c3e675fb9dab466aeb501d5",
+      "branches": {
+        "master": "9bac7af9ef86278b8c3e675fb9dab466aeb501d5"
+      }
+    },
+    "goldenpipes/openclam": {
+      "default_branch": "main",
+      "sha": "c4be429be59a81ee34076d93616d8393720da3c1",
+      "branches": {
+        "main": "c4be429be59a81ee34076d93616d8393720da3c1"
+      }
+    },
+    "goldenpipes/pfquest_fu": {
+      "default_branch": "main",
+      "sha": "c37708cd290b6e06c2a3476f3f05f2c72bf48008",
+      "branches": {
+        "main": "c37708cd290b6e06c2a3476f3f05f2c72bf48008"
+      }
+    },
+    "goldenpipes/silverdragon": {
+      "default_branch": "master",
+      "sha": "d8eaf9fddbe529d2135dff0914196bd844c39c87",
+      "branches": {
+        "master": "d8eaf9fddbe529d2135dff0914196bd844c39c87"
+      }
+    },
+    "goldenpipes/vpeddler": {
+      "default_branch": "main",
+      "sha": "08a8916743e3ee39c6bde5488d0f187521e1e60e",
+      "branches": {
+        "main": "08a8916743e3ee39c6bde5488d0f187521e1e60e"
+      }
+    },
+    "goose404/channel_monitor": {
+      "default_branch": "master",
+      "sha": "ed3869ca3cfeff5ca5c7cfc27c01ffa1f72b2837",
+      "branches": {
+        "master": "ed3869ca3cfeff5ca5c7cfc27c01ffa1f72b2837"
+      }
+    },
+    "goose404/raidrollbuddy": {
+      "default_branch": "main",
+      "sha": "4d1c7a6ee4be2bcc00dc57eaeefa60ba60c03cd1",
+      "branches": {
+        "main": "4d1c7a6ee4be2bcc00dc57eaeefa60ba60c03cd1"
+      }
+    },
+    "goose404/warriortweaks": {
+      "default_branch": "main",
+      "sha": "21fdef525dc6fb92b98756d66c879cfdf86404f1",
+      "branches": {
+        "main": "21fdef525dc6fb92b98756d66c879cfdf86404f1"
+      }
+    },
+    "gordijnman/mobsonlevel": {
+      "default_branch": "master",
+      "sha": "b9c4cf5f766a5454065f18df2a92ed919d908d6f",
+      "branches": {
+        "master": "b9c4cf5f766a5454065f18df2a92ed919d908d6f"
+      }
+    },
+    "graved/guildmaintagger": {
+      "default_branch": "main",
+      "sha": "37c259e18473445ad3c96c70e5b785b7d432b164",
+      "branches": {
+        "main": "37c259e18473445ad3c96c70e5b785b7d432b164"
+      }
+    },
+    "graved/lootblare": {
+      "default_branch": "master",
+      "sha": "29d4c1c13b2d07e88c5ee63cf8e49c3278ffcf8b",
+      "branches": {
+        "master": "29d4c1c13b2d07e88c5ee63cf8e49c3278ffcf8b"
+      }
+    },
+    "graved/questprogressshare": {
+      "default_branch": "main",
+      "sha": "afbc780d394dc68131fb1244fe322f149c3ba356",
+      "branches": {
+        "main": "afbc780d394dc68131fb1244fe322f149c3ba356"
+      },
+      "latest_tag": "1.6.0"
+    },
+    "greegro2/bongos": {
+      "default_branch": "main",
+      "sha": "cb3b7af12165c647885e7ee5052cb397b0773784",
+      "branches": {
+        "main": "cb3b7af12165c647885e7ee5052cb397b0773784"
+      }
+    },
+    "greendam/rabuffs": {
+      "default_branch": "master",
+      "sha": "3e6c8bdcd2ccf3770a3353c98aa9c7cedd77c75d",
+      "branches": {
+        "master": "3e6c8bdcd2ccf3770a3353c98aa9c7cedd77c75d"
+      }
+    },
+    "greendam/theorycraft-turtle": {
+      "default_branch": "master",
+      "sha": "10d128aa3855c3fa10cb3609e121e272fba5b1a0",
+      "branches": {
+        "master": "10d128aa3855c3fa10cb3609e121e272fba5b1a0"
+      }
+    },
+    "greendam/triviabot-turtlewow": {
+      "default_branch": "master",
+      "sha": "320c59d1a63022b08672f52008e9e69f6135c4a1",
+      "branches": {
+        "master": "320c59d1a63022b08672f52008e9e69f6135c4a1"
+      }
+    },
+    "gregdeichler/professionlevels": {
+      "default_branch": "main",
+      "sha": "5b97d211a8096d42b1c8bc76cf2bdbff0f405c65",
+      "branches": {
+        "main": "5b97d211a8096d42b1c8bc76cf2bdbff0f405c65"
+      },
+      "latest_tag": "Release2.8"
+    },
+    "gregdeichler/totemtimers": {
+      "default_branch": "main",
+      "sha": "eeb49f807d3a18f805cf2e7514efd29ff3f23805",
+      "branches": {
+        "main": "eeb49f807d3a18f805cf2e7514efd29ff3f23805"
+      }
+    },
+    "gregdeichler/vizput": {
+      "default_branch": "main",
+      "sha": "ef28e445c11e5c48c87a099a6338d4932426a363",
+      "branches": {
+        "main": "ef28e445c11e5c48c87a099a6338d4932426a363"
+      }
+    },
+    "grenderg/gmr": {
+      "default_branch": "master",
+      "sha": "e7ffd2498de4b96e8f11593ebb75d738580f2dfb",
+      "branches": {
+        "master": "e7ffd2498de4b96e8f11593ebb75d738580f2dfb"
+      }
+    },
+    "grenderg/questhistory": {
+      "default_branch": "master",
+      "sha": "3e2b54a8e5d6b381e4827a305d2879b9d09b6b83",
+      "branches": {
+        "master": "3e2b54a8e5d6b381e4827a305d2879b9d09b6b83"
+      }
+    },
+    "grim-tale-tavern/turtleroleplayinghelper": {
+      "default_branch": "main",
+      "sha": "07ae5a6de1a0426c2efb085cd45044f910e4067f",
+      "branches": {
+        "main": "07ae5a6de1a0426c2efb085cd45044f910e4067f"
+      }
+    },
+    "grimfiendish/statcompare": {
+      "default_branch": "master",
+      "sha": "4b325f1b2d599c171e409f712c84b275294eb9a8",
+      "branches": {
+        "master": "4b325f1b2d599c171e409f712c84b275294eb9a8"
+      }
+    },
+    "grimwow/shagudps": {
+      "default_branch": "master",
+      "sha": "0d297a3fda7c2dca37ed8894c9d3cf99e542d39d",
+      "branches": {
+        "master": "0d297a3fda7c2dca37ed8894c9d3cf99e542d39d"
+      },
+      "latest_tag": "0.0.1"
+    },
+    "grimwow/statcompare": {
+      "default_branch": "master",
+      "sha": "f54e0082204265899cb746d48b23c7d21a1b26c6",
+      "branches": {
+        "master": "f54e0082204265899cb746d48b23c7d21a1b26c6"
+      },
+      "latest_tag": "2.0.1"
+    },
+    "gruksgruks/cursive": {
+      "default_branch": "master",
+      "sha": "f7c0bb9f51e34aed4a2a7aa1b9f3e46de4be2b30",
+      "branches": {
+        "master": "f7c0bb9f51e34aed4a2a7aa1b9f3e46de4be2b30"
+      }
+    },
+    "grymessa/turtleroleplayinghelper": {
+      "default_branch": "main",
+      "sha": "0c4a861d225d2b1b57dd523dccdbf6897e3dbf5d",
+      "branches": {
+        "main": "0c4a861d225d2b1b57dd523dccdbf6897e3dbf5d"
+      }
+    },
+    "grymskvll/kangz": {
+      "default_branch": "master",
+      "sha": "a721a1d6ef0bc63cd34f86479a4a259778f3bd26",
+      "branches": {
+        "master": "a721a1d6ef0bc63cd34f86479a4a259778f3bd26"
+      }
+    },
+    "grymskvll/safeshift": {
+      "default_branch": "master",
+      "sha": "c5b4960c8629a4937e632aad8a36a23271bd93ad",
+      "branches": {
+        "master": "c5b4960c8629a4937e632aad8a36a23271bd93ad"
+      }
+    },
+    "grymskvll/swapraidsubgroupbyname": {
+      "default_branch": "master",
+      "sha": "2b2e73ec3abd00478bf64b4dd208f2b54cd17dce",
+      "branches": {
+        "master": "2b2e73ec3abd00478bf64b4dd208f2b54cd17dce"
+      }
+    },
+    "gryzorz/quiver": {
+      "default_branch": "main",
+      "sha": "73e2c8cf562203107194f2e31667a85988ed0a41",
+      "branches": {
+        "main": "73e2c8cf562203107194f2e31667a85988ed0a41"
+      }
+    },
+    "gutterrotisaseriousissue-cyber/sunderarmor": {
+      "default_branch": "master",
+      "sha": "7b6a0743ad0d7381269b531191981c04457c807d",
+      "branches": {
+        "master": "7b6a0743ad0d7381269b531191981c04457c807d"
+      }
+    },
+    "gvdn78/lazyscript": {
+      "default_branch": "master",
+      "sha": "861c035a966bb16c1a51b69d8e8245a1e5cf0422",
+      "branches": {
+        "master": "861c035a966bb16c1a51b69d8e8245a1e5cf0422"
+      }
+    },
+    "haaxor1689/gatherer": {
+      "default_branch": "master",
+      "sha": "81ee08ba49d14b3f2dc670749af7c9821b71d621",
+      "branches": {
+        "master": "81ee08ba49d14b3f2dc670749af7c9821b71d621"
+      }
+    },
+    "haaxor1689/guildmap": {
+      "default_branch": "master",
+      "sha": "e3788a64d7a524430df4bef941a6814ff5bd5635",
+      "branches": {
+        "master": "e3788a64d7a524430df4bef941a6814ff5bd5635"
+      }
+    },
+    "haaxor1689/instancejournal": {
+      "default_branch": "master",
+      "sha": "6ec791f7d31129ca4783fc5e5bb9e5c66f0c505b",
+      "branches": {
+        "master": "6ec791f7d31129ca4783fc5e5bb9e5c66f0c505b"
+      }
+    },
+    "haaxor1689/pfquest-turtle": {
+      "default_branch": "master",
+      "sha": "ad59dd2e335497801005368287820c6b0a16c257",
+      "branches": {
+        "master": "ad59dd2e335497801005368287820c6b0a16c257"
+      }
+    },
+    "hannesmann/vanillafixes": {
+      "default_branch": "main",
+      "sha": "a4c42e6a3f12a841a668359e0027c252989867bd",
+      "branches": {
+        "main": "a4c42e6a3f12a841a668359e0027c252989867bd"
+      },
+      "latest_tag": "v1.5.3"
+    },
+    "hat3ph/pfquest-turtle": {
+      "default_branch": "master",
+      "sha": "506f8793b593d459f56e29d565043030093a4163",
+      "branches": {
+        "master": "506f8793b593d459f56e29d565043030093a4163"
+      }
+    },
+    "hazlema/rested": {
+      "default_branch": "master",
+      "sha": "8bcc360ddec4b3ca56a89d1cd445c5d19484d0b2",
+      "branches": {
+        "master": "8bcc360ddec4b3ca56a89d1cd445c5d19484d0b2"
+      }
+    },
+    "hcydlee/ezpoison": {
+      "default_branch": "main",
+      "sha": "3585762c82679ee8de274cc8cd52e5599c0ada7e",
+      "branches": {
+        "main": "3585762c82679ee8de274cc8cd52e5599c0ada7e"
+      }
+    },
+    "heartnotsmart/bagshui": {
+      "default_branch": "main",
+      "sha": "a401fc62bd20b613480a79b931e8ddf85504036a",
+      "branches": {
+        "main": "a401fc62bd20b613480a79b931e8ddf85504036a"
+      }
+    },
+    "helix-dev0/shaguscan": {
+      "default_branch": "master",
+      "sha": "9c81161e29d28b2e7191b532b2437c5ffd8bf803",
+      "branches": {
+        "master": "9c81161e29d28b2e7191b532b2437c5ffd8bf803"
+      },
+      "latest_tag": "v1.0.1"
+    },
+    "hellowind777/pfquest-turtle": {
+      "default_branch": "master",
+      "sha": "a7cf38736174ef287bbea3203338b5872659ece1",
+      "branches": {
+        "master": "a7cf38736174ef287bbea3203338b5872659ece1"
+      }
+    },
+    "hellowind777/shaguplates": {
+      "default_branch": "master",
+      "sha": "0f6a1530780552905a0237e295c37370b10898db",
+      "branches": {
+        "master": "0f6a1530780552905a0237e295c37370b10898db"
       }
     },
     "hellowind777/specialtalent": {
@@ -14604,48 +5329,1320 @@
         "main": "7af578d2034e1e239f86b27055ae84f16a2b6610"
       }
     },
-    "vargv666/specialtalent": {
-      "default_branch": "main",
-      "sha": "12266488dc31939b1fa3845808f52a8cce1782ab",
-      "branches": {
-        "main": "12266488dc31939b1fa3845808f52a8cce1782ab"
-      }
-    },
-    "yani9o/specialtalent": {
-      "default_branch": "main",
-      "sha": "12266488dc31939b1fa3845808f52a8cce1782ab",
-      "branches": {
-        "main": "12266488dc31939b1fa3845808f52a8cce1782ab"
-      }
-    },
-    "checkem/succ-ui": {
+    "hellowind777/sw_stats": {
       "default_branch": "master",
-      "sha": "11679eac1b16814e1ef3c41a0baffe872c7f698b",
+      "sha": "2d74332822b5801c4f7cb1a3a6c900810f39cda0",
       "branches": {
-        "master": "11679eac1b16814e1ef3c41a0baffe872c7f698b"
-      },
-      "latest_tag": "0.2"
-    },
-    "vashin1/syncedui": {
-      "default_branch": "master",
-      "sha": "3793fb4c6ae341635eeab54df264fb5f3ed05b04",
-      "branches": {
-        "master": "3793fb4c6ae341635eeab54df264fb5f3ed05b04"
+        "master": "2d74332822b5801c4f7cb1a3a6c900810f39cda0"
       }
     },
-    "phrxqt/targetsoundrestore": {
-      "default_branch": "main",
-      "sha": "7a3a32630fbc62e2c036192a250e0be29921f651",
+    "herrtrigger/wiiiui": {
+      "default_branch": "master",
+      "sha": "3901983b56129ca5754da1cbfeb86f1c1287caf2",
       "branches": {
-        "main": "7a3a32630fbc62e2c036192a250e0be29921f651"
-      },
-      "latest_tag": "v1.0"
+        "master": "3901983b56129ca5754da1cbfeb86f1c1287caf2"
+      }
     },
-    "francisegan/turtlereagentdisplay": {
+    "heschlie/necrosis-twow": {
       "default_branch": "main",
-      "sha": "caf7832432607e3e70527bce3cb9069b95924f63",
+      "sha": "91a40cb87a8a452c7882e3e2dc32683883f7cc67",
       "branches": {
-        "main": "caf7832432607e3e70527bce3cb9069b95924f63"
+        "main": "91a40cb87a8a452c7882e3e2dc32683883f7cc67"
+      }
+    },
+    "hestiacn/dialogui": {
+      "default_branch": "main",
+      "sha": "fc4e5986b06b230a3ca3f706dcf5f908b7e51b9c",
+      "branches": {
+        "main": "fc4e5986b06b230a3ca3f706dcf5f908b7e51b9c"
+      }
+    },
+    "hippoom/dragonflightui-reforged": {
+      "default_branch": "dev",
+      "sha": "64824b7442e93c8d0720efd09e0758378aef4507",
+      "branches": {
+        "dev": "64824b7442e93c8d0720efd09e0758378aef4507"
+      }
+    },
+    "hippoom/modernfocusframe": {
+      "default_branch": "main",
+      "sha": "6a2288ff7133c3d69be0259af380bb884abf47e8",
+      "branches": {
+        "main": "6a2288ff7133c3d69be0259af380bb884abf47e8"
+      }
+    },
+    "hippoom/pfquest": {
+      "default_branch": "main",
+      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
+      "branches": {
+        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
+      }
+    },
+    "hippoom/rank14lossa": {
+      "default_branch": "master",
+      "sha": "289aacf0ee647692ad16a90666b676a9ebe1c442",
+      "branches": {
+        "master": "289aacf0ee647692ad16a90666b676a9ebe1c442"
+      }
+    },
+    "hippoom/shaguplates": {
+      "default_branch": "master",
+      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
+      "branches": {
+        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
+      }
+    },
+    "hippoom/supercleveroidmacros": {
+      "default_branch": "main",
+      "sha": "4c61394e00dcbf492263c5d018743cf87a4f05ee",
+      "branches": {
+        "main": "4c61394e00dcbf492263c5d018743cf87a4f05ee"
+      }
+    },
+    "hippoom/targetframebuff": {
+      "default_branch": "master",
+      "sha": "78c9f220da71af7047d6325ef12d82ebbc522800",
+      "branches": {
+        "master": "78c9f220da71af7047d6325ef12d82ebbc522800"
+      }
+    },
+    "hippoom/unicodefont": {
+      "default_branch": "master",
+      "sha": "d05916b18d02f6bd34eddeaa7fc0d87033b9c911",
+      "branches": {
+        "master": "d05916b18d02f6bd34eddeaa7fc0d87033b9c911"
+      }
+    },
+    "hitbutton/hbactionbars": {
+      "default_branch": "master",
+      "sha": "dc39f5a16a173d58f65a0e6c71ec8f526b667714",
+      "branches": {
+        "master": "dc39f5a16a173d58f65a0e6c71ec8f526b667714"
+      }
+    },
+    "hitbutton/hbpowerinfusion": {
+      "default_branch": "master",
+      "sha": "87fa6f0a6989765592b8eb15a622f021f2a36b47",
+      "branches": {
+        "master": "87fa6f0a6989765592b8eb15a622f021f2a36b47"
+      }
+    },
+    "hitbutton/sniper": {
+      "default_branch": "master",
+      "sha": "05494e1b2a29d7c9a148b806c8a7bb8ae9215a14",
+      "branches": {
+        "master": "05494e1b2a29d7c9a148b806c8a7bb8ae9215a14"
+      }
+    },
+    "hixio-mh/vanillagraphicboost": {
+      "default_branch": "master",
+      "sha": "0b19da75d19cdb0754171a2167bc533f1337ec01",
+      "branches": {
+        "master": "0b19da75d19cdb0754171a2167bc533f1337ec01"
+      }
+    },
+    "hlado/totemtimers-enhanced": {
+      "default_branch": "master",
+      "sha": "e6a10d7f5feeaa55304453e0321e9b031ec72d7b",
+      "branches": {
+        "master": "e6a10d7f5feeaa55304453e0321e9b031ec72d7b"
+      }
+    },
+    "hmimesh/wiiiui-tbc-anniversary": {
+      "default_branch": "master",
+      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
+      "branches": {
+        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
+      }
+    },
+    "hodareh/hardcoredeath": {
+      "default_branch": "main",
+      "sha": "3ee5511f6859e50b8aa8b8373b7d4b9e42e0bde9",
+      "branches": {
+        "main": "3ee5511f6859e50b8aa8b8373b7d4b9e42e0bde9"
+      }
+    },
+    "hordexl/dragonflightui-reforged": {
+      "default_branch": "main",
+      "sha": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8",
+      "branches": {
+        "main": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8"
+      },
+      "latest_tag": "1.3.4"
+    },
+    "hosq/hidenameplates": {
+      "default_branch": "master",
+      "sha": "c95fde46d944690e5db263a6310cb47c5898bf5a",
+      "branches": {
+        "master": "c95fde46d944690e5db263a6310cb47c5898bf5a"
+      }
+    },
+    "hoys/mikscrollingbattletext": {
+      "default_branch": "master",
+      "sha": "e65811e2bc4a1d622df4fe8567f3629eb0edfa44",
+      "branches": {
+        "master": "e65811e2bc4a1d622df4fe8567f3629eb0edfa44"
+      }
+    },
+    "hp-data/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "f43019aba2c7816d02a76265cfc827ddc566d064",
+      "branches": {
+        "master": "f43019aba2c7816d02a76265cfc827ddc566d064"
+      }
+    },
+    "humblekagu/blizzardplates": {
+      "default_branch": "master",
+      "sha": "3343df98b46d2dbeb6ca6577bf0713328d4cb3fc",
+      "branches": {
+        "master": "3343df98b46d2dbeb6ca6577bf0713328d4cb3fc"
+      }
+    },
+    "humblekagu/zui": {
+      "default_branch": "master",
+      "sha": "acec4c0c585ac6b2782ab2705e110d649155bace",
+      "branches": {
+        "master": "acec4c0c585ac6b2782ab2705e110d649155bace"
+      }
+    },
+    "hwesta2001/bongos_hw": {
+      "default_branch": "main",
+      "sha": "74ac638f9f71b6b64e5de6308e1e51dfc56d55d8",
+      "branches": {
+        "main": "74ac638f9f71b6b64e5de6308e1e51dfc56d55d8"
+      }
+    },
+    "i2ichardt/healersmate": {
+      "default_branch": "main",
+      "sha": "8d4801947edaf07fa8f8dd0145f046c45cb5493b",
+      "branches": {
+        "main": "8d4801947edaf07fa8f8dd0145f046c45cb5493b"
+      },
+      "latest_tag": "v1.3.0"
+    },
+    "idontbyte/mobstolevel": {
+      "default_branch": "master",
+      "sha": "5ea57074ce45d066ba58e321f04685aa8f8ceedb",
+      "branches": {
+        "master": "5ea57074ce45d066ba58e321f04685aa8f8ceedb"
+      },
+      "latest_tag": "1.0"
+    },
+    "igreed1993/greedmeter": {
+      "default_branch": "main",
+      "sha": "899d7a28f0b4c35e41d6e4b11f4c02668395a22b",
+      "branches": {
+        "main": "899d7a28f0b4c35e41d6e4b11f4c02668395a22b"
+      }
+    },
+    "ilivans/akkio_consume_helper": {
+      "default_branch": "main",
+      "sha": "f116b85ed338c1726abba4afef83955c5fb7f4f2",
+      "branches": {
+        "main": "f116b85ed338c1726abba4afef83955c5fb7f4f2"
+      }
+    },
+    "immortalsom/dragonflightui-reforged": {
+      "default_branch": "main",
+      "sha": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8",
+      "branches": {
+        "main": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8"
+      }
+    },
+    "increikesoul/bongos": {
+      "default_branch": "main",
+      "sha": "cb3b7af12165c647885e7ee5052cb397b0773784",
+      "branches": {
+        "main": "cb3b7af12165c647885e7ee5052cb397b0773784"
+      }
+    },
+    "incstk/chronometer-turtle": {
+      "default_branch": "master",
+      "sha": "1df10c165ec92179079a10ab07bd595376f71657",
+      "branches": {
+        "master": "1df10c165ec92179079a10ab07bd595376f71657"
+      }
+    },
+    "indiemiao/bagshui": {
+      "default_branch": "main",
+      "sha": "7a7cefdf096d1613215944e015bffad2400ea76b",
+      "branches": {
+        "main": "7a7cefdf096d1613215944e015bffad2400ea76b"
+      },
+      "latest_tag": "v1.5.15"
+    },
+    "indiemiao/engbags": {
+      "default_branch": "main",
+      "sha": "a69b533cbc8ef345c1f0ee78262abb12e75af7a6",
+      "branches": {
+        "main": "a69b533cbc8ef345c1f0ee78262abb12e75af7a6"
+      }
+    },
+    "indiemiao/enginventory": {
+      "default_branch": "master",
+      "sha": "8ebaf3dee5e1bbd4d819f8f49b66319b0cb6aa80",
+      "branches": {
+        "master": "8ebaf3dee5e1bbd4d819f8f49b66319b0cb6aa80"
+      }
+    },
+    "indiemiao/guda": {
+      "default_branch": "main",
+      "sha": "7d0c023a8183242943cd845975a03b5bb2fa7028",
+      "branches": {
+        "main": "7d0c023a8183242943cd845975a03b5bb2fa7028"
+      },
+      "latest_tag": "2.0.9"
+    },
+    "iroido/moveanything": {
+      "default_branch": "main",
+      "sha": "5949166413384b8f8d01463c83ee775fb2fa1385",
+      "branches": {
+        "main": "5949166413384b8f8d01463c83ee775fb2fa1385"
+      }
+    },
+    "ironscyde/clevermacro": {
+      "default_branch": "master",
+      "sha": "b31aa55e2276a7c99e11a65e55a25d9b7c8e4a60",
+      "branches": {
+        "master": "b31aa55e2276a7c99e11a65e55a25d9b7c8e4a60"
+      }
+    },
+    "ironscyde/cooline": {
+      "default_branch": "master",
+      "sha": "90513b67e740e5abe20342d42abf85e958fafcbe",
+      "branches": {
+        "master": "90513b67e740e5abe20342d42abf85e958fafcbe"
+      }
+    },
+    "isfir/vanillahelpers": {
+      "default_branch": "master",
+      "sha": "4375c03a51778ad440bc14be512e659b39c0c558",
+      "branches": {
+        "master": "4375c03a51778ad440bc14be512e659b39c0c558"
+      },
+      "latest_tag": "v1.1.2"
+    },
+    "isitlove/epgpexport": {
+      "default_branch": "master",
+      "sha": "9d50d4df254bc50aecb57880c54216df74759864",
+      "branches": {
+        "master": "9d50d4df254bc50aecb57880c54216df74759864"
+      },
+      "latest_tag": "1.0"
+    },
+    "isitlove/titancritline": {
+      "default_branch": "master",
+      "sha": "e3dc9cf79a7a6f3188b838e0b5e2ae6c91d02c05",
+      "branches": {
+        "master": "e3dc9cf79a7a6f3188b838e0b5e2ae6c91d02c05"
+      }
+    },
+    "isitlove/titanguild": {
+      "default_branch": "master",
+      "sha": "fc5a45134a1cc796444a9776cf2fa5768201f424",
+      "branches": {
+        "master": "fc5a45134a1cc796444a9776cf2fa5768201f424"
+      },
+      "latest_tag": "2.20"
+    },
+    "itslusse/akkio_consume_helper": {
+      "default_branch": "main",
+      "sha": "658b11fb40dde610a2ca6f794695442966ae463b",
+      "branches": {
+        "main": "658b11fb40dde610a2ca6f794695442966ae463b"
+      }
+    },
+    "itslusse/clifftells": {
+      "default_branch": "main",
+      "sha": "eade44ff6dd3693584358eadb6851ea254a1aa7b",
+      "branches": {
+        "main": "eade44ff6dd3693584358eadb6851ea254a1aa7b"
+      }
+    },
+    "itslusse/fika": {
+      "default_branch": "main",
+      "sha": "062c34120fdc10dddb499f6fd3fef8442af9db94",
+      "branches": {
+        "main": "062c34120fdc10dddb499f6fd3fef8442af9db94"
+      }
+    },
+    "j0n12/fury": {
+      "default_branch": "master",
+      "sha": "e832d00beebe52c32989f8621e4eaf05730ecd7e",
+      "branches": {
+        "master": "e832d00beebe52c32989f8621e4eaf05730ecd7e"
+      }
+    },
+    "jacamo555/bongos": {
+      "default_branch": "main",
+      "sha": "00873e5dca5468f89c384e7d6d471fa0b74f6e73",
+      "branches": {
+        "main": "00873e5dca5468f89c384e7d6d471fa0b74f6e73"
+      }
+    },
+    "jakebergeron/warriortank": {
+      "default_branch": "master",
+      "sha": "120a3bf3703691113cf3439b2d94cb83c08da47b",
+      "branches": {
+        "master": "120a3bf3703691113cf3439b2d94cb83c08da47b"
+      }
+    },
+    "jakekeeys/roid-macros": {
+      "default_branch": "master",
+      "sha": "43a442d52e3ccba6c4c2fa37329008d6b9d18082",
+      "branches": {
+        "master": "43a442d52e3ccba6c4c2fa37329008d6b9d18082"
+      }
+    },
+    "jakiraelysium/hideui": {
+      "default_branch": "master",
+      "sha": "ef5f35ff875061d1a51a9081808b9fef870df6ae",
+      "branches": {
+        "master": "ef5f35ff875061d1a51a9081808b9fef870df6ae"
+      }
+    },
+    "jan125/quiver": {
+      "default_branch": "main",
+      "sha": "143675cb4fbc2cf21d0a4c6452574de5aa2b7e7c",
+      "branches": {
+        "main": "143675cb4fbc2cf21d0a4c6452574de5aa2b7e7c"
+      }
+    },
+    "jaraxxuss/retarget": {
+      "default_branch": "master",
+      "sha": "61bbc36cd10e668be7731d3db84510017b7e489e",
+      "branches": {
+        "master": "61bbc36cd10e668be7731d3db84510017b7e489e"
+      }
+    },
+    "jaydeshow/guidecreator": {
+      "default_branch": "master",
+      "sha": "d213fa83b71f0b9dd2613dd52ea85052bebd981a",
+      "branches": {
+        "master": "d213fa83b71f0b9dd2613dd52ea85052bebd981a"
+      }
+    },
+    "jayparry/xtolevel-classic": {
+      "default_branch": "develop",
+      "sha": "41e8a92d79e565959492e6e3c3f704bff5701d1e",
+      "branches": {
+        "develop": "41e8a92d79e565959492e6e3c3f704bff5701d1e"
+      }
+    },
+    "jejkas/bigbrother": {
+      "default_branch": "master",
+      "sha": "a1193b887b84067b21eb98ec8c14af6d32845c68",
+      "branches": {
+        "master": "a1193b887b84067b21eb98ec8c14af6d32845c68"
+      }
+    },
+    "jejkas/devilshunters": {
+      "default_branch": "master",
+      "sha": "2b76f0d2647fc8d53adedde1532b74ac652d1e98",
+      "branches": {
+        "master": "2b76f0d2647fc8d53adedde1532b74ac652d1e98"
+      }
+    },
+    "jejkas/inventorysale": {
+      "default_branch": "master",
+      "sha": "86242cf1c30e1db2ab509709ad615c1766758cd9",
+      "branches": {
+        "master": "86242cf1c30e1db2ab509709ad615c1766758cd9"
+      }
+    },
+    "jejkas/meleestats": {
+      "default_branch": "master",
+      "sha": "eb3adcbe9b1f35734a3a4e7b6f8c4133a3ade5a5",
+      "branches": {
+        "master": "eb3adcbe9b1f35734a3a4e7b6f8c4133a3ade5a5"
+      }
+    },
+    "jejkas/ooi": {
+      "default_branch": "master",
+      "sha": "fc2bfe8d7ac2ea596295ae87a92d417905b10f2d",
+      "branches": {
+        "master": "fc2bfe8d7ac2ea596295ae87a92d417905b10f2d"
+      }
+    },
+    "jejkas/smartroll": {
+      "default_branch": "master",
+      "sha": "fd2ca53c752e198070e032c86ab8f43d8e03ed16",
+      "branches": {
+        "master": "fd2ca53c752e198070e032c86ab8f43d8e03ed16"
+      }
+    },
+    "jejkas/timetracker": {
+      "default_branch": "master",
+      "sha": "ad3f897521aa7cfea62bf0f69da439e441ddf71d",
+      "branches": {
+        "master": "ad3f897521aa7cfea62bf0f69da439e441ddf71d"
+      }
+    },
+    "jejkas/wfw": {
+      "default_branch": "master",
+      "sha": "71deefad363323bd719d4669c225b1030ae13a5d",
+      "branches": {
+        "master": "71deefad363323bd719d4669c225b1030ae13a5d"
+      }
+    },
+    "jemadux/pfquest-turtle": {
+      "default_branch": "master",
+      "sha": "0b9b04daf67fb0632c965b4e825534f5c6c53f36",
+      "branches": {
+        "master": "0b9b04daf67fb0632c965b4e825534f5c6c53f36"
+      }
+    },
+    "jembawow/moveanything": {
+      "default_branch": "main",
+      "sha": "01b20a0a35d7526a31f136227beac5b23bf544ab",
+      "branches": {
+        "main": "01b20a0a35d7526a31f136227beac5b23bf544ab"
+      }
+    },
+    "jembawow/questannouncer": {
+      "default_branch": "main",
+      "sha": "bbf71adc957d6c5d2e637a0f974845ff69903691",
+      "branches": {
+        "main": "bbf71adc957d6c5d2e637a0f974845ff69903691"
+      }
+    },
+    "jembawow/shaguinventory": {
+      "default_branch": "master",
+      "sha": "bc4002eb18bc266607b208cd42af761c0590ee4d",
+      "branches": {
+        "master": "bc4002eb18bc266607b208cd42af761c0590ee4d"
+      }
+    },
+    "jembawow/shaguscan": {
+      "default_branch": "master",
+      "sha": "60d7257f10db5cdfc53d15533bd4ce54f4f5eb40",
+      "branches": {
+        "master": "60d7257f10db5cdfc53d15533bd4ce54f4f5eb40"
+      }
+    },
+    "jeromem/bettereverlookbroadcastingco": {
+      "default_branch": "master",
+      "sha": "1be039605b90931afbed8533034618da54a1504d",
+      "branches": {
+        "master": "1be039605b90931afbed8533034618da54a1504d"
+      },
+      "latest_tag": "v1.1.0"
+    },
+    "jeromem/guidelimevanilla": {
+      "default_branch": "master",
+      "sha": "bd87cdb5fc9c3bd125afdb6da5819b5e92f2dec5",
+      "branches": {
+        "master": "bd87cdb5fc9c3bd125afdb6da5819b5e92f2dec5"
+      },
+      "latest_tag": "v0.12.7"
+    },
+    "jeromem/vanillaguidereloaded": {
+      "default_branch": "master",
+      "sha": "9309495f06cde851461f71d068f7f29c0014db9c",
+      "branches": {
+        "master": "9309495f06cde851461f71d068f7f29c0014db9c"
+      },
+      "latest_tag": "v2.0.3"
+    },
+    "jesmyrna/stonewall-inn---automarker": {
+      "default_branch": "master",
+      "sha": "98656f5a09f912af429544fced6232d9a42c20e5",
+      "branches": {
+        "master": "98656f5a09f912af429544fced6232d9a42c20e5"
+      }
+    },
+    "jhinzuo/another.screenresolutiondropdownfix": {
+      "default_branch": "main",
+      "sha": "5b7457c6c5df860e6ad6d7e900d8d9ae0a18f38e",
+      "branches": {
+        "main": "5b7457c6c5df860e6ad6d7e900d8d9ae0a18f38e"
+      }
+    },
+    "jiangxt316/cartographer": {
+      "default_branch": "master",
+      "sha": "9b2997bf85f2758e9d3a94028fa0ad158b001245",
+      "branches": {
+        "master": "9b2997bf85f2758e9d3a94028fa0ad158b001245"
+      }
+    },
+    "jiangxt316/pfquest-icons": {
+      "default_branch": "master",
+      "sha": "709ba275b7198b93713b5b06cf896dc9006ebeea",
+      "branches": {
+        "master": "709ba275b7198b93713b5b06cf896dc9006ebeea"
+      }
+    },
+    "jiangxt316/pfstudio": {
+      "default_branch": "master",
+      "sha": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78",
+      "branches": {
+        "master": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78"
+      }
+    },
+    "jiangxt316/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "8cc036f32f67ace0baf749f2e67163460374c5a8",
+      "branches": {
+        "main": "8cc036f32f67ace0baf749f2e67163460374c5a8"
+      }
+    },
+    "jiangxt316/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
+      "branches": {
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
+      }
+    },
+    "jiangxt316/shaguactions": {
+      "default_branch": "master",
+      "sha": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8",
+      "branches": {
+        "master": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8"
+      }
+    },
+    "jiangxt316/shagubam": {
+      "default_branch": "master",
+      "sha": "5fd6bc33e1b0b4d1999a2470d651295163daeab2",
+      "branches": {
+        "master": "5fd6bc33e1b0b4d1999a2470d651295163daeab2"
+      }
+    },
+    "jiangxt316/shaguboat": {
+      "default_branch": "master",
+      "sha": "e2b3877a31cefdc36cf6fe46f4ef7a2f98dc228a",
+      "branches": {
+        "master": "e2b3877a31cefdc36cf6fe46f4ef7a2f98dc228a"
+      }
+    },
+    "jiangxt316/shagubop": {
+      "default_branch": "master",
+      "sha": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9",
+      "branches": {
+        "master": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9"
+      }
+    },
+    "jiangxt316/shaguchat": {
+      "default_branch": "master",
+      "sha": "01c37853c5e714b218837d24932c316f68b2728f",
+      "branches": {
+        "master": "01c37853c5e714b218837d24932c316f68b2728f"
+      }
+    },
+    "jiangxt316/shagucopy": {
+      "default_branch": "master",
+      "sha": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182",
+      "branches": {
+        "master": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182"
+      }
+    },
+    "jiangxt316/shagudps": {
+      "default_branch": "master",
+      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
+      "branches": {
+        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
+      }
+    },
+    "jiangxt316/shagujunk": {
+      "default_branch": "master",
+      "sha": "9a91065d8ef9078a9ea8b7d254e88605e8367567",
+      "branches": {
+        "master": "9a91065d8ef9078a9ea8b7d254e88605e8367567"
+      }
+    },
+    "jiangxt316/shagukill": {
+      "default_branch": "master",
+      "sha": "498e2db84d2d666717d04538641add7ebca967cd",
+      "branches": {
+        "master": "498e2db84d2d666717d04538641add7ebca967cd"
+      }
+    },
+    "jiangxt316/shagumount": {
+      "default_branch": "master",
+      "sha": "e688d31e6f7792728d2e9adf5c33bc8d48f72e75",
+      "branches": {
+        "master": "e688d31e6f7792728d2e9adf5c33bc8d48f72e75"
+      }
+    },
+    "jiangxt316/shagunotify": {
+      "default_branch": "master",
+      "sha": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49",
+      "branches": {
+        "master": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49"
+      }
+    },
+    "jiangxt316/shaguplates": {
+      "default_branch": "master",
+      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
+      "branches": {
+        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
+      }
+    },
+    "jiangxt316/shaguscore": {
+      "default_branch": "master",
+      "sha": "b07d25e6a1fa30391d9dca0dd728e33a762c6711",
+      "branches": {
+        "master": "b07d25e6a1fa30391d9dca0dd728e33a762c6711"
+      }
+    },
+    "jiangxt316/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
+      "branches": {
+        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
+      }
+    },
+    "jiangxt316/shaguvalue": {
+      "default_branch": "master",
+      "sha": "debbde88b68a941b13a614612a7aa867cadbe542",
+      "branches": {
+        "master": "debbde88b68a941b13a614612a7aa867cadbe542"
+      }
+    },
+    "jiangxt316/shaguwidget": {
+      "default_branch": "master",
+      "sha": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0",
+      "branches": {
+        "master": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0"
+      }
+    },
+    "jlabranche/elitewarriorttd": {
+      "default_branch": "main",
+      "sha": "bab48b161c016848ea9ff52b60015948622c0ade",
+      "branches": {
+        "main": "bab48b161c016848ea9ff52b60015948622c0ade"
+      }
+    },
+    "jlabranche/raidmemberexport": {
+      "default_branch": "main",
+      "sha": "3dd211673a47e0e03102f4461318d7477abaab40",
+      "branches": {
+        "main": "3dd211673a47e0e03102f4461318d7477abaab40"
+      }
+    },
+    "jmiecz/cursive": {
+      "default_branch": "master",
+      "sha": "5eabc4f34105689a349c0589009c1a2f7f0e4eb5",
+      "branches": {
+        "master": "5eabc4f34105689a349c0589009c1a2f7f0e4eb5"
+      }
+    },
+    "joegnis/coolline": {
+      "default_branch": "master",
+      "sha": "b94fe3184074b8575cb4ac98d11d50d313a26678",
+      "branches": {
+        "master": "b94fe3184074b8575cb4ac98d11d50d313a26678"
+      }
+    },
+    "joey34kaze/tradedispenser": {
+      "default_branch": "master",
+      "sha": "954224618d48ccd6a3f03f0f8724b495f6409b0f",
+      "branches": {
+        "master": "954224618d48ccd6a3f03f0f8724b495f6409b0f"
+      }
+    },
+    "jogadoaoleu/bartender2-read-instructions": {
+      "default_branch": "master",
+      "sha": "1eec247ecaf755916ece74009b367c5f7219f0c4",
+      "branches": {
+        "master": "1eec247ecaf755916ece74009b367c5f7219f0c4"
+      }
+    },
+    "johnmichael/lagcast": {
+      "default_branch": "master",
+      "sha": "fccc0a815853d7add7994a2c6b31728fb1579384",
+      "branches": {
+        "master": "fccc0a815853d7add7994a2c6b31728fb1579384"
+      }
+    },
+    "jordanfaz/atlasloot": {
+      "default_branch": "main",
+      "sha": "4e1a18135b029986af1fd47ac86a2f1b65e20865",
+      "branches": {
+        "main": "4e1a18135b029986af1fd47ac86a2f1b65e20865"
+      }
+    },
+    "jordanfaz/questie-octo": {
+      "default_branch": "main",
+      "sha": "5e4d74a6d6aeb3b944d2c4660a751c83fea1e772",
+      "branches": {
+        "main": "5e4d74a6d6aeb3b944d2c4660a751c83fea1e772"
+      }
+    },
+    "joseph-box/fury": {
+      "default_branch": "master",
+      "sha": "d66923619abd0b6d22f2c6f95a4f2080338d8a19",
+      "branches": {
+        "master": "d66923619abd0b6d22f2c6f95a4f2080338d8a19"
+      }
+    },
+    "josh-sachs/aux-revamped-opaque": {
+      "default_branch": "master",
+      "sha": "7420d65782119c4cb850e4e20f5eeab59ef32aa2",
+      "branches": {
+        "master": "7420d65782119c4cb850e4e20f5eeab59ef32aa2"
+      }
+    },
+    "jprothwell/pfstudio": {
+      "default_branch": "master",
+      "sha": "094f940476137bc1638c1274242a1b3735a4d6bf",
+      "branches": {
+        "master": "094f940476137bc1638c1274242a1b3735a4d6bf"
+      }
+    },
+    "jrc13245/_lazypig": {
+      "default_branch": "master",
+      "sha": "9319eeb79bd39d7952bc09ee62e62c303c8deee6",
+      "branches": {
+        "master": "9319eeb79bd39d7952bc09ee62e62c303c8deee6"
+      }
+    },
+    "jrc13245/adf": {
+      "default_branch": "master",
+      "sha": "25f10ae7f1be92778057ba1230dd7444aab516ce",
+      "branches": {
+        "master": "25f10ae7f1be92778057ba1230dd7444aab516ce"
+      }
+    },
+    "jrc13245/automarker": {
+      "default_branch": "master",
+      "sha": "6a194f1f11339bede0db8e0464b25c08db626cae",
+      "branches": {
+        "master": "6a194f1f11339bede0db8e0464b25c08db626cae"
+      }
+    },
+    "jrc13245/bettercharacterstats": {
+      "default_branch": "main",
+      "sha": "0eb361ee6df2891c5417d08bb690c0987c48c5a8",
+      "branches": {
+        "main": "0eb361ee6df2891c5417d08bb690c0987c48c5a8"
+      }
+    },
+    "jrc13245/bonusscanner": {
+      "default_branch": "main",
+      "sha": "caf3cbf3836e84d740934b9fb8752eaa1a9b62c4",
+      "branches": {
+        "main": "caf3cbf3836e84d740934b9fb8752eaa1a9b62c4"
+      }
+    },
+    "jrc13245/bosstactics": {
+      "default_branch": "main",
+      "sha": "e21c19dee734cf3f647f8298ad6c37ba253b15b9",
+      "branches": {
+        "main": "e21c19dee734cf3f647f8298ad6c37ba253b15b9"
+      }
+    },
+    "jrc13245/consoleexperienceclassic": {
+      "default_branch": "main",
+      "sha": "cbe1925867e7ee59fa4c47fcc8921847b6bcbaec",
+      "branches": {
+        "main": "cbe1925867e7ee59fa4c47fcc8921847b6bcbaec"
+      }
+    },
+    "jrc13245/enemyframes": {
+      "default_branch": "master",
+      "sha": "2f0f840b65cd1a3de76e1e416665a646ac99ce90",
+      "branches": {
+        "master": "2f0f840b65cd1a3de76e1e416665a646ac99ce90"
+      }
+    },
+    "jrc13245/gentlegc": {
+      "default_branch": "master",
+      "sha": "15ec914abb726c0acbadca4c77048257d0aecd7f",
+      "branches": {
+        "master": "15ec914abb726c0acbadca4c77048257d0aecd7f"
+      }
+    },
+    "jrc13245/intellisense": {
+      "default_branch": "main",
+      "sha": "e8968c2088054bd3f567529e9f177ebf032d4241",
+      "branches": {
+        "main": "e8968c2088054bd3f567529e9f177ebf032d4241"
+      }
+    },
+    "jrc13245/iwinenhanced": {
+      "default_branch": "main",
+      "sha": "9f6bdc0af04d4a396ae22f9262882e8418df04b6",
+      "branches": {
+        "main": "9f6bdc0af04d4a396ae22f9262882e8418df04b6"
+      }
+    },
+    "jrc13245/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "f9873f69b656c9cb717febbb536beee51b7f910f",
+      "branches": {
+        "main": "f9873f69b656c9cb717febbb536beee51b7f910f"
+      }
+    },
+    "jrc13245/pfui-weakicons": {
+      "default_branch": "master",
+      "sha": "fe59bea6e70ef6ec54a1f84c914d070cdea065c8",
+      "branches": {
+        "master": "fe59bea6e70ef6ec54a1f84c914d070cdea065c8"
+      }
+    },
+    "jrc13245/soloraidtargeticons": {
+      "default_branch": "master",
+      "sha": "37e05530cea74335c23c0cec087af8935f2d316a",
+      "branches": {
+        "master": "37e05530cea74335c23c0cec087af8935f2d316a"
+      }
+    },
+    "jrc13245/supercleveroidmacros": {
+      "default_branch": "main",
+      "sha": "3a196c484f84dc7b4fbce1b327f117890d24d96d",
+      "branches": {
+        "main": "3a196c484f84dc7b4fbce1b327f117890d24d96d"
+      }
+    },
+    "jrc13245/supermacro-turtle-superwow": {
+      "default_branch": "master",
+      "sha": "8f2978b992358ab86757d34107f6ddf890467dc7",
+      "branches": {
+        "master": "8f2978b992358ab86757d34107f6ddf890467dc7"
+      }
+    },
+    "jrc13245/timetokill": {
+      "default_branch": "master",
+      "sha": "e9ee2e5520535c19674ed88d63fbd68aa7fa0d56",
+      "branches": {
+        "master": "e9ee2e5520535c19674ed88d63fbd68aa7fa0d56"
+      }
+    },
+    "jrc13245/trinketmenu": {
+      "default_branch": "master",
+      "sha": "ad2a196ae8c9dc87c78cbe28e9d13853a89f678f",
+      "branches": {
+        "master": "ad2a196ae8c9dc87c78cbe28e9d13853a89f678f"
+      }
+    },
+    "jrc13245/ultimamacros": {
+      "default_branch": "main",
+      "sha": "67d908144a85b5d4ceed84491e6e80fa034a5d9e",
+      "branches": {
+        "main": "67d908144a85b5d4ceed84491e6e80fa034a5d9e"
+      }
+    },
+    "jsb/gourmet": {
+      "default_branch": "master",
+      "sha": "f0a31d2b0baa4e595481b611fb185923a9981fc4",
+      "branches": {
+        "master": "f0a31d2b0baa4e595481b611fb185923a9981fc4"
+      }
+    },
+    "jsb/picopoisons": {
+      "default_branch": "master",
+      "sha": "92f89feb2959910106c960f71c9913279cee0073",
+      "branches": {
+        "master": "92f89feb2959910106c960f71c9913279cee0073"
+      },
+      "latest_tag": "v1.00"
+    },
+    "jsb/resourcecountactionbuttons": {
+      "default_branch": "master",
+      "sha": "aeaeb3aa940ba2cfb4a87b75b2b6f46b22b9ec14",
+      "branches": {
+        "master": "aeaeb3aa940ba2cfb4a87b75b2b6f46b22b9ec14"
+      }
+    },
+    "jsb/ringmenu": {
+      "default_branch": "master",
+      "sha": "23db580b0ddc04b8650afdf50179302fbb67128f",
+      "branches": {
+        "master": "23db580b0ddc04b8650afdf50179302fbb67128f"
+      },
+      "latest_tag": "v2.2.1"
+    },
+    "jslquintero/dialogui": {
+      "default_branch": "main",
+      "sha": "99cb4864753c716bbcdd756d49c64edb35c58dcc",
+      "branches": {
+        "main": "99cb4864753c716bbcdd756d49c64edb35c58dcc"
+      }
+    },
+    "judo101/chronometer": {
+      "default_branch": "master",
+      "sha": "ddb6a1364174cec86594c5a7659b659406861d89",
+      "branches": {
+        "master": "ddb6a1364174cec86594c5a7659b659406861d89"
+      }
+    },
+    "jvaneg/libramswap": {
+      "default_branch": "main",
+      "sha": "46114022eb4a33eefcb2189f24ddb4d5b620b364",
+      "branches": {
+        "main": "46114022eb4a33eefcb2189f24ddb4d5b620b364"
+      }
+    },
+    "kameleonuk/adf": {
+      "default_branch": "master",
+      "sha": "d3c3869393e2dd394348a220c11ec16c37cf4a18",
+      "branches": {
+        "master": "d3c3869393e2dd394348a220c11ec16c37cf4a18"
+      }
+    },
+    "kameleonuk/auldlangsyne": {
+      "default_branch": "master",
+      "sha": "33970b2ece4adb92278d4cc0c688454bae48e390",
+      "branches": {
+        "master": "33970b2ece4adb92278d4cc0c688454bae48e390"
+      }
+    },
+    "kameleonuk/difficultbulletinboard": {
+      "default_branch": "master",
+      "sha": "ddbdd7a569e8688ec42c4b5738309ace5eb11c0e",
+      "branches": {
+        "master": "ddbdd7a569e8688ec42c4b5738309ace5eb11c0e"
+      }
+    },
+    "kameleonuk/fadeframeui": {
+      "default_branch": "main",
+      "sha": "94a8aa13d167ba885b1184f9dd04950533d7ebe0",
+      "branches": {
+        "main": "94a8aa13d167ba885b1184f9dd04950533d7ebe0"
+      }
+    },
+    "kameleonuk/flighttracker": {
+      "default_branch": "main",
+      "sha": "23bebc73fc6410f5b065e710522a233808609003",
+      "branches": {
+        "main": "23bebc73fc6410f5b065e710522a233808609003"
+      }
+    },
+    "kameleonuk/flyout": {
+      "default_branch": "main",
+      "sha": "067a4873808f0710b19f59a14cfc79c67fdd38a0",
+      "branches": {
+        "main": "067a4873808f0710b19f59a14cfc79c67fdd38a0"
+      }
+    },
+    "kameleonuk/guda": {
+      "default_branch": "main",
+      "sha": "e52be32310fa79c7f191f42c4f91fe87e250bc7f",
+      "branches": {
+        "main": "e52be32310fa79c7f191f42c4f91fe87e250bc7f"
+      }
+    },
+    "kameleonuk/instancejournal": {
+      "default_branch": "master",
+      "sha": "458523854e726c9b0f44c16c86e4a51643990e76",
+      "branches": {
+        "master": "458523854e726c9b0f44c16c86e4a51643990e76"
+      }
+    },
+    "kameleonuk/lootblare": {
+      "default_branch": "main",
+      "sha": "16164655407924b01974fcbf3f7b27e1a866b0ac",
+      "branches": {
+        "main": "16164655407924b01974fcbf3f7b27e1a866b0ac"
+      }
+    },
+    "kameleonuk/lootcrestreminder": {
+      "default_branch": "main",
+      "sha": "927f1a414bba42a817dd3900632e8ea2947bc959",
+      "branches": {
+        "main": "927f1a414bba42a817dd3900632e8ea2947bc959"
+      }
+    },
+    "kameleonuk/masterlootbyclass": {
+      "default_branch": "master",
+      "sha": "15c85de28fcc4f86819b79e42a66817d9b9cfcc3",
+      "branches": {
+        "master": "15c85de28fcc4f86819b79e42a66817d9b9cfcc3"
+      }
+    },
+    "kameleonuk/mutecities": {
+      "default_branch": "main",
+      "sha": "2d038834b06ac6b0749479ff2151d2998a66191e",
+      "branches": {
+        "main": "2d038834b06ac6b0749479ff2151d2998a66191e"
+      }
+    },
+    "kameleonuk/notgrid": {
+      "default_branch": "master",
+      "sha": "f088643d297b4195e3971fb305721da436e3ffaf",
+      "branches": {
+        "master": "f088643d297b4195e3971fb305721da436e3ffaf"
+      }
+    },
+    "kameleonuk/og-raidhelper": {
+      "default_branch": "main",
+      "sha": "53b6035d8fc372ccdd60ad671558083fac3bc333",
+      "branches": {
+        "main": "53b6035d8fc372ccdd60ad671558083fac3bc333"
+      }
+    },
+    "kameleonuk/pfquest-turtle": {
+      "default_branch": "main",
+      "sha": "5b8eeeeb4119be9d075087f0f0e08c187b35ad61",
+      "branches": {
+        "main": "5b8eeeeb4119be9d075087f0f0e08c187b35ad61"
+      }
+    },
+    "kameleonuk/rabuffs": {
+      "default_branch": "master",
+      "sha": "6ae5e7cb86ddc6f5112903f7fa32e5f001c7613a",
+      "branches": {
+        "master": "6ae5e7cb86ddc6f5112903f7fa32e5f001c7613a"
+      }
+    },
+    "kameleonuk/turtlemenagerie": {
+      "default_branch": "main",
+      "sha": "2c4fe1181595aafd66fef445f2be4706014319ec",
+      "branches": {
+        "main": "2c4fe1181595aafd66fef445f2be4706014319ec"
+      }
+    },
+    "kaneha/shaguscan": {
+      "default_branch": "master",
+      "sha": "052d2d7d5bcfeb02109478314af67047f75f6d21",
+      "branches": {
+        "master": "052d2d7d5bcfeb02109478314af67047f75f6d21"
+      }
+    },
+    "kangaroux/inventorysale": {
+      "default_branch": "master",
+      "sha": "1bf5961bff92f9fe0de89e2da94a191582d42ef1",
+      "branches": {
+        "master": "1bf5961bff92f9fe0de89e2da94a191582d42ef1"
+      }
+    },
+    "kangaroux/roguefocus": {
+      "default_branch": "master",
+      "sha": "469737c7679e5720fc842d037efce2ff4b2ce8cb",
+      "branches": {
+        "master": "469737c7679e5720fc842d037efce2ff4b2ce8cb"
+      }
+    },
+    "karstenbade/betterquest": {
+      "default_branch": "main",
+      "sha": "9957848d96a606b3880ce366228768208adf3eaa",
+      "branches": {
+        "main": "9957848d96a606b3880ce366228768208adf3eaa"
+      }
+    },
+    "karstenbade/consoleexperienceclassic": {
+      "default_branch": "main",
+      "sha": "f264409395ee1fa9b05059e8b661c90e530f8072",
+      "branches": {
+        "main": "f264409395ee1fa9b05059e8b661c90e530f8072"
+      }
+    },
+    "karstenbade/simpleactionsets": {
+      "default_branch": "master",
+      "sha": "ac5162e195513d3658fea3f6ff91a90b0a549cb0",
+      "branches": {
+        "master": "ac5162e195513d3658fea3f6ff91a90b0a549cb0"
+      }
+    },
+    "kastelmarra-stack/moveanything": {
+      "default_branch": "main",
+      "sha": "01b20a0a35d7526a31f136227beac5b23bf544ab",
+      "branches": {
+        "main": "01b20a0a35d7526a31f136227beac5b23bf544ab"
+      }
+    },
+    "kc8pnd/dotimer": {
+      "default_branch": "master",
+      "sha": "90bad43fe9347cdeb5f2640f71f082255f6bb7a5",
+      "branches": {
+        "master": "90bad43fe9347cdeb5f2640f71f082255f6bb7a5"
+      }
+    },
+    "kc8pnd/mobhealth": {
+      "default_branch": "master",
+      "sha": "74982883284a6c79f50247e1cf7b5d4842ef37f3",
+      "branches": {
+        "master": "74982883284a6c79f50247e1cf7b5d4842ef37f3"
+      }
+    },
+    "keijinde/keijinachievementmonitor": {
+      "default_branch": "main",
+      "sha": "b7d4f1d3bad50446ffacfe460c7dcbb9f22d6381",
+      "branches": {
+        "main": "b7d4f1d3bad50446ffacfe460c7dcbb9f22d6381"
+      },
+      "latest_tag": "v1.0.0"
+    },
+    "keijinde/keijinautovendor": {
+      "default_branch": "main",
+      "sha": "4cefadbc99d7c5d452e67c7c151bdf917c8de0cc",
+      "branches": {
+        "main": "4cefadbc99d7c5d452e67c7c151bdf917c8de0cc"
+      },
+      "latest_tag": "v0.1.4"
+    },
+    "keldisko/em_yatlas-turtlewow": {
+      "default_branch": "master",
+      "sha": "2e86389160b33795b46bd47206752daa53297f23",
+      "branches": {
+        "master": "2e86389160b33795b46bd47206752daa53297f23"
+      },
+      "latest_tag": "V.02"
+    },
+    "kemkerj3/unclenortresurrectionannounce": {
+      "default_branch": "master",
+      "sha": "fec26dd7d8823d31b658afce54bb546d84e1d968",
+      "branches": {
+        "master": "fec26dd7d8823d31b658afce54bb546d84e1d968"
+      }
+    },
+    "kevinchow9527/wiiiui": {
+      "default_branch": "master",
+      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
+      "branches": {
+        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
+      }
+    },
+    "kevmodrome/spellpowermulti": {
+      "default_branch": "master",
+      "sha": "de2d75a5b80543848094e01b7bc85c4255a32b09",
+      "branches": {
+        "master": "de2d75a5b80543848094e01b7bc85c4255a32b09"
+      },
+      "latest_tag": "0.1"
+    },
+    "khiu/cursive": {
+      "default_branch": "master",
+      "sha": "58a8133beff0485ea6786749d22dde25a47d3053",
+      "branches": {
+        "master": "58a8133beff0485ea6786749d22dde25a47d3053"
+      }
+    },
+    "kiiruaa/_antinvite": {
+      "default_branch": "master",
+      "sha": "35257bba9cf9645c1c9a927525a6c3880d2381a5",
+      "branches": {
+        "master": "35257bba9cf9645c1c9a927525a6c3880d2381a5"
+      },
+      "latest_tag": "v0.3"
+    },
+    "kingfisher387/antiafk": {
+      "default_branch": "main",
+      "sha": "cfa303f8147c8bef19642cb9ea16e61e976f83b4",
+      "branches": {
+        "main": "cfa303f8147c8bef19642cb9ea16e61e976f83b4"
+      }
+    },
+    "kingfisher387/pizzaworldbuffs": {
+      "default_branch": "main",
+      "sha": "72d6861926c1a2106c8773e8e251da27ab617471",
+      "branches": {
+        "main": "72d6861926c1a2106c8773e8e251da27ab617471"
+      }
+    },
+    "kirchlive/atlasloot-gearfilter": {
+      "default_branch": "main",
+      "sha": "7b24283dc1e428b01d9a9535c5ae9c05e666336d",
+      "branches": {
+        "main": "7b24283dc1e428b01d9a9535c5ae9c05e666336d"
+      },
+      "latest_tag": "v1.1.2"
+    },
+    "kirchlive/consumesmanager": {
+      "default_branch": "main",
+      "sha": "f6c8e17c583f4a6d0b9d78f29720731f55072fd9",
+      "branches": {
+        "main": "f6c8e17c583f4a6d0b9d78f29720731f55072fd9"
+      }
+    },
+    "kirchlive/cursive-raid": {
+      "default_branch": "master",
+      "sha": "3abd16a5a6c3984be2affeac44c7366dd19e2bce",
+      "branches": {
+        "master": "3abd16a5a6c3984be2affeac44c7366dd19e2bce"
+      },
+      "latest_tag": "v4.0"
+    },
+    "kirchlive/deathlog_vanilla": {
+      "default_branch": "main",
+      "sha": "81e28be99cd026f17d79fa97693899128136095e",
+      "branches": {
+        "main": "81e28be99cd026f17d79fa97693899128136095e"
+      }
+    },
+    "kirchlive/elkbuffbarhor": {
+      "default_branch": "master",
+      "sha": "b25a66da88af21cfccd7a5e0e5949c1b00ff41f9",
+      "branches": {
+        "master": "b25a66da88af21cfccd7a5e0e5949c1b00ff41f9"
+      }
+    },
+    "kirchlive/impulse-booster": {
+      "default_branch": "master",
+      "sha": "72985612600bb8ab6811883d4e99fd118ab3bed5",
+      "branches": {
+        "master": "72985612600bb8ab6811883d4e99fd118ab3bed5"
+      }
+    },
+    "kirchlive/shaguplates-extra": {
+      "default_branch": "master",
+      "sha": "22def58171c521ccf825904d4ff70a51141a33a1",
+      "branches": {
+        "master": "22def58171c521ccf825904d4ff70a51141a33a1"
+      }
+    },
+    "kirchlive/wim": {
+      "default_branch": "master",
+      "sha": "a3a6006d136bcb88a3e303cedd86735390fce15e",
+      "branches": {
+        "master": "a3a6006d136bcb88a3e303cedd86735390fce15e"
+      }
+    },
+    "kirillserogodsky/tframes": {
+      "default_branch": "main",
+      "sha": "3f9d5d16d858c1ec74934bbcef9932404a9a99cb",
+      "branches": {
+        "main": "3f9d5d16d858c1ec74934bbcef9932404a9a99cb"
+      }
+    },
+    "kirillserogodsky/vanillastoryline-turtle": {
+      "default_branch": "master",
+      "sha": "b5536df41bf71437e6d0373906b63a3c7662e5b1",
+      "branches": {
+        "master": "b5536df41bf71437e6d0373906b63a3c7662e5b1"
+      }
+    },
+    "kluverua/portalfu": {
+      "default_branch": "main",
+      "sha": "1313a03b18c3e969f451428b144789d69206c481",
+      "branches": {
+        "main": "1313a03b18c3e969f451428b144789d69206c481"
+      },
+      "latest_tag": "2.2"
+    },
+    "kluy18/druidmanabar": {
+      "default_branch": "master",
+      "sha": "50170223a7dfa38e15c303fbf668b256f9ca9b12",
+      "branches": {
+        "master": "50170223a7dfa38e15c303fbf668b256f9ca9b12"
+      }
+    },
+    "kmschr/xiaomount": {
+      "default_branch": "main",
+      "sha": "dc5d777c5c16e84e1ba5d93588cc7890165f2f57",
+      "branches": {
+        "main": "dc5d777c5c16e84e1ba5d93588cc7890165f2f57"
+      }
+    },
+    "knadra/samuel": {
+      "default_branch": "master",
+      "sha": "c9211a089a93dbdbf61e79eaaec602224c3f77b9",
+      "branches": {
+        "master": "c9211a089a93dbdbf61e79eaaec602224c3f77b9"
+      }
+    },
+    "knopex42/zorlen": {
+      "default_branch": "main",
+      "sha": "c6b3b1b7faa5dcdfc495f6b1035e8c6887b7b36b",
+      "branches": {
+        "main": "c6b3b1b7faa5dcdfc495f6b1035e8c6887b7b36b"
+      }
+    },
+    "ko0z/classportraits_vanilla": {
+      "default_branch": "master",
+      "sha": "1d98c52195de8f603b5c33ddf62bd13d9984319e",
+      "branches": {
+        "master": "1d98c52195de8f603b5c33ddf62bd13d9984319e"
       }
     },
     "ko0z/unitframesimproved_vanilla": {
@@ -14656,25 +6653,11 @@
       },
       "latest_tag": "v1.0-beta"
     },
-    "eqomdx/equadisunitframes": {
-      "default_branch": "main",
-      "sha": "9a9d40a078f4d19e1f2c53e46bd25e4a37eecd08",
-      "branches": {
-        "main": "9a9d40a078f4d19e1f2c53e46bd25e4a37eecd08"
-      }
-    },
-    "lordglarthir/vanillastoryline-visual-novel": {
-      "default_branch": "main",
-      "sha": "a1f21276b172a71c1729d4e784ef9cb9d5c169c7",
-      "branches": {
-        "main": "a1f21276b172a71c1729d4e784ef9cb9d5c169c7"
-      }
-    },
-    "mr-rosh/warriorhud": {
+    "ko0z/xloot": {
       "default_branch": "master",
-      "sha": "692722c7b68e0a3b5590b53f06866568e6c71051",
+      "sha": "e693b39dcae6254072ec6b663622f36b4e9a783f",
       "branches": {
-        "master": "692722c7b68e0a3b5590b53f06866568e6c71051"
+        "master": "e693b39dcae6254072ec6b663622f36b4e9a783f"
       }
     },
     "ko0z/zui": {
@@ -14684,230 +6667,75 @@
         "master": "acec4c0c585ac6b2782ab2705e110d649155bace"
       }
     },
-    "zaicopx/zui": {
+    "kobeniiiiii/combatledger": {
+      "default_branch": "main",
+      "sha": "515e791a9daaf4a6dc56cc54e05c99fe94c3152a",
+      "branches": {
+        "main": "515e791a9daaf4a6dc56cc54e05c99fe94c3152a"
+      }
+    },
+    "kogorash/chatmonitor": {
+      "default_branch": "main",
+      "sha": "2095edc3e5a10c8065304dbb567914424b8d9bf5",
+      "branches": {
+        "main": "2095edc3e5a10c8065304dbb567914424b8d9bf5"
+      }
+    },
+    "koraykarakus/shaguplates": {
       "default_branch": "master",
-      "sha": "b3742ef6a6c6db8fbf35e0cb4c8ca32048ef2b16",
+      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
       "branches": {
-        "master": "b3742ef6a6c6db8fbf35e0cb4c8ca32048ef2b16"
+        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
       }
     },
-    "nehswu/zui": {
+    "kornfedfred/lootblare-wrath": {
       "default_branch": "master",
-      "sha": "575497213b50aa583224a59a44216d04fb0ee1bd",
+      "sha": "c85151700613ba77bbf29a70509afbd769079222",
       "branches": {
-        "master": "575497213b50aa583224a59a44216d04fb0ee1bd"
-      }
-    },
-    "humblekagu/zui": {
-      "default_branch": "master",
-      "sha": "acec4c0c585ac6b2782ab2705e110d649155bace",
-      "branches": {
-        "master": "acec4c0c585ac6b2782ab2705e110d649155bace"
-      }
-    },
-    "gabrin18/zui": {
-      "default_branch": "master",
-      "sha": "6a5709de4bc37577b824565db3fe3f1c048e7923",
-      "branches": {
-        "master": "6a5709de4bc37577b824565db3fe3f1c048e7923"
-      }
-    },
-    "vargv666/zui": {
-      "default_branch": "master",
-      "sha": "56da9bb7d9a24fdae1db351ea97f920370b8f140",
-      "branches": {
-        "master": "56da9bb7d9a24fdae1db351ea97f920370b8f140"
-      }
-    },
-    "russlando/zui": {
-      "default_branch": "master",
-      "sha": "d984370471ab64ede453ea9549fa3d64099dfd09",
-      "branches": {
-        "master": "d984370471ab64ede453ea9549fa3d64099dfd09"
-      }
-    },
-    "skllskll/zui": {
-      "default_branch": "master",
-      "sha": "d984370471ab64ede453ea9549fa3d64099dfd09",
-      "branches": {
-        "master": "d984370471ab64ede453ea9549fa3d64099dfd09"
-      }
-    },
-    "zedris/zui": {
-      "default_branch": "master",
-      "sha": "d984370471ab64ede453ea9549fa3d64099dfd09",
-      "branches": {
-        "master": "d984370471ab64ede453ea9549fa3d64099dfd09"
-      }
-    },
-    "torchlite-bit/aegis_sbr": {
-      "default_branch": "main",
-      "sha": "c99a0e8dbd47e9d38e24fe579f56b87a6e6650bf",
-      "branches": {
-        "main": "c99a0e8dbd47e9d38e24fe579f56b87a6e6650bf"
-      }
-    },
-    "eirikaskheim/aegis_sbr": {
-      "default_branch": "main",
-      "sha": "b8d0d809806f05712303b57b16d2ddcb51451e76",
-      "branches": {
-        "main": "b8d0d809806f05712303b57b16d2ddcb51451e76"
-      }
-    },
-    "torchlite-bit/aegis_courier": {
-      "default_branch": "main",
-      "sha": "c78fdcfe0b1bc3de300126c3ee7549c648c6033c",
-      "branches": {
-        "main": "c78fdcfe0b1bc3de300126c3ee7549c648c6033c"
-      }
-    },
-    "torchlite-bit/aegis_exchange": {
-      "default_branch": "main",
-      "sha": "0c4b11dc8b8d16be3c6b6abee57ace38d2a537ca",
-      "branches": {
-        "main": "0c4b11dc8b8d16be3c6b6abee57ace38d2a537ca"
-      }
-    },
-    "rustybelter77/aegis_exchange": {
-      "default_branch": "main",
-      "sha": "f84f423a006bcc202602ddeaf72b38a75d3bfd47",
-      "branches": {
-        "main": "f84f423a006bcc202602ddeaf72b38a75d3bfd47"
-      }
-    },
-    "eirikaskheim/aegis_exchange": {
-      "default_branch": "main",
-      "sha": "a3385950c9b7100446f1fcf39168a36a642b3f0a",
-      "branches": {
-        "main": "a3385950c9b7100446f1fcf39168a36a642b3f0a"
-      }
-    },
-    "torchlite-bit/aegis_rallypower": {
-      "default_branch": "main",
-      "sha": "8f1ba229ce018c23811dbeaa3e93f0b6368fb563",
-      "branches": {
-        "main": "8f1ba229ce018c23811dbeaa3e93f0b6368fb563"
-      }
-    },
-    "cinos03/bijoucounter": {
-      "default_branch": "main",
-      "sha": "f6ce02e7b66566912b00de739f2f042ab0914323",
-      "branches": {
-        "main": "f6ce02e7b66566912b00de739f2f042ab0914323"
-      }
-    },
-    "cinos03/bankraider": {
-      "default_branch": "main",
-      "sha": "7de9a083e653593daa9285be7aa24650d9726aca",
-      "branches": {
-        "main": "7de9a083e653593daa9285be7aa24650d9726aca"
-      }
-    },
-    "cinos03/surpriseme-1.12": {
-      "default_branch": "main",
-      "sha": "5be9b5eaeb3b01a2862d1ac21873000b84d8a46a",
-      "branches": {
-        "main": "5be9b5eaeb3b01a2862d1ac21873000b84d8a46a"
-      }
-    },
-    "bycfm2/atlas-cfm": {
-      "default_branch": "main",
-      "sha": "07218cc2e6a43a00f37444abebbee20b71f4e944",
-      "branches": {
-        "main": "07218cc2e6a43a00f37444abebbee20b71f4e944"
-      }
-    },
-    "leokem/pfquest-turtle": {
-      "default_branch": "master",
-      "sha": "d5a5e6ea35aa2ad16a78f108c75b4a3064862123",
-      "branches": {
-        "master": "d5a5e6ea35aa2ad16a78f108c75b4a3064862123"
-      }
-    },
-    "bennylavaa/pfquest-turtle": {
-      "default_branch": "master",
-      "sha": "cd20d143a193b12d5c550246005085474cf17dcd",
-      "branches": {
-        "master": "cd20d143a193b12d5c550246005085474cf17dcd"
+        "master": "c85151700613ba77bbf29a70509afbd769079222"
       },
-      "latest_tag": "pfQuest-turtle-v1.0.2"
+      "latest_tag": "2.0.7"
     },
-    "shagu/pfquest-turtle": {
+    "kpteam2024/guidecreator": {
       "default_branch": "master",
-      "sha": "0bc7bf4e55d8867a065354da6f386461255e4801",
+      "sha": "36d92e3e9ec730991e8e65ca11d8310751d6142e",
       "branches": {
-        "master": "0bc7bf4e55d8867a065354da6f386461255e4801"
+        "master": "36d92e3e9ec730991e8e65ca11d8310751d6142e"
       }
     },
-    "vill8/pfquest-octo": {
+    "krautchanpro/vf_tankaddon": {
       "default_branch": "master",
-      "sha": "b0f70e9b2e74276391083ae88c6a72eca849975a",
+      "sha": "b39c7bee4a7750c578b0dc0eaadebef0dbd6e75b",
       "branches": {
-        "master": "b0f70e9b2e74276391083ae88c6a72eca849975a"
+        "master": "b39c7bee4a7750c578b0dc0eaadebef0dbd6e75b"
       }
     },
-    "talex00/pfquest-turtle": {
-      "default_branch": "master",
-      "sha": "dce1ad0d6a0e55b25f6b9b9a52f7bee611c756fc",
+    "krekog/skelacustomnameplates": {
+      "default_branch": "main",
+      "sha": "8ee5ace1b67d6f88cc070c79dc19990e46277ca1",
       "branches": {
-        "master": "dce1ad0d6a0e55b25f6b9b9a52f7bee611c756fc"
+        "main": "8ee5ace1b67d6f88cc070c79dc19990e46277ca1"
       }
     },
-    "xerik444x/pfquest-turtle-es": {
-      "default_branch": "master",
-      "sha": "1f40881b742e4d819784e61b11e8c55f00d74eaa",
+    "krekog/specialtalent": {
+      "default_branch": "main",
+      "sha": "12266488dc31939b1fa3845808f52a8cce1782ab",
       "branches": {
-        "master": "1f40881b742e4d819784e61b11e8c55f00d74eaa"
+        "main": "12266488dc31939b1fa3845808f52a8cce1782ab"
       }
     },
-    "superyoung9208/pfquest-turtle": {
-      "default_branch": "master",
-      "sha": "2188e4dcda172954007227aa37fd87d7ea534812",
+    "krekog/specialtalentui": {
+      "default_branch": "main",
+      "sha": "7332d3e7fd5377eaabfd547d79dddb3e71381045",
       "branches": {
-        "master": "2188e4dcda172954007227aa37fd87d7ea534812"
+        "main": "7332d3e7fd5377eaabfd547d79dddb3e71381045"
       }
     },
-    "tomek7667/pfquest-turtle": {
+    "krekog/wiiiui": {
       "default_branch": "master",
-      "sha": "271448449840e7cc6a862f89962f767eb4507978",
+      "sha": "c6e0170171054612cf7bdc7766c399bc17dff2c0",
       "branches": {
-        "master": "271448449840e7cc6a862f89962f767eb4507978"
-      },
-      "latest_tag": "v0.0.1"
-    },
-    "hellowind777/pfquest-turtle": {
-      "default_branch": "master",
-      "sha": "a7cf38736174ef287bbea3203338b5872659ece1",
-      "branches": {
-        "master": "a7cf38736174ef287bbea3203338b5872659ece1"
-      }
-    },
-    "haaxor1689/pfquest-turtle": {
-      "default_branch": "master",
-      "sha": "ad59dd2e335497801005368287820c6b0a16c257",
-      "branches": {
-        "master": "ad59dd2e335497801005368287820c6b0a16c257"
-      }
-    },
-    "hat3ph/pfquest-turtle": {
-      "default_branch": "master",
-      "sha": "506f8793b593d459f56e29d565043030093a4163",
-      "branches": {
-        "master": "506f8793b593d459f56e29d565043030093a4163"
-      }
-    },
-    "evannnn1996/pfquest-turtle": {
-      "default_branch": "master",
-      "sha": "0f8a218f5aeb76cc74661a659ca17ef8dd7eb19f",
-      "branches": {
-        "master": "0f8a218f5aeb76cc74661a659ca17ef8dd7eb19f"
-      }
-    },
-    "jemadux/pfquest-turtle": {
-      "default_branch": "master",
-      "sha": "0b9b04daf67fb0632c965b4e825534f5c6c53f36",
-      "branches": {
-        "master": "0b9b04daf67fb0632c965b4e825534f5c6c53f36"
+        "master": "c6e0170171054612cf7bdc7766c399bc17dff2c0"
       }
     },
     "krlosbf/pfquest-turtle": {
@@ -14917,132 +6745,1614 @@
         "master": "37dd6b08171b832adaae5167c78318a09dd1ab17"
       }
     },
-    "samahee/pfquest-turtle": {
+    "kxseven/vanillaratingbuster": {
       "default_branch": "master",
-      "sha": "08d9a117dabfbf9db0a7c2e0da47ee995302785f",
+      "sha": "d1c4df6a3a2f59e5a0c794f600090bfe55078818",
       "branches": {
-        "master": "08d9a117dabfbf9db0a7c2e0da47ee995302785f"
+        "master": "d1c4df6a3a2f59e5a0c794f600090bfe55078818"
+      },
+      "latest_tag": "0.13"
+    },
+    "ladabr/whisperfilter": {
+      "default_branch": "universal",
+      "sha": "666977c9117ee5777f053ac9eedcae1e3961df3a",
+      "branches": {
+        "universal": "666977c9117ee5777f053ac9eedcae1e3961df3a"
       }
     },
-    "uss-enterprise-guild/pfquest-turtle": {
+    "lanrutcon/abreathbeneath": {
       "default_branch": "master",
-      "sha": "4c6f8d0a659bc7fc80867d51823b0dc967146087",
+      "sha": "43efe7e36b4272c76e4b2f0b91e24c60e582d8f5",
       "branches": {
-        "master": "4c6f8d0a659bc7fc80867d51823b0dc967146087"
+        "master": "43efe7e36b4272c76e4b2f0b91e24c60e582d8f5"
+      },
+      "latest_tag": "v1.0"
+    },
+    "lanrutcon/sunofthenight": {
+      "default_branch": "master",
+      "sha": "35fa987754f7912d6465681bcac8c6dc15f12c9c",
+      "branches": {
+        "master": "35fa987754f7912d6465681bcac8c6dc15f12c9c"
+      },
+      "latest_tag": "v1.1"
+    },
+    "lastozavr1/bartender2-read-instructions": {
+      "default_branch": "master",
+      "sha": "1eec247ecaf755916ece74009b367c5f7219f0c4",
+      "branches": {
+        "master": "1eec247ecaf755916ece74009b367c5f7219f0c4"
       }
     },
-    "vaniron/tourguide-turtle": {
-      "default_branch": "master",
-      "sha": "90d3837e3f1f3a97d9cd446696598b8207cc0de4",
+    "laubuur/simpleauras": {
+      "default_branch": "main",
+      "sha": "748900496a17aae8cea80175807af30b0fbc822a",
       "branches": {
-        "master": "90d3837e3f1f3a97d9cd446696598b8207cc0de4"
+        "main": "748900496a17aae8cea80175807af30b0fbc822a"
+      }
+    },
+    "laytya/autobar-for-turtle-wow": {
+      "default_branch": "main",
+      "sha": "5ea82b9cf57571e48836eff76944ac84ccc0a709",
+      "branches": {
+        "main": "5ea82b9cf57571e48836eff76944ac84ccc0a709"
+      }
+    },
+    "laytya/customnameplates": {
+      "default_branch": "master",
+      "sha": "5088926b4900cedcf90b34853b974112352b395f",
+      "branches": {
+        "master": "5088926b4900cedcf90b34853b974112352b395f"
+      },
+      "latest_tag": "1.70"
+    },
+    "laytya/eavesdrop": {
+      "default_branch": "master",
+      "sha": "244cba1c61f861bfc643a8b8617691a742e33c44",
+      "branches": {
+        "master": "244cba1c61f861bfc643a8b8617691a742e33c44"
+      },
+      "latest_tag": "1.4.1"
+    },
+    "laytya/engbags": {
+      "default_branch": "main",
+      "sha": "d01c2c2c25cb563390ecbb6ec108a6bc55abb995",
+      "branches": {
+        "main": "d01c2c2c25cb563390ecbb6ec108a6bc55abb995"
+      }
+    },
+    "laytya/eqcompare-vanilla": {
+      "default_branch": "master",
+      "sha": "6871aa28a2e9fd5cdef743d5debfe333da528b05",
+      "branches": {
+        "master": "6871aa28a2e9fd5cdef743d5debfe333da528b05"
+      },
+      "latest_tag": "v1.5"
+    },
+    "laytya/eql3": {
+      "default_branch": "master",
+      "sha": "a0ced1c73e99aa2662e5d959dd96fcec33ddcfb4",
+      "branches": {
+        "master": "a0ced1c73e99aa2662e5d959dd96fcec33ddcfb4"
+      }
+    },
+    "laytya/ezdismount": {
+      "default_branch": "master",
+      "sha": "e95b05be42a35f05367749dda6e8930ad592247d",
+      "branches": {
+        "master": "e95b05be42a35f05367749dda6e8930ad592247d"
+      }
+    },
+    "laytya/fubar": {
+      "default_branch": "main",
+      "sha": "2bb40fb180791eae3d144f99d1c672235c61fe5a",
+      "branches": {
+        "main": "2bb40fb180791eae3d144f99d1c672235c61fe5a"
+      }
+    },
+    "laytya/fubar_portalfu": {
+      "default_branch": "main",
+      "sha": "d50fdbbe0765edd073640ed317bfade682cffb4f",
+      "branches": {
+        "main": "d50fdbbe0765edd073640ed317bfade682cffb4f"
+      }
+    },
+    "laytya/fubar_pursuefu": {
+      "default_branch": "main",
+      "sha": "135fbeb81ff01942d8ff308928c74b0e4b17db70",
+      "branches": {
+        "main": "135fbeb81ff01942d8ff308928c74b0e4b17db70"
+      },
+      "latest_tag": "v1.2"
+    },
+    "laytya/lazyscript": {
+      "default_branch": "master",
+      "sha": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92",
+      "branches": {
+        "master": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92"
+      }
+    },
+    "laytya/lazyspell": {
+      "default_branch": "master",
+      "sha": "1af9fc538bf010116290b3399ca67b9b2b95043f",
+      "branches": {
+        "master": "1af9fc538bf010116290b3399ca67b9b2b95043f"
+      }
+    },
+    "laytya/lilsparkysworkshop-vanilla": {
+      "default_branch": "master",
+      "sha": "326db62006d5281b749bb0b3587fd0b977575581",
+      "branches": {
+        "master": "326db62006d5281b749bb0b3587fd0b977575581"
+      },
+      "latest_tag": "v0.7"
+    },
+    "laytya/magehud": {
+      "default_branch": "main",
+      "sha": "b707cccc8e8ac6e053ddffcd812ae94a9fe17aa0",
+      "branches": {
+        "main": "b707cccc8e8ac6e053ddffcd812ae94a9fe17aa0"
+      }
+    },
+    "laytya/mendeleev": {
+      "default_branch": "main",
+      "sha": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a",
+      "branches": {
+        "main": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a"
+      },
+      "latest_tag": "1.1"
+    },
+    "laytya/metamap-vanilla": {
+      "default_branch": "master",
+      "sha": "8dcc99d182480cac3e44efd9b4ac2ccb9f441e14",
+      "branches": {
+        "master": "8dcc99d182480cac3e44efd9b4ac2ccb9f441e14"
+      },
+      "latest_tag": "11200-10"
+    },
+    "laytya/minimapbuttonframe-vanilla": {
+      "default_branch": "master",
+      "sha": "0923f9e4128c6fcdc97df448c7665ca71bca2a18",
+      "branches": {
+        "master": "0923f9e4128c6fcdc97df448c7665ca71bca2a18"
+      },
+      "latest_tag": "1.12"
+    },
+    "laytya/modernfocusframe": {
+      "default_branch": "main",
+      "sha": "f9243c70da7b2725f158f093856687aa48457e36",
+      "branches": {
+        "main": "f9243c70da7b2725f158f093856687aa48457e36"
+      }
+    },
+    "laytya/niagara": {
+      "default_branch": "master",
+      "sha": "9c09951be42a8a7152a2c67eebc42077618eb39d",
+      "branches": {
+        "master": "9c09951be42a8a7152a2c67eebc42077618eb39d"
+      },
+      "latest_tag": "v1.1"
+    },
+    "laytya/quartz": {
+      "default_branch": "main",
+      "sha": "2df6312bef7d7d05a122f16cf7e35b3d5b658493",
+      "branches": {
+        "main": "2df6312bef7d7d05a122f16cf7e35b3d5b658493"
+      }
+    },
+    "laytya/reciperadar-vanilla": {
+      "default_branch": "master",
+      "sha": "db200dae1f2d349e8f3fba83188e3950c73307af",
+      "branches": {
+        "master": "db200dae1f2d349e8f3fba83188e3950c73307af"
+      },
+      "latest_tag": "v1.15"
+    },
+    "laytya/seethungroups": {
+      "default_branch": "master",
+      "sha": "86193af2f6fe285da9959f172acb939680497d96",
+      "branches": {
+        "master": "86193af2f6fe285da9959f172acb939680497d96"
+      }
+    },
+    "laytya/shootyepgp": {
+      "default_branch": "master",
+      "sha": "57c787f2719cfd71a247600ed18ba0daa1962331",
+      "branches": {
+        "master": "57c787f2719cfd71a247600ed18ba0daa1962331"
+      }
+    },
+    "laytya/simplecombatlog": {
+      "default_branch": "master",
+      "sha": "6fe81a43e446eb9b5f696ce3d82e61e72a4b6436",
+      "branches": {
+        "master": "6fe81a43e446eb9b5f696ce3d82e61e72a4b6436"
+      },
+      "latest_tag": "r27330"
+    },
+    "laytya/spamthrottle": {
+      "default_branch": "master",
+      "sha": "14a08db9aa8c0d53fef03dff14345c7005c029a7",
+      "branches": {
+        "master": "14a08db9aa8c0d53fef03dff14345c7005c029a7"
+      },
+      "latest_tag": "1.17"
+    },
+    "laytya/tankbuddyenh": {
+      "default_branch": "master",
+      "sha": "41823497534e08be7055ff9fe14ac9e280b492a1",
+      "branches": {
+        "master": "41823497534e08be7055ff9fe14ac9e280b492a1"
+      }
+    },
+    "laytya/tomtom-twow": {
+      "default_branch": "master",
+      "sha": "a9c8af10c0d17e4705a2be1cb5e4ab3d71a34ba0",
+      "branches": {
+        "master": "a9c8af10c0d17e4705a2be1cb5e4ab3d71a34ba0"
+      }
+    },
+    "laytya/vanilla_ocb": {
+      "default_branch": "master",
+      "sha": "0c6ff25a2acf38cbe0d93e831b7401577c8967aa",
+      "branches": {
+        "master": "0c6ff25a2acf38cbe0d93e831b7401577c8967aa"
+      },
+      "latest_tag": "v3.3.3"
+    },
+    "laytya/wowluavanilla": {
+      "default_branch": "master",
+      "sha": "be006cbbcd6fbf5dcaf769dd300168389225604b",
+      "branches": {
+        "master": "be006cbbcd6fbf5dcaf769dd300168389225604b"
+      },
+      "latest_tag": "v1.0"
+    },
+    "leenux/autoexpenable": {
+      "default_branch": "main",
+      "sha": "d4a134d62aae9ceab4e42152a7803a1556bb1015",
+      "branches": {
+        "main": "d4a134d62aae9ceab4e42152a7803a1556bb1015"
+      }
+    },
+    "leenux/debufffilter": {
+      "default_branch": "master",
+      "sha": "bb049ddd7ee5a9e59e1764fa58626c6aae994150",
+      "branches": {
+        "master": "bb049ddd7ee5a9e59e1764fa58626c6aae994150"
+      }
+    },
+    "leenux/mobresistanddmg": {
+      "default_branch": "main",
+      "sha": "f04af9fc33f76f989bae23f604f54a8aa1597c81",
+      "branches": {
+        "main": "f04af9fc33f76f989bae23f604f54a8aa1597c81"
+      }
+    },
+    "leokem/pfquest-turtle": {
+      "default_branch": "master",
+      "sha": "d5a5e6ea35aa2ad16a78f108c75b4a3064862123",
+      "branches": {
+        "master": "d5a5e6ea35aa2ad16a78f108c75b4a3064862123"
+      }
+    },
+    "leperidot/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "adf55dc12ddba6e5227da34949755985ecfad64b",
+      "branches": {
+        "master": "adf55dc12ddba6e5227da34949755985ecfad64b"
+      }
+    },
+    "leperidot/turtlehcfilter": {
+      "default_branch": "main",
+      "sha": "e6737f46663ed7ee195de316d7548d3df631f01e",
+      "branches": {
+        "main": "e6737f46663ed7ee195de316d7548d3df631f01e"
+      }
+    },
+    "lexxoi/actionbarprofiles": {
+      "default_branch": "master",
+      "sha": "54d8c4f54322e955c4eb6c2fd0aaed1405db7e9f",
+      "branches": {
+        "master": "54d8c4f54322e955c4eb6c2fd0aaed1405db7e9f"
+      }
+    },
+    "lexxoi/flighttracker": {
+      "default_branch": "main",
+      "sha": "cc46bf61ee1c9d5cc33fa7ce9c1cca1c71332795",
+      "branches": {
+        "main": "cc46bf61ee1c9d5cc33fa7ce9c1cca1c71332795"
+      }
+    },
+    "lichery/zgloot": {
+      "default_branch": "master",
+      "sha": "ded78b18d4a28f7cd157b763d25116aea698d5be",
+      "branches": {
+        "master": "ded78b18d4a28f7cd157b763d25116aea698d5be"
+      }
+    },
+    "lichong8826/lazyscript": {
+      "default_branch": "master",
+      "sha": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92",
+      "branches": {
+        "master": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92"
+      }
+    },
+    "lihvar/shagunotify": {
+      "default_branch": "master",
+      "sha": "a95334e9a4accae5e6e28d6be7e0656ca28e291b",
+      "branches": {
+        "master": "a95334e9a4accae5e6e28d6be7e0656ca28e291b"
+      }
+    },
+    "liijin/trailblazer": {
+      "default_branch": "main",
+      "sha": "6e448a724eb35381ec63f10576bf013f1251387c",
+      "branches": {
+        "main": "6e448a724eb35381ec63f10576bf013f1251387c"
+      }
+    },
+    "liiora/pfui-lazyres": {
+      "default_branch": "master",
+      "sha": "d33a17af316de26595cbeac252a08767f7dcbf5f",
+      "branches": {
+        "master": "d33a17af316de26595cbeac252a08767f7dcbf5f"
+      }
+    },
+    "likesc/pfstudio": {
+      "default_branch": "master",
+      "sha": "616f06a4132f90a7eebea5a2496bc813fa7de059",
+      "branches": {
+        "master": "616f06a4132f90a7eebea5a2496bc813fa7de059"
+      }
+    },
+    "liminalwarmth/sortbags-vanilla-fixed": {
+      "default_branch": "master",
+      "sha": "14db91333e15d1b4375918e234f103c86742c471",
+      "branches": {
+        "master": "14db91333e15d1b4375918e234f103c86742c471"
+      }
+    },
+    "linae-kronos/casterstats": {
+      "default_branch": "master",
+      "sha": "ed43393184e81d488b106c5b1b12a4382189e04d",
+      "branches": {
+        "master": "ed43393184e81d488b106c5b1b12a4382189e04d"
+      }
+    },
+    "linae-kronos/itemrackfu": {
+      "default_branch": "master",
+      "sha": "78c032c3c78f6fa326d04ba2381592024ec94135",
+      "branches": {
+        "master": "78c032c3c78f6fa326d04ba2381592024ec94135"
+      }
+    },
+    "linae-kronos/raidsummon": {
+      "default_branch": "master",
+      "sha": "cd982bfbef2bc88ca5ad5aa654cf3ca86b85c33e",
+      "branches": {
+        "master": "cd982bfbef2bc88ca5ad5aa654cf3ca86b85c33e"
+      },
+      "latest_tag": "latest"
+    },
+    "linae-kronos/tradedispenser": {
+      "default_branch": "master",
+      "sha": "63aee841b835e291a30c40b46c452a9aa47717b1",
+      "branches": {
+        "master": "63aee841b835e291a30c40b46c452a9aa47717b1"
+      }
+    },
+    "lioryx/aux-addon": {
+      "default_branch": "master",
+      "sha": "51407dfe9c2edc8a2a1e8a2ee12dcb44b24e9cbd",
+      "branches": {
+        "master": "51407dfe9c2edc8a2a1e8a2ee12dcb44b24e9cbd"
+      }
+    },
+    "lioryx/chatbar": {
+      "default_branch": "master",
+      "sha": "aee17453d3e15659cc3e665db579a70397c2f294",
+      "branches": {
+        "master": "aee17453d3e15659cc3e665db579a70397c2f294"
+      }
+    },
+    "lioryx/modernspellbook": {
+      "default_branch": "master",
+      "sha": "f55e71de726acd615393a59c91c8c95565d9aeb5",
+      "branches": {
+        "master": "f55e71de726acd615393a59c91c8c95565d9aeb5"
+      }
+    },
+    "lioryx/puppeteer": {
+      "default_branch": "main",
+      "sha": "fe50882bd521475217325d2984dd5ba1de3df312",
+      "branches": {
+        "main": "fe50882bd521475217325d2984dd5ba1de3df312"
+      }
+    },
+    "lioryx/simpleactionsets": {
+      "default_branch": "master",
+      "sha": "a51baa1d0b2bd85313596e0fe593ccef4578b0a8",
+      "branches": {
+        "master": "a51baa1d0b2bd85313596e0fe593ccef4578b0a8"
+      }
+    },
+    "lioryx/sortbags": {
+      "default_branch": "master",
+      "sha": "1b59767ca41749e70d72f2991c27054beebcdfcd",
+      "branches": {
+        "master": "1b59767ca41749e70d72f2991c27054beebcdfcd"
+      }
+    },
+    "liruqi/pfquest": {
+      "default_branch": "main",
+      "sha": "b349cd5e3e71d6deef78601efccb84a3093df60e",
+      "branches": {
+        "main": "b349cd5e3e71d6deef78601efccb84a3093df60e"
+      }
+    },
+    "litaosmile/consoleexperienceclassic": {
+      "default_branch": "main",
+      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
+      "branches": {
+        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
+      }
+    },
+    "lluistfc/quiver": {
+      "default_branch": "main",
+      "sha": "f12ecb171f7a8a4ea7af682bcd030b943f852122",
+      "branches": {
+        "main": "f12ecb171f7a8a4ea7af682bcd030b943f852122"
+      },
+      "latest_tag": "v3.1.1"
+    },
+    "logicsec/consumesmanager": {
+      "default_branch": "main",
+      "sha": "f6c8e17c583f4a6d0b9d78f29720731f55072fd9",
+      "branches": {
+        "main": "f6c8e17c583f4a6d0b9d78f29720731f55072fd9"
+      }
+    },
+    "longpiggy/pfui-custommedia": {
+      "default_branch": "main",
+      "sha": "09e3d9c6a372c82c3a9fa039e6b421b5b4eb9476",
+      "branches": {
+        "main": "09e3d9c6a372c82c3a9fa039e6b421b5b4eb9476"
+      }
+    },
+    "longpiggy/questprogressshare": {
+      "default_branch": "main",
+      "sha": "46bd8bb6a9f67c54b99ed3d7ea6b1fcdae7f9f62",
+      "branches": {
+        "main": "46bd8bb6a9f67c54b99ed3d7ea6b1fcdae7f9f62"
+      }
+    },
+    "loogosh/cursive": {
+      "default_branch": "master",
+      "sha": "e734f9bac791550e73af4b6bc0412956a0f51b69",
+      "branches": {
+        "master": "e734f9bac791550e73af4b6bc0412956a0f51b69"
+      }
+    },
+    "loogosh/rabuffs": {
+      "default_branch": "master",
+      "sha": "5ff997ec79456eda99616cc517e5823cad161bbc",
+      "branches": {
+        "master": "5ff997ec79456eda99616cc517e5823cad161bbc"
+      }
+    },
+    "loogosh/simpleauras": {
+      "default_branch": "main",
+      "sha": "9bc981deaafc1609f6b03e8f5a14991dda21719b",
+      "branches": {
+        "main": "9bc981deaafc1609f6b03e8f5a14991dda21719b"
+      }
+    },
+    "loogosh/sotamockbadkp": {
+      "default_branch": "master",
+      "sha": "980bdb03270cacb1a5a667882ffaea4909f114cf",
+      "branches": {
+        "master": "980bdb03270cacb1a5a667882ffaea4909f114cf"
+      }
+    },
+    "loogosh/warriortweaks": {
+      "default_branch": "main",
+      "sha": "16f00117fbcd42130c0b44133a2a275bb4843bfe",
+      "branches": {
+        "main": "16f00117fbcd42130c0b44133a2a275bb4843bfe"
+      }
+    },
+    "lookino/flyout": {
+      "default_branch": "main",
+      "sha": "f13633a7adc6169e9b5112b68322252b1e623740",
+      "branches": {
+        "main": "f13633a7adc6169e9b5112b68322252b1e623740"
+      }
+    },
+    "lookino/magnify": {
+      "default_branch": "main",
+      "sha": "3ff15a844a5ade917c6ac63489a9dc375b1411b2",
+      "branches": {
+        "main": "3ff15a844a5ade917c6ac63489a9dc375b1411b2"
+      }
+    },
+    "lordglarthir/vanillastoryline-visual-novel": {
+      "default_branch": "main",
+      "sha": "a1f21276b172a71c1729d4e784ef9cb9d5c169c7",
+      "branches": {
+        "main": "a1f21276b172a71c1729d4e784ef9cb9d5c169c7"
+      }
+    },
+    "lukeelrod/autoconfirm": {
+      "default_branch": "turtle-wow",
+      "sha": "fe4495d0d32a1d208900a6fed1de8a05af844329",
+      "branches": {
+        "turtle-wow": "fe4495d0d32a1d208900a6fed1de8a05af844329"
+      }
+    },
+    "lurexx/chatsuey": {
+      "default_branch": "master",
+      "sha": "42219504605a7db7dafa2df636a21f463423e1fd",
+      "branches": {
+        "master": "42219504605a7db7dafa2df636a21f463423e1fd"
+      },
+      "latest_tag": "1.2.0"
+    },
+    "lxxie1988/mendeleev": {
+      "default_branch": "main",
+      "sha": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a",
+      "branches": {
+        "main": "c57c7e66cc48717d776caf5a54a0a61d073b2b1a"
+      }
+    },
+    "lxxie1988/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "ceae89b14544fd87a8449bd4a751802dd118809c",
+      "branches": {
+        "master": "ceae89b14544fd87a8449bd4a751802dd118809c"
+      }
+    },
+    "lythandrawow/enemyframes": {
+      "default_branch": "master",
+      "sha": "2f0f840b65cd1a3de76e1e416665a646ac99ce90",
+      "branches": {
+        "master": "2f0f840b65cd1a3de76e1e416665a646ac99ce90"
+      }
+    },
+    "lythandrawow/lyth_automana": {
+      "default_branch": "master",
+      "sha": "e3c52bd2a97f64c08b65bc7bdc3eab3f4e4c4058",
+      "branches": {
+        "master": "e3c52bd2a97f64c08b65bc7bdc3eab3f4e4c4058"
+      }
+    },
+    "lythandrawow/lyth_consume_helper": {
+      "default_branch": "main",
+      "sha": "55224c3e005aa29a25d36afa99045d92728a5e08",
+      "branches": {
+        "main": "55224c3e005aa29a25d36afa99045d92728a5e08"
+      }
+    },
+    "lythandrawow/lythcursive": {
+      "default_branch": "master",
+      "sha": "74f5c80e228010e5b134a8319bd383a384be0d93",
+      "branches": {
+        "master": "74f5c80e228010e5b134a8319bd383a384be0d93"
+      }
+    },
+    "lythandrawow/lythroid-macros": {
+      "default_branch": "master",
+      "sha": "7f349499bb840a1ed6c47f52abccf23652c8e27c",
+      "branches": {
+        "master": "7f349499bb840a1ed6c47f52abccf23652c8e27c"
+      }
+    },
+    "lythandrawow/rp_wim": {
+      "default_branch": "master",
+      "sha": "e9664e4481167b93ba0379ed00a1e3b65a445c06",
+      "branches": {
+        "master": "e9664e4481167b93ba0379ed00a1e3b65a445c06"
+      }
+    },
+    "macumbafeh/hunterswissknife": {
+      "default_branch": "master",
+      "sha": "ac63524189294b9f38b1fe60f7e8ab19275962bc",
+      "branches": {
+        "master": "ac63524189294b9f38b1fe60f7e8ab19275962bc"
+      }
+    },
+    "macumbafeh/niagara": {
+      "default_branch": "master",
+      "sha": "9c09951be42a8a7152a2c67eebc42077618eb39d",
+      "branches": {
+        "master": "9c09951be42a8a7152a2c67eebc42077618eb39d"
+      },
+      "latest_tag": "v1.1"
+    },
+    "macumbafeh/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
+      "branches": {
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
+      }
+    },
+    "macumbafeh/shaguchat": {
+      "default_branch": "master",
+      "sha": "01c37853c5e714b218837d24932c316f68b2728f",
+      "branches": {
+        "master": "01c37853c5e714b218837d24932c316f68b2728f"
+      }
+    },
+    "macumbafeh/shagudps": {
+      "default_branch": "master",
+      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
+      "branches": {
+        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
+      }
+    },
+    "macumbafeh/shagunotify": {
+      "default_branch": "master",
+      "sha": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49",
+      "branches": {
+        "master": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49"
+      }
+    },
+    "macumbafeh/shaguplates": {
+      "default_branch": "master",
+      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
+      "branches": {
+        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
+      }
+    },
+    "macumbafeh/shaguvalue": {
+      "default_branch": "master",
+      "sha": "debbde88b68a941b13a614612a7aa867cadbe542",
+      "branches": {
+        "master": "debbde88b68a941b13a614612a7aa867cadbe542"
+      }
+    },
+    "macumbafeh/shaguwidget": {
+      "default_branch": "master",
+      "sha": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0",
+      "branches": {
+        "master": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0"
+      }
+    },
+    "macumbafeh/unicodefont": {
+      "default_branch": "master",
+      "sha": "f19092f3bf49b5303f9bba16f45d51397b610c0a",
+      "branches": {
+        "master": "f19092f3bf49b5303f9bba16f45d51397b610c0a"
+      }
+    },
+    "macumbafeh/vanillagraphicboost": {
+      "default_branch": "master",
+      "sha": "082405f1d4e9081b2adf110596b67e44c4fd4bd6",
+      "branches": {
+        "master": "082405f1d4e9081b2adf110596b67e44c4fd4bd6"
+      }
+    },
+    "madamsmall/turtleenchant": {
+      "default_branch": "master",
+      "sha": "79a8aab329f579b995dbb4aae19a62cffb5d5ff9",
+      "branches": {
+        "master": "79a8aab329f579b995dbb4aae19a62cffb5d5ff9"
+      }
+    },
+    "madscripting/snaguloatheb-turtleedition": {
+      "default_branch": "main",
+      "sha": "b111b5a6d5cecb0c928c60c05a0cb017706c8e08",
+      "branches": {
+        "main": "b111b5a6d5cecb0c928c60c05a0cb017706c8e08"
+      }
+    },
+    "madskrist/turtlemail": {
+      "default_branch": "master",
+      "sha": "2a8cc7204c93dd83b54ea95009fbc6c6075d7573",
+      "branches": {
+        "master": "2a8cc7204c93dd83b54ea95009fbc6c6075d7573"
+      }
+    },
+    "maistatv/ezpoison": {
+      "default_branch": "main",
+      "sha": "d83e25a5ed6c2e334f2df6161134a335adaebf11",
+      "branches": {
+        "main": "d83e25a5ed6c2e334f2df6161134a335adaebf11"
+      }
+    },
+    "malcolmdahling/shaguplatesx": {
+      "default_branch": "master",
+      "sha": "80ab5540266b56a5fd173fe0f91be3fbad1d2df9",
+      "branches": {
+        "master": "80ab5540266b56a5fd173fe0f91be3fbad1d2df9"
+      }
+    },
+    "manalow/missingcrafts": {
+      "default_branch": "master",
+      "sha": "e702ce7d781d68c2ead5f8223e59689edb8cfc91",
+      "branches": {
+        "master": "e702ce7d781d68c2ead5f8223e59689edb8cfc91"
+      }
+    },
+    "manaril/totemtimers-enhanced": {
+      "default_branch": "master",
+      "sha": "dc0f87507671c02200a83b9a46efcce118eca944",
+      "branches": {
+        "master": "dc0f87507671c02200a83b9a46efcce118eca944"
+      }
+    },
+    "manrades/guda": {
+      "default_branch": "main",
+      "sha": "f1618b71bddf816bac82d1a0be67bc1417e8ba20",
+      "branches": {
+        "main": "f1618b71bddf816bac82d1a0be67bc1417e8ba20"
+      }
+    },
+    "marcelinevq/adf": {
+      "default_branch": "master",
+      "sha": "b3cacbaa52c12a8e2d5d671cd1e348d45eae3489",
+      "branches": {
+        "master": "b3cacbaa52c12a8e2d5d671cd1e348d45eae3489"
+      }
+    },
+    "marcelinevq/automana": {
+      "default_branch": "master",
+      "sha": "4a38b3353a294667da04938e03957f53ce1518f1",
+      "branches": {
+        "master": "4a38b3353a294667da04938e03957f53ce1518f1"
+      }
+    },
+    "marcelinevq/automarker": {
+      "default_branch": "master",
+      "sha": "cd66b7ae08da2a6258f53778a73689aca4ec027b",
+      "branches": {
+        "master": "cd66b7ae08da2a6258f53778a73689aca4ec027b"
+      }
+    },
+    "marcelinevq/bongos": {
+      "default_branch": "main",
+      "sha": "3365e3f6f199f8e48a042965809d161d3e3408cf",
+      "branches": {
+        "main": "3365e3f6f199f8e48a042965809d161d3e3408cf"
+      }
+    },
+    "marcelinevq/brainsaver": {
+      "default_branch": "master",
+      "sha": "35aa13b050915862b5a7303eb43bd6525876fb09",
+      "branches": {
+        "master": "35aa13b050915862b5a7303eb43bd6525876fb09"
+      }
+    },
+    "marcelinevq/clique": {
+      "default_branch": "master",
+      "sha": "872d441ca796e08eba79747909632cf3097100a9",
+      "branches": {
+        "master": "872d441ca796e08eba79747909632cf3097100a9"
+      }
+    },
+    "marcelinevq/consumesmanager": {
+      "default_branch": "main",
+      "sha": "202fadadeadc22477ea25903137bca03707e3664",
+      "branches": {
+        "main": "202fadadeadc22477ea25903137bca03707e3664"
+      }
+    },
+    "marcelinevq/decursive": {
+      "default_branch": "master",
+      "sha": "44ea26bdcb2e9feded63a42809ce97c6b8cdcd2a",
+      "branches": {
+        "master": "44ea26bdcb2e9feded63a42809ce97c6b8cdcd2a"
+      }
+    },
+    "marcelinevq/gentlegc": {
+      "default_branch": "master",
+      "sha": "a41404979d9919ebb781e02ea6a493ad604ef2cc",
+      "branches": {
+        "master": "a41404979d9919ebb781e02ea6a493ad604ef2cc"
+      }
+    },
+    "marcelinevq/healersmate": {
+      "default_branch": "main",
+      "sha": "75e77122fc8a30e3f2b58f264bed11865549cd7f",
+      "branches": {
+        "main": "75e77122fc8a30e3f2b58f264bed11865549cd7f"
+      }
+    },
+    "marcelinevq/instancetimers": {
+      "default_branch": "master",
+      "sha": "5d4e5535c92aeed47e06e7ee143263931401d96c",
+      "branches": {
+        "master": "5d4e5535c92aeed47e06e7ee143263931401d96c"
+      }
+    },
+    "marcelinevq/lazyweirdo": {
+      "default_branch": "master",
+      "sha": "5e248132d6814788f3154e00445c6f7ea45a74fb",
+      "branches": {
+        "master": "5e248132d6814788f3154e00445c6f7ea45a74fb"
+      }
+    },
+    "marcelinevq/loatheborder": {
+      "default_branch": "master",
+      "sha": "2ae69de1aa38abe90acc9e24996ccf7546e704c3",
+      "branches": {
+        "master": "2ae69de1aa38abe90acc9e24996ccf7546e704c3"
+      }
+    },
+    "marcelinevq/lootblare": {
+      "default_branch": "master",
+      "sha": "eccea47172a2d600aa73001008cc3c1f34b221da",
+      "branches": {
+        "master": "eccea47172a2d600aa73001008cc3c1f34b221da"
+      }
+    },
+    "marcelinevq/modifiedpowerauras": {
+      "default_branch": "master",
+      "sha": "faf26552df05146251866a092dd6812999ed578d",
+      "branches": {
+        "master": "faf26552df05146251866a092dd6812999ed578d"
+      }
+    },
+    "marcelinevq/outfitter": {
+      "default_branch": "master",
+      "sha": "779af2766aedd03e72d57750389b66ddb2ff7b3d",
+      "branches": {
+        "master": "779af2766aedd03e72d57750389b66ddb2ff7b3d"
+      }
+    },
+    "marcelinevq/questrepeat": {
+      "default_branch": "master",
+      "sha": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf",
+      "branches": {
+        "master": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf"
+      }
+    },
+    "marcelinevq/quiver": {
+      "default_branch": "main",
+      "sha": "8d778d753e749ca4cd317ab80d2241cb24368372",
+      "branches": {
+        "main": "8d778d753e749ca4cd317ab80d2241cb24368372"
+      }
+    },
+    "marcelinevq/rabuffs": {
+      "default_branch": "master",
+      "sha": "9abaa03ad37b6a484cb7271018455ce1eacb7291",
+      "branches": {
+        "master": "9abaa03ad37b6a484cb7271018455ce1eacb7291"
+      }
+    },
+    "marcelinevq/rightclickmodifier": {
+      "default_branch": "master",
+      "sha": "dc40936c0991230c8e92bc099b26c022510603a1",
+      "branches": {
+        "master": "dc40936c0991230c8e92bc099b26c022510603a1"
+      }
+    },
+    "marcelinevq/rinse": {
+      "default_branch": "master",
+      "sha": "c1b02b81d004b6b2931e5bbc5f379ad41ce6a246",
+      "branches": {
+        "master": "c1b02b81d004b6b2931e5bbc5f379ad41ce6a246"
+      }
+    },
+    "marcelinevq/roid-macros": {
+      "default_branch": "master",
+      "sha": "019afbcc018dc3765bc802b8c2fea2811f300689",
+      "branches": {
+        "master": "019afbcc018dc3765bc802b8c2fea2811f300689"
+      }
+    },
+    "marcelinevq/shaguplatesx": {
+      "default_branch": "master",
+      "sha": "86cc312adece44b24378fe9c10854f7c7c4f6cd7",
+      "branches": {
+        "master": "86cc312adece44b24378fe9c10854f7c7c4f6cd7"
+      }
+    },
+    "marcelinevq/sorgis_raid_marks": {
+      "default_branch": "master",
+      "sha": "080b75b1572e777384a7331cfe7c4174a92eb8b0",
+      "branches": {
+        "master": "080b75b1572e777384a7331cfe7c4174a92eb8b0"
+      }
+    },
+    "marcelinevq/tankalyze": {
+      "default_branch": "master",
+      "sha": "99cc74be8dd4e1292f57d45365657bc7849398f4",
+      "branches": {
+        "master": "99cc74be8dd4e1292f57d45365657bc7849398f4"
+      }
+    },
+    "marcelinevq/tankplates": {
+      "default_branch": "master",
+      "sha": "8f5c98fed26d3a90e0653db96a64fa9852fc055c",
+      "branches": {
+        "master": "8f5c98fed26d3a90e0653db96a64fa9852fc055c"
+      }
+    },
+    "marcelinevq/tattler": {
+      "default_branch": "master",
+      "sha": "61ec222b47ce8268510aac8e49e9808c8cd20229",
+      "branches": {
+        "master": "61ec222b47ce8268510aac8e49e9808c8cd20229"
+      }
+    },
+    "marcelinevq/tracktarget": {
+      "default_branch": "master",
+      "sha": "f5b28a96cfef537f52c34f73212053646e699208",
+      "branches": {
+        "master": "f5b28a96cfef537f52c34f73212053646e699208"
+      }
+    },
+    "marcelinevq/twow-raid-visuals": {
+      "default_branch": "master",
+      "sha": "862af96df93d594b034915893b844eaea051bb9e",
+      "branches": {
+        "master": "862af96df93d594b034915893b844eaea051bb9e"
+      },
+      "latest_tag": "1.4.18"
+    },
+    "marcelinevq/twthreat": {
+      "default_branch": "master",
+      "sha": "e1af6d03776233569a9d6dc75c3045e13f71e78f",
+      "branches": {
+        "master": "e1af6d03776233569a9d6dc75c3045e13f71e78f"
+      }
+    },
+    "marcelinevq/vamper": {
+      "default_branch": "master",
+      "sha": "2306cc10e8d3ea86d04e4fbca3fe4fb1ad76e2d1",
+      "branches": {
+        "master": "2306cc10e8d3ea86d04e4fbca3fe4fb1ad76e2d1"
+      }
+    },
+    "marcelinevq/vendorlist": {
+      "default_branch": "master",
+      "sha": "6fcec31fbf19fabec6dcb58075f677a766d0dda4",
+      "branches": {
+        "master": "6fcec31fbf19fabec6dcb58075f677a766d0dda4"
+      }
+    },
+    "marena/modifiedpowerauras": {
+      "default_branch": "master",
+      "sha": "9dd7e01c819895e56e015c259c6d4b1c90302866",
+      "branches": {
+        "master": "9dd7e01c819895e56e015c259c6d4b1c90302866"
+      }
+    },
+    "marktiedemann/feralfire": {
+      "default_branch": "master",
+      "sha": "57dabfa970a5f7c6a123cc213df14d2a3813e855",
+      "branches": {
+        "master": "57dabfa970a5f7c6a123cc213df14d2a3813e855"
+      }
+    },
+    "markuruthunderhoof/reciperadar": {
+      "default_branch": "octowow",
+      "sha": "30103ceb8717976ec70fef23e8fd91c9b6545a21",
+      "branches": {
+        "octowow": "30103ceb8717976ec70fef23e8fd91c9b6545a21"
+      }
+    },
+    "mats391/libramswap": {
+      "default_branch": "main",
+      "sha": "46114022eb4a33eefcb2189f24ddb4d5b620b364",
+      "branches": {
+        "main": "46114022eb4a33eefcb2189f24ddb4d5b620b364"
+      }
+    },
+    "mats391/rinse": {
+      "default_branch": "master",
+      "sha": "c14b56ab2bffe828a8994e71b3064cebbdeb3303",
+      "branches": {
+        "master": "c14b56ab2bffe828a8994e71b3064cebbdeb3303"
+      }
+    },
+    "matwebmasta/blacklist": {
+      "default_branch": "master",
+      "sha": "dab8cda0052b8b5ee565a6dae29a03c147c27c80",
+      "branches": {
+        "master": "dab8cda0052b8b5ee565a6dae29a03c147c27c80"
+      }
+    },
+    "max-bruhn/shaguactions": {
+      "default_branch": "master",
+      "sha": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8",
+      "branches": {
+        "master": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8"
+      }
+    },
+    "max-bruhn/shaguscore": {
+      "default_branch": "master",
+      "sha": "b07d25e6a1fa30391d9dca0dd728e33a762c6711",
+      "branches": {
+        "master": "b07d25e6a1fa30391d9dca0dd728e33a762c6711"
+      }
+    },
+    "max-bruhn/shaguvalue": {
+      "default_branch": "master",
+      "sha": "debbde88b68a941b13a614612a7aa867cadbe542",
+      "branches": {
+        "master": "debbde88b68a941b13a614612a7aa867cadbe542"
+      }
+    },
+    "maxcodk/paladinlibramswap": {
+      "default_branch": "main",
+      "sha": "62142d89d734a03faf4030ad1925a75d981f1dd7",
+      "branches": {
+        "main": "62142d89d734a03faf4030ad1925a75d981f1dd7"
+      }
+    },
+    "maxcodk/paladinsalvaremover": {
+      "default_branch": "main",
+      "sha": "f2c68fd14699b54e4ba3230fc28b94783401987c",
+      "branches": {
+        "main": "f2c68fd14699b54e4ba3230fc28b94783401987c"
+      }
+    },
+    "maxcodk/togglegather-by-svarrog": {
+      "default_branch": "main",
+      "sha": "2cccdd58b4acdec885df92c465e6dcd845337641",
+      "branches": {
+        "main": "2cccdd58b4acdec885df92c465e6dcd845337641"
+      }
+    },
+    "mazdur/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "f9873f69b656c9cb717febbb536beee51b7f910f",
+      "branches": {
+        "main": "f9873f69b656c9cb717febbb536beee51b7f910f"
+      }
+    },
+    "mcggithub/mcgui": {
+      "default_branch": "master",
+      "sha": "bdcdfd6b16f7ec69abcb999b7455cc36785c0485",
+      "branches": {
+        "master": "bdcdfd6b16f7ec69abcb999b7455cc36785c0485"
+      }
+    },
+    "mcpewpew/archud2": {
+      "default_branch": "master",
+      "sha": "06abb11870bce892fd34816e5e54dd1f0e64409c",
+      "branches": {
+        "master": "06abb11870bce892fd34816e5e54dd1f0e64409c"
+      }
+    },
+    "mcpewpew/autodecline": {
+      "default_branch": "master",
+      "sha": "119aa402925bc5a427b07c6eb0e21696e639b54d",
+      "branches": {
+        "master": "119aa402925bc5a427b07c6eb0e21696e639b54d"
+      }
+    },
+    "mcpewpew/bagnon": {
+      "default_branch": "master",
+      "sha": "06ee0b46ebda38470ef60ede699280454a812f97",
+      "branches": {
+        "master": "06ee0b46ebda38470ef60ede699280454a812f97"
+      }
+    },
+    "mcpewpew/bartender2-read-instructions": {
+      "default_branch": "master",
+      "sha": "1eec247ecaf755916ece74009b367c5f7219f0c4",
+      "branches": {
+        "master": "1eec247ecaf755916ece74009b367c5f7219f0c4"
+      }
+    },
+    "mcpewpew/bmloot": {
+      "default_branch": "master",
+      "sha": "73585e353410ea0bbf205fc22ef337ad3c850d5b",
+      "branches": {
+        "master": "73585e353410ea0bbf205fc22ef337ad3c850d5b"
+      }
+    },
+    "mcpewpew/bugsack": {
+      "default_branch": "master",
+      "sha": "163158abcd49464d285b5c3f3e547c4b873a687f",
+      "branches": {
+        "master": "163158abcd49464d285b5c3f3e547c4b873a687f"
+      }
+    },
+    "mcpewpew/cthunwarner": {
+      "default_branch": "master",
+      "sha": "70f5129730bb96834abab7678ec7e51c402fbbc8",
+      "branches": {
+        "master": "70f5129730bb96834abab7678ec7e51c402fbbc8"
+      }
+    },
+    "mcpewpew/fizzle": {
+      "default_branch": "master",
+      "sha": "90ae4215bcde84cc8347f274de55d9d012063f42",
+      "branches": {
+        "master": "90ae4215bcde84cc8347f274de55d9d012063f42"
+      }
+    },
+    "mcpewpew/flyout": {
+      "default_branch": "main",
+      "sha": "17fef1f9988867e1d76429e77f70563fb888e844",
+      "branches": {
+        "main": "17fef1f9988867e1d76429e77f70563fb888e844"
+      }
+    },
+    "mcpewpew/gfw_disenchantpredictor": {
+      "default_branch": "master",
+      "sha": "54cbcf2f377028253ae7f6a88cb093c83ca6e1b3",
+      "branches": {
+        "master": "54cbcf2f377028253ae7f6a88cb093c83ca6e1b3"
+      }
+    },
+    "mcpewpew/gfw_huntershelper": {
+      "default_branch": "master",
+      "sha": "306a625f1b97e80013aae9887de8ba8d278e96ae",
+      "branches": {
+        "master": "306a625f1b97e80013aae9887de8ba8d278e96ae"
+      }
+    },
+    "mcpewpew/goblinbrainwashinghelper": {
+      "default_branch": "master",
+      "sha": "26159e4ef29e0af7259ae92b66dde3da4c68f7d2",
+      "branches": {
+        "master": "26159e4ef29e0af7259ae92b66dde3da4c68f7d2"
+      },
+      "latest_tag": "v0.1"
+    },
+    "mcpewpew/hidebattlegroundfinder": {
+      "default_branch": "main",
+      "sha": "dba37510eb9dd867db350d083d7d7ecae53a2479",
+      "branches": {
+        "main": "dba37510eb9dd867db350d083d7d7ecae53a2479"
+      }
+    },
+    "mcpewpew/minimapbuttonbag": {
+      "default_branch": "master",
+      "sha": "a3ae16a352889ec491b8d917297aecb262d0b437",
+      "branches": {
+        "master": "a3ae16a352889ec491b8d917297aecb262d0b437"
+      },
+      "latest_tag": "v0.508"
+    },
+    "mcpewpew/minimapbuttonframe": {
+      "default_branch": "master",
+      "sha": "c49fc6491934726cdce012194fd17c355c2014a3",
+      "branches": {
+        "master": "c49fc6491934726cdce012194fd17c355c2014a3"
+      }
+    },
+    "mcpewpew/mrplow": {
+      "default_branch": "master",
+      "sha": "865f76924c37060236ec60a3d7c136637debc6f5",
+      "branches": {
+        "master": "865f76924c37060236ec60a3d7c136637debc6f5"
+      }
+    },
+    "mcpewpew/shagumount": {
+      "default_branch": "master",
+      "sha": "845b98efd714abcb0f30265893ee7c217becfe91",
+      "branches": {
+        "master": "845b98efd714abcb0f30265893ee7c217becfe91"
+      }
+    },
+    "mcpewpew/simpleactionsets": {
+      "default_branch": "master",
+      "sha": "081327a9ed780038ad8ef90a7f699b7a37d31a3c",
+      "branches": {
+        "master": "081327a9ed780038ad8ef90a7f699b7a37d31a3c"
+      }
+    },
+    "mcpewpew/simpleminimap": {
+      "default_branch": "master",
+      "sha": "b02e7be9995ecac8c7055f2f31b5d661fe65cf38",
+      "branches": {
+        "master": "b02e7be9995ecac8c7055f2f31b5d661fe65cf38"
+      }
+    },
+    "mcpewpew/turtlesnacks": {
+      "default_branch": "main",
+      "sha": "4c0f3b1746ee06e020d4ea94434e8fd90e94f3dc",
+      "branches": {
+        "main": "4c0f3b1746ee06e020d4ea94434e8fd90e94f3dc"
+      }
+    },
+    "mdmcclel/totemtimers-enhanced": {
+      "default_branch": "master",
+      "sha": "dd1702bcd16f697473b4e74aec7824638c01e2ee",
+      "branches": {
+        "master": "dd1702bcd16f697473b4e74aec7824638c01e2ee"
       },
       "latest_tag": "1.3"
     },
-    "zaicopx/tourguidevanilla": {
+    "medeah/egnar": {
       "default_branch": "master",
-      "sha": "e61f87fb014326b4004652d0bf6d465d24e932c6",
+      "sha": "23a6b3ea9efe8eacce395e97a16a011958a0560f",
       "branches": {
-        "master": "e61f87fb014326b4004652d0bf6d465d24e932c6"
-      }
-    },
-    "blueager2/tourguideturtle": {
-      "default_branch": "master",
-      "sha": "83235bec8fc1a75ea90cdd3cc6387d3991b93927",
-      "branches": {
-        "master": "83235bec8fc1a75ea90cdd3cc6387d3991b93927"
+        "master": "23a6b3ea9efe8eacce395e97a16a011958a0560f"
       },
-      "latest_tag": "1.1.3-beta"
+      "latest_tag": "0.1"
     },
-    "cralor/tomtomvanilla": {
-      "default_branch": "master",
-      "sha": "075a6840535da89526c6469e7eb27a1863f9dba1",
-      "branches": {
-        "master": "075a6840535da89526c6469e7eb27a1863f9dba1"
-      },
-      "latest_tag": "1.0.1-beta"
-    },
-    "gescht/tomtom": {
-      "default_branch": "master",
-      "sha": "55085d3c5a420b659833e5afee2aba13bcce4d18",
-      "branches": {
-        "master": "55085d3c5a420b659833e5afee2aba13bcce4d18"
-      }
-    },
-    "cralor/tourguidevanilla": {
-      "default_branch": "master",
-      "sha": "bc94ceaf497d6b524a2f2dced3ef1fededa1bfa1",
-      "branches": {
-        "master": "bc94ceaf497d6b524a2f2dced3ef1fededa1bfa1"
-      },
-      "latest_tag": "1.1.3-beta"
-    },
-    "vempz/tourguidevanilla": {
-      "default_branch": "master",
-      "sha": "6cda6009c824ec24d652b9fd3f2c6b26c86a3eb2",
-      "branches": {
-        "master": "6cda6009c824ec24d652b9fd3f2c6b26c86a3eb2"
-      },
-      "latest_tag": "1.0.6-beta"
-    },
-    "wouatwouat/tomtom": {
-      "default_branch": "master",
-      "sha": "b87129dfe74141e77d5e0be4d4ede4cacbb6ef17",
-      "branches": {
-        "master": "b87129dfe74141e77d5e0be4d4ede4cacbb6ef17"
-      }
-    },
-    "vatichild/gudaplates": {
+    "megaevilz/mlooklock": {
       "default_branch": "main",
-      "sha": "e5204a4e8035257bbdb66234eab0494231443d5c",
+      "sha": "ca36e990a7d01993d28d3d11febcf6d7f0fa86f7",
       "branches": {
-        "main": "e5204a4e8035257bbdb66234eab0494231443d5c"
-      },
-      "latest_tag": "1.3.5"
-    },
-    "cosminpop/twthreat": {
-      "default_branch": "master",
-      "sha": "07b97382a7f72f0c8d65f20e47a50b843b073ebf",
-      "branches": {
-        "master": "07b97382a7f72f0c8d65f20e47a50b843b073ebf"
+        "main": "ca36e990a7d01993d28d3d11febcf6d7f0fa86f7"
       }
     },
-    "eqomdx/equadisthreatmeter": {
-      "default_branch": "main",
-      "sha": "a82bc8be2a213ac5f752ba4ec929d336c075c193",
+    "megaevilz/rightclickmodifier": {
+      "default_branch": "master",
+      "sha": "dc40936c0991230c8e92bc099b26c022510603a1",
       "branches": {
-        "main": "a82bc8be2a213ac5f752ba4ec929d336c075c193"
+        "master": "dc40936c0991230c8e92bc099b26c022510603a1"
       }
     },
-    "roby-brok/pfui": {
-      "default_branch": "octo",
-      "sha": "3df77210ad68543dcce39dff96e5d664677acd98",
-      "branches": {
-        "octo": "3df77210ad68543dcce39dff96e5d664677acd98"
-      },
-      "latest_tag": "v9.0.21"
-    },
-    "brues-code/pfui": {
+    "melbaa/adf": {
       "default_branch": "master",
-      "sha": "5815b9e81e1567d7bcb768338876764d30ed5bee",
+      "sha": "b26d774db501a687461ead891985fcc85dee606c",
       "branches": {
-        "master": "5815b9e81e1567d7bcb768338876764d30ed5bee"
-      },
-      "latest_tag": "v9.0.23"
+        "master": "b26d774db501a687461ead891985fcc85dee606c"
+      }
     },
-    "wurmschwanz/nicedamage-1.12": {
+    "melbaa/apd": {
+      "default_branch": "master",
+      "sha": "0ea3c1b2a1e55b8e1bee9bd21593bcdd5becad84",
+      "branches": {
+        "master": "0ea3c1b2a1e55b8e1bee9bd21593bcdd5becad84"
+      }
+    },
+    "melbaa/manaminder": {
+      "default_branch": "master",
+      "sha": "ababafd952ef3d4b293c0dd9b64f2cc272fc477a",
+      "branches": {
+        "master": "ababafd952ef3d4b293c0dd9b64f2cc272fc477a"
+      },
+      "latest_tag": "v1.7"
+    },
+    "melbaa/smarthealer": {
+      "default_branch": "master",
+      "sha": "3c550f8ee8e185ee223d1a1f5910847fe81e92f9",
+      "branches": {
+        "master": "3c550f8ee8e185ee223d1a1f5910847fe81e92f9"
+      }
+    },
+    "melbaa/sunderarmor": {
+      "default_branch": "master",
+      "sha": "dc5dff076f131d24f61e1fe31b12c03085c88c3e",
+      "branches": {
+        "master": "dc5dff076f131d24f61e1fe31b12c03085c88c3e"
+      }
+    },
+    "melbaa/swapondeath": {
+      "default_branch": "master",
+      "sha": "7cb4dae14c14ae4a9f4887d23d9e9f255f3123f1",
+      "branches": {
+        "master": "7cb4dae14c14ae4a9f4887d23d9e9f255f3123f1"
+      }
+    },
+    "melbaa/tankhelper": {
+      "default_branch": "master",
+      "sha": "9431b5cc6fbb8770e984871c021f6ce3eb3a1ed9",
+      "branches": {
+        "master": "9431b5cc6fbb8770e984871c021f6ce3eb3a1ed9"
+      }
+    },
+    "melbaa/topmeoff": {
+      "default_branch": "master",
+      "sha": "5a3e66b6d9d0996238a2c01b030397344fc19097",
+      "branches": {
+        "master": "5a3e66b6d9d0996238a2c01b030397344fc19097"
+      }
+    },
+    "mentalxgit/lootmonitor": {
       "default_branch": "main",
-      "sha": "bda369919efcfc1313eb0471fd63a5ffe81ab58a",
+      "sha": "90982082f384104f46aabefb2fd4dab093efcf97",
       "branches": {
-        "main": "bda369919efcfc1313eb0471fd63a5ffe81ab58a"
-      },
-      "latest_tag": "v2.1.1"
+        "main": "90982082f384104f46aabefb2fd4dab093efcf97"
+      }
     },
-    "incstk/chronometer-turtle": {
+    "metalgrid/crapfilter": {
       "default_branch": "master",
-      "sha": "1df10c165ec92179079a10ab07bd595376f71657",
+      "sha": "1ab564e2ec7939b01e2203ba0fcade5467b3b7b9",
       "branches": {
-        "master": "1df10c165ec92179079a10ab07bd595376f71657"
+        "master": "1ab564e2ec7939b01e2203ba0fcade5467b3b7b9"
+      },
+      "latest_tag": "v0.2"
+    },
+    "metaroa/lazyscript": {
+      "default_branch": "master",
+      "sha": "97e277bd060924da418becb945e321b54065ad4e",
+      "branches": {
+        "master": "97e277bd060924da418becb945e321b54065ad4e"
+      }
+    },
+    "metaroa/quickheal": {
+      "default_branch": "master",
+      "sha": "33a3172bbcfa930b57bb3f0b9002eb09f99d4760",
+      "branches": {
+        "master": "33a3172bbcfa930b57bb3f0b9002eb09f99d4760"
+      }
+    },
+    "meyyday/onebuttonhunter": {
+      "default_branch": "master",
+      "sha": "25d08ba9e7da6e50805579344baaaa1c0cbc9aaf",
+      "branches": {
+        "master": "25d08ba9e7da6e50805579344baaaa1c0cbc9aaf"
+      }
+    },
+    "michewarr/decursive": {
+      "default_branch": "master",
+      "sha": "70e984187af6ce00466265a4864adee0ae4d0008",
+      "branches": {
+        "master": "70e984187af6ce00466265a4864adee0ae4d0008"
+      }
+    },
+    "michewarr/puppeteer": {
+      "default_branch": "main",
+      "sha": "406330c255118b37956cb31b4b5815b36d7ce9b4",
+      "branches": {
+        "main": "406330c255118b37956cb31b4b5815b36d7ce9b4"
+      }
+    },
+    "michewarr/raidrollbuddy": {
+      "default_branch": "main",
+      "sha": "20b43dcb1750dd5657ebab5d8c0e37ad6973fc9e",
+      "branches": {
+        "main": "20b43dcb1750dd5657ebab5d8c0e37ad6973fc9e"
+      }
+    },
+    "michewarr/shaguplates": {
+      "default_branch": "master",
+      "sha": "0fc82b4e7892d719d3b651ef35bad426ae426e64",
+      "branches": {
+        "master": "0fc82b4e7892d719d3b651ef35bad426ae426e64"
+      }
+    },
+    "mickeypickey/autoquest": {
+      "default_branch": "master",
+      "sha": "0190202588b29d1d7f8bac73845e78ce46301210",
+      "branches": {
+        "master": "0190202588b29d1d7f8bac73845e78ce46301210"
+      },
+      "latest_tag": "v2.0.3"
+    },
+    "midanaaticoss/aux-addon-tsm-flavored-turtle-wow": {
+      "default_branch": "master",
+      "sha": "34fd65c0666636f5c476fbadda8e6ff7042f4fc8",
+      "branches": {
+        "master": "34fd65c0666636f5c476fbadda8e6ff7042f4fc8"
+      }
+    },
+    "mijkrofl/mijksraidassist": {
+      "default_branch": "main",
+      "sha": "a556201bada046e4c4d072d08baf1a638d10710e",
+      "branches": {
+        "main": "a556201bada046e4c4d072d08baf1a638d10710e"
+      }
+    },
+    "mijohansen/shootyepgp": {
+      "default_branch": "master",
+      "sha": "167f1b37b64b068bf0a521a104a02e77b39bf2db",
+      "branches": {
+        "master": "167f1b37b64b068bf0a521a104a02e77b39bf2db"
+      }
+    },
+    "mikefirefly/mouseoversounds_pvp": {
+      "default_branch": "main",
+      "sha": "791787d62a0b0065477bc235f861cf4c2b0b1d5a",
+      "branches": {
+        "main": "791787d62a0b0065477bc235f861cf4c2b0b1d5a"
+      }
+    },
+    "mimiwarmini/consumesmanager": {
+      "default_branch": "main",
+      "sha": "10284dbd9947122a0bd988461c4e7ebf089989fc",
+      "branches": {
+        "main": "10284dbd9947122a0bd988461c4e7ebf089989fc"
+      }
+    },
+    "minexew/zerodb": {
+      "default_branch": "master",
+      "sha": "b77faf7c78b6dcdfa55e7a02c0eb26e798004392",
+      "branches": {
+        "master": "b77faf7c78b6dcdfa55e7a02c0eb26e798004392"
+      },
+      "latest_tag": "r1"
+    },
+    "missdyrella/t-oom-dyrella": {
+      "default_branch": "main",
+      "sha": "98d3118af6aacac22ea3469ce9e510b2ea9a5f23",
+      "branches": {
+        "main": "98d3118af6aacac22ea3469ce9e510b2ea9a5f23"
+      }
+    },
+    "mitjafelicijan/lootatmouse": {
+      "default_branch": "master",
+      "sha": "b9801539d7366c9f17d76c97fde77f8f42a10d75",
+      "branches": {
+        "master": "b9801539d7366c9f17d76c97fde77f8f42a10d75"
+      }
+    },
+    "mitjafelicijan/turtletweaks": {
+      "default_branch": "master",
+      "sha": "91ee7f608a6b35085e8b0be8d6d136210daf3b33",
+      "branches": {
+        "master": "91ee7f608a6b35085e8b0be8d6d136210daf3b33"
+      },
+      "latest_tag": "v0.7"
+    },
+    "mjesp20/shootyepgp": {
+      "default_branch": "master",
+      "sha": "04f2aee0e0ce1a926419b571554a3f1cbcbd54d1",
+      "branches": {
+        "master": "04f2aee0e0ce1a926419b571554a3f1cbcbd54d1"
+      }
+    },
+    "mmesnage/dotimer": {
+      "default_branch": "master",
+      "sha": "90bad43fe9347cdeb5f2640f71f082255f6bb7a5",
+      "branches": {
+        "master": "90bad43fe9347cdeb5f2640f71f082255f6bb7a5"
+      }
+    },
+    "mnemozin/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "48562174a3a1fd861b10ca4c2668625b67ac4e22",
+      "branches": {
+        "master": "48562174a3a1fd861b10ca4c2668625b67ac4e22"
+      }
+    },
+    "mobbeyy/buffblock-tw": {
+      "default_branch": "master",
+      "sha": "da2abfdced4cd74d54cbb352de3da1e31e3fa281",
+      "branches": {
+        "master": "da2abfdced4cd74d54cbb352de3da1e31e3fa281"
+      }
+    },
+    "moiian/ffxivcrosshotbar": {
+      "default_branch": "main",
+      "sha": "7408d6b40d78bb28850cfe291d02836bfa95d14e",
+      "branches": {
+        "main": "7408d6b40d78bb28850cfe291d02836bfa95d14e"
+      },
+      "latest_tag": "FFXIVCrossHotbar_ver1.3"
+    },
+    "moiian/immersivedialogui": {
+      "default_branch": "main",
+      "sha": "6acec0e0c01bbdf846c468c94ac583cd28b33705",
+      "branches": {
+        "main": "6acec0e0c01bbdf846c468c94ac583cd28b33705"
+      },
+      "latest_tag": "1.2"
+    },
+    "mongrul/mobhealth3-kronos4-edition": {
+      "default_branch": "master",
+      "sha": "a08d5fb9c18ed30b6ee99a50be7ba1dc4a16b04a",
+      "branches": {
+        "master": "a08d5fb9c18ed30b6ee99a50be7ba1dc4a16b04a"
+      },
+      "latest_tag": "2.0.3"
+    },
+    "monomode/shagudps": {
+      "default_branch": "master",
+      "sha": "1d32cf9d420a7c793ec022c558941f4532a6c33d",
+      "branches": {
+        "master": "1d32cf9d420a7c793ec022c558941f4532a6c33d"
+      }
+    },
+    "monomode/turtlewow--autolfg": {
+      "default_branch": "master",
+      "sha": "6ec7b8150b44f5fed4891ac31e4d931ca914724f",
+      "branches": {
+        "master": "6ec7b8150b44f5fed4891ac31e4d931ca914724f"
+      }
+    },
+    "monteo/addonorganizer": {
+      "default_branch": "master",
+      "sha": "b11a9485d0060831af67171c26a5107f82f21cf6",
+      "branches": {
+        "master": "b11a9485d0060831af67171c26a5107f82f21cf6"
+      }
+    },
+    "monteo/gfw_feedomatic": {
+      "default_branch": "master",
+      "sha": "2f0586f2fc0efb14ef9d2990056e5822acd97cf8",
+      "branches": {
+        "master": "2f0586f2fc0efb14ef9d2990056e5822acd97cf8"
+      }
+    },
+    "monteo/groupcalendar": {
+      "default_branch": "master",
+      "sha": "41ec2f9313376530fd3854c7cd3ee04834a808db",
+      "branches": {
+        "master": "41ec2f9313376530fd3854c7cd3ee04834a808db"
+      }
+    },
+    "monteo/punschrulle": {
+      "default_branch": "master",
+      "sha": "b181e7b17416e1a52327a0e1b167e4e9acc6e6de",
+      "branches": {
+        "master": "b181e7b17416e1a52327a0e1b167e4e9acc6e6de"
+      }
+    },
+    "monteo/roguepack": {
+      "default_branch": "master",
+      "sha": "1a8d0dba7dd4799e6a1881559665b57b9089f562",
+      "branches": {
+        "master": "1a8d0dba7dd4799e6a1881559665b57b9089f562"
+      }
+    },
+    "monteo/tne_nightfall": {
+      "default_branch": "main",
+      "sha": "c7bbcdfd7a15946513a1e2457ec69225faad1430",
+      "branches": {
+        "main": "c7bbcdfd7a15946513a1e2457ec69225faad1430"
+      }
+    },
+    "montspy/sqminimapfix": {
+      "default_branch": "master",
+      "sha": "407ccee4c0b99db89c8c2191f841d567690c56c0",
+      "branches": {
+        "master": "407ccee4c0b99db89c8c2191f841d567690c56c0"
+      }
+    },
+    "moonshinephoenix/roll-for-vanilla-quiet": {
+      "default_branch": "master",
+      "sha": "ec6518df78c7903ab9229065d9e9d21b2fe4d0e2",
+      "branches": {
+        "master": "ec6518df78c7903ab9229065d9e9d21b2fe4d0e2"
+      }
+    },
+    "morkahja/roarguild": {
+      "default_branch": "main",
+      "sha": "1ba833dab3d546dc165cf9b17207b8c710eeba61",
+      "branches": {
+        "main": "1ba833dab3d546dc165cf9b17207b8c710eeba61"
+      }
+    },
+    "mouzu/totemtimers-enhanced": {
+      "default_branch": "master",
+      "sha": "a4107a83a4f557bced0c00d592a79e8e1abc475b",
+      "branches": {
+        "master": "a4107a83a4f557bced0c00d592a79e8e1abc475b"
+      },
+      "latest_tag": "1.3"
+    },
+    "mouzu/workaroundselfcast": {
+      "default_branch": "master",
+      "sha": "8587d8bd37b00f5f69c969887812cf21749b2e1c",
+      "branches": {
+        "master": "8587d8bd37b00f5f69c969887812cf21749b2e1c"
+      }
+    },
+    "mr-rosh/colorpickerplus": {
+      "default_branch": "master",
+      "sha": "178e7b9980467a70bd353a9afb95db1ebf6b6a0b",
+      "branches": {
+        "master": "178e7b9980467a70bd353a9afb95db1ebf6b6a0b"
+      }
+    },
+    "mr-rosh/lern2spell": {
+      "default_branch": "master",
+      "sha": "eb66f354a363b29c7140edd857ea4cbd01b3d8f5",
+      "branches": {
+        "master": "eb66f354a363b29c7140edd857ea4cbd01b3d8f5"
+      }
+    },
+    "mr-rosh/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "2c9d3e84131dcc12c3f2844b8d369fbde048398f",
+      "branches": {
+        "main": "2c9d3e84131dcc12c3f2844b8d369fbde048398f"
+      }
+    },
+    "mr-rosh/pfui-custommedia": {
+      "default_branch": "main",
+      "sha": "701bee8b249fbe91050e6e3645bf810841704696",
+      "branches": {
+        "main": "701bee8b249fbe91050e6e3645bf810841704696"
+      }
+    },
+    "mr-rosh/warriorhud": {
+      "default_branch": "master",
+      "sha": "692722c7b68e0a3b5590b53f06866568e6c71051",
+      "branches": {
+        "master": "692722c7b68e0a3b5590b53f06866568e6c71051"
       }
     },
     "mrboxie88/chronometer-twow": {
@@ -15053,276 +8363,681 @@
       },
       "latest_tag": "v0.15.2"
     },
-    "judo101/chronometer": {
+    "mrdoufuru/gcdisplay": {
       "default_branch": "master",
-      "sha": "ddb6a1364174cec86594c5a7659b659406861d89",
+      "sha": "3f1b6e973508d1a960f16903074e591e834a741d",
       "branches": {
-        "master": "ddb6a1364174cec86594c5a7659b659406861d89"
+        "master": "3f1b6e973508d1a960f16903074e591e834a741d"
       }
     },
-    "hoys/mikscrollingbattletext": {
-      "default_branch": "master",
-      "sha": "e65811e2bc4a1d622df4fe8567f3629eb0edfa44",
-      "branches": {
-        "master": "e65811e2bc4a1d622df4fe8567f3629eb0edfa44"
-      }
-    },
-    "kameleonuk/notgrid": {
-      "default_branch": "master",
-      "sha": "f088643d297b4195e3971fb305721da436e3ffaf",
-      "branches": {
-        "master": "f088643d297b4195e3971fb305721da436e3ffaf"
-      }
-    },
-    "igreed1993/greedmeter": {
+    "mrflamberg/hardcoredeath": {
       "default_branch": "main",
-      "sha": "899d7a28f0b4c35e41d6e4b11f4c02668395a22b",
+      "sha": "342ab3eb9468a4f342c75702960909bf9cb5bc8f",
       "branches": {
-        "main": "899d7a28f0b4c35e41d6e4b11f4c02668395a22b"
-      }
-    },
-    "kobeniiiiii/combatledger": {
-      "default_branch": "main",
-      "sha": "515e791a9daaf4a6dc56cc54e05c99fe94c3152a",
-      "branches": {
-        "main": "515e791a9daaf4a6dc56cc54e05c99fe94c3152a"
-      }
-    },
-    "sandreasub/questie-octo": {
-      "default_branch": "main",
-      "sha": "7b33aee91bcdce4e387559222a1428768c08643f",
-      "branches": {
-        "main": "7b33aee91bcdce4e387559222a1428768c08643f"
-      }
-    },
-    "jordanfaz/questie-octo": {
-      "default_branch": "main",
-      "sha": "5e4d74a6d6aeb3b944d2c4660a751c83fea1e772",
-      "branches": {
-        "main": "5e4d74a6d6aeb3b944d2c4660a751c83fea1e772"
-      }
-    },
-    "excinerus/exautocshs": {
-      "default_branch": "main",
-      "sha": "9c1492b2894ba740dee5a7042a9beac780f6d91c",
-      "branches": {
-        "main": "9c1492b2894ba740dee5a7042a9beac780f6d91c"
-      }
-    },
-    "kninib12a/exautocshs": {
-      "default_branch": "main",
-      "sha": "86eef31a96199821d3238a5ea7d97db819a3eae9",
-      "branches": {
-        "main": "86eef31a96199821d3238a5ea7d97db819a3eae9"
-      }
-    },
-    "wurmschwanz/blizznameplatesplus": {
-      "default_branch": "main",
-      "sha": "4fb662bbd67ccda645c779f045fc917ff99006cc",
-      "branches": {
-        "main": "4fb662bbd67ccda645c779f045fc917ff99006cc"
-      }
-    },
-    "otari98/atlas": {
-      "default_branch": "master",
-      "sha": "9179b654672cffcdb1272f29662e44f516e1484c",
-      "branches": {
-        "master": "9179b654672cffcdb1272f29662e44f516e1484c"
-      }
-    },
-    "seven7000/fishingbuddy": {
-      "default_branch": "main",
-      "sha": "de057d0b6ed86f8a8bcfb5588c793dadd35cc53d",
-      "branches": {
-        "main": "de057d0b6ed86f8a8bcfb5588c793dadd35cc53d"
-      }
-    },
-    "buzzkill54/atlasquest": {
-      "default_branch": "master",
-      "sha": "dc9c364566ca173a75a1fd15adc5d35f4c8f3e00",
-      "branches": {
-        "master": "dc9c364566ca173a75a1fd15adc5d35f4c8f3e00"
-      }
-    },
-    "jrc13245/supermacro-turtle-superwow": {
-      "default_branch": "master",
-      "sha": "8f2978b992358ab86757d34107f6ddf890467dc7",
-      "branches": {
-        "master": "8f2978b992358ab86757d34107f6ddf890467dc7"
-      }
-    },
-    "retrocro/unitscan-turtle-hc": {
-      "default_branch": "master",
-      "sha": "0a1002827b611c6cfbefe186329e9e412530f012",
-      "branches": {
-        "master": "0a1002827b611c6cfbefe186329e9e412530f012"
-      }
-    },
-    "shagu/pfui": {
-      "default_branch": "master",
-      "sha": "b2f6df84a93a4ce6adbe1fd8f0372454795151f1",
-      "branches": {
-        "master": "b2f6df84a93a4ce6adbe1fd8f0372454795151f1"
-      }
-    },
-    "redbu11dev/unitplates": {
-      "default_branch": "main",
-      "sha": "1d7cd29b6a196bccafd0d68e6932db4372bd5d0d",
-      "branches": {
-        "main": "1d7cd29b6a196bccafd0d68e6932db4372bd5d0d"
-      }
-    },
-    "pylebecq/necrosis-twow": {
-      "default_branch": "main",
-      "sha": "8d05b2c7adce1f1849b18cffb46a1635087caf82",
-      "branches": {
-        "main": "8d05b2c7adce1f1849b18cffb46a1635087caf82"
+        "main": "342ab3eb9468a4f342c75702960909bf9cb5bc8f"
       },
-      "latest_tag": "1.8.0"
+      "latest_tag": "v2.3.1"
     },
-    "blackhobbit/necrosis-twow": {
-      "default_branch": "main",
-      "sha": "b7eb990c0a92affc543d5e549026ab938a150911",
+    "mrmaffen/instancejournal": {
+      "default_branch": "master",
+      "sha": "05dbfdd6bc7721e74d5bda0a191e6f756d3708ad",
       "branches": {
-        "main": "b7eb990c0a92affc543d5e549026ab938a150911"
+        "master": "05dbfdd6bc7721e74d5bda0a191e6f756d3708ad"
       }
     },
-    "ashigaru/atlasloot": {
-      "default_branch": "master",
-      "sha": "1b0d4971bac9b71adf72111b1943d25e59f6e02a",
+    "mrmaffen/modernmapmarkers": {
+      "default_branch": "main",
+      "sha": "063f2fd8bf932f003c6671ac8a4dfdd73283b8f0",
       "branches": {
-        "master": "1b0d4971bac9b71adf72111b1943d25e59f6e02a"
+        "main": "063f2fd8bf932f003c6671ac8a4dfdd73283b8f0"
       }
     },
-    "shagu/pfquest": {
-      "default_branch": "master",
-      "sha": "104f35678ca39ab1fb78b655f815cc7016f5e0c8",
+    "mrmaffen/pfquest-turtle": {
+      "default_branch": "main",
+      "sha": "6228f8f780e5850013f8612a4e0a45430ca6336d",
       "branches": {
-        "master": "104f35678ca39ab1fb78b655f815cc7016f5e0c8"
-      },
-      "latest_tag": "7.0.1"
-    },
-    "monteo/addonorganizer": {
-      "default_branch": "master",
-      "sha": "b11a9485d0060831af67171c26a5107f82f21cf6",
-      "branches": {
-        "master": "b11a9485d0060831af67171c26a5107f82f21cf6"
+        "main": "6228f8f780e5850013f8612a4e0a45430ca6336d"
       }
     },
-    "tubtubs/vanilla-tweaks": {
-      "default_branch": "master",
-      "sha": "1e18414f8f3535d3436d3dc6a7351d4ea74b50b4",
+    "mrtoffee/caramelnotes": {
+      "default_branch": "main",
+      "sha": "e607ec7c7a3c7d27c7cfcd391f5fb8a715ce4b07",
       "branches": {
-        "master": "1e18414f8f3535d3436d3dc6a7351d4ea74b50b4"
+        "main": "e607ec7c7a3c7d27c7cfcd391f5fb8a715ce4b07"
       }
     },
-    "brndd/vanilla-tweaks": {
+    "mrtoffee/minimapbuttonbag-turtlewow": {
       "default_branch": "master",
-      "sha": "fbbe31add71b23602d981d70f1a58520fc349b47",
+      "sha": "30088bff0861b6773e79bd4e4236a751777f0f31",
       "branches": {
-        "master": "fbbe31add71b23602d981d70f1a58520fc349b47"
-      },
-      "latest_tag": "v1.6.0"
-    },
-    "hannesmann/vanillafixes": {
-      "default_branch": "main",
-      "sha": "a4c42e6a3f12a841a668359e0027c252989867bd",
-      "branches": {
-        "main": "a4c42e6a3f12a841a668359e0027c252989867bd"
-      },
-      "latest_tag": "v1.5.3"
-    },
-    "balakethelock/superwow": {
-      "default_branch": "master",
-      "sha": "60c05fa1bed338f50092ee73894ee4e3b81b5a65",
-      "branches": {
-        "master": "60c05fa1bed338f50092ee73894ee4e3b81b5a65"
-      },
-      "latest_tag": "Release",
-      "display_version": "v2.2"
-    },
-    "brues-code/nampower": {
-      "default_branch": "main",
-      "sha": "2c7f51cd436e9b0ce88271e84ce5a77c19f2c23b",
-      "branches": {
-        "main": "2c7f51cd436e9b0ce88271e84ce5a77c19f2c23b"
-      },
-      "latest_tag": "v4.6.1"
-    },
-    "brues-code/unitxp_sp3": {
-      "default_branch": "main",
-      "sha": "cedbf4b59776567db954ce38f681af1cbb9f0e1c",
-      "branches": {
-        "main": "cedbf4b59776567db954ce38f681af1cbb9f0e1c"
-      },
-      "latest_tag": "v90"
-    },
-    "brues-code/auctionquerythrottle": {
-      "default_branch": "main",
-      "sha": "27ce3633dfc94714e070dab67cf56f85e1146287",
-      "branches": {
-        "main": "27ce3633dfc94714e070dab67cf56f85e1146287"
-      },
-      "latest_tag": "v1.2.0"
-    },
-    "brues-code/classicapi": {
-      "default_branch": "master",
-      "sha": "fdbe66b05740bc34cef3d93754ac409f6abaa5bb",
-      "branches": {
-        "master": "fdbe66b05740bc34cef3d93754ac409f6abaa5bb"
-      },
-      "latest_tag": "v1.13.3"
-    },
-    "retrocro/turtlewow-mods": {
-      "default_branch": "main",
-      "sha": "aeb405ef9f207bfbd7fb63afb4ffc4e58f3589f9",
-      "branches": {
-        "main": "aeb405ef9f207bfbd7fb63afb4ffc4e58f3589f9"
+        "master": "30088bff0861b6773e79bd4e4236a751777f0f31"
       }
     },
-    "doitsujin/dxvk": {
+    "mtools-top/wiiiui": {
       "default_branch": "master",
-      "sha": "d7ac2580aa274a14a500e74edbe4ec6aae250e4a",
+      "sha": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600",
       "branches": {
-        "master": "d7ac2580aa274a14a500e74edbe4ec6aae250e4a"
-      },
-      "latest_tag": "v3.1"
-    },
-    "isfir/vanillahelpers": {
-      "default_branch": "master",
-      "sha": "4375c03a51778ad440bc14be512e659b39c0c558",
-      "branches": {
-        "master": "4375c03a51778ad440bc14be512e659b39c0c558"
-      },
-      "latest_tag": "v1.1.2"
-    },
-    "marcelinevq/twow-raid-visuals": {
-      "default_branch": "master",
-      "sha": "862af96df93d594b034915893b844eaea051bb9e",
-      "branches": {
-        "master": "862af96df93d594b034915893b844eaea051bb9e"
-      },
-      "latest_tag": "1.4.18"
-    },
-    "seacrabsam/patch-herb": {
-      "default_branch": "main",
-      "sha": "c252bbdc2aef1ac928eb237cf4d28edc21806ed8",
-      "branches": {
-        "main": "c252bbdc2aef1ac928eb237cf4d28edc21806ed8"
+        "master": "c6a6d1dfa68ed80aea8343ad9ec4fcba39588600"
       }
     },
-    "paokkerkir/vanilla-autologin": {
-      "default_branch": "main",
-      "sha": "2665aeb14d9eaaa51f1532c7dc689c6a18b49a73",
+    "muehe/classicdb": {
+      "default_branch": "master",
+      "sha": "e7ecc0f18fd764694b3acc5c3a31d297b1c4eb3e",
       "branches": {
-        "main": "2665aeb14d9eaaa51f1532c7dc689c6a18b49a73"
+        "master": "e7ecc0f18fd764694b3acc5c3a31d297b1c4eb3e"
+      },
+      "latest_tag": "1.0-beta.2"
+    },
+    "muellerj/bloodrage": {
+      "default_branch": "master",
+      "sha": "9095d91c9a74724738601d0b3d814d755aaa5af5",
+      "branches": {
+        "master": "9095d91c9a74724738601d0b3d814d755aaa5af5"
       }
     },
-    "laytya/fubar": {
-      "default_branch": "main",
-      "sha": "2bb40fb180791eae3d144f99d1c672235c61fe5a",
+    "muellerj/threat": {
+      "default_branch": "master",
+      "sha": "9fa3b290ff864eca3e12bedd4cf0ea1f4546a57e",
       "branches": {
-        "main": "2bb40fb180791eae3d144f99d1c672235c61fe5a"
+        "master": "9fa3b290ff864eca3e12bedd4cf0ea1f4546a57e"
+      }
+    },
+    "mxttosierrv/levelrange-turtle-espanol": {
+      "default_branch": "main",
+      "sha": "01a5ae13848d4da7e54321644520126428858992",
+      "branches": {
+        "main": "01a5ae13848d4da7e54321644520126428858992"
+      }
+    },
+    "mymacd/lazyscript": {
+      "default_branch": "master",
+      "sha": "97e277bd060924da418becb945e321b54065ad4e",
+      "branches": {
+        "master": "97e277bd060924da418becb945e321b54065ad4e"
+      }
+    },
+    "naakarg/auctionatorvanillafixed": {
+      "default_branch": "master",
+      "sha": "ac332d5da47462d8d0a01a02dd7ce5226cb7125c",
+      "branches": {
+        "master": "ac332d5da47462d8d0a01a02dd7ce5226cb7125c"
+      }
+    },
+    "nabelon/gatherer": {
+      "default_branch": "master",
+      "sha": "225fdf8fd721c94ccb0495d3559611671797bd51",
+      "branches": {
+        "master": "225fdf8fd721c94ccb0495d3559611671797bd51"
+      }
+    },
+    "nanatot/channel_monitor": {
+      "default_branch": "master",
+      "sha": "3fbd7f205c86f3bc9f6ecd2b8f72c88ca9d9b0c3",
+      "branches": {
+        "master": "3fbd7f205c86f3bc9f6ecd2b8f72c88ca9d9b0c3"
+      }
+    },
+    "nanatot/lockport": {
+      "default_branch": "main",
+      "sha": "7148cb1119c9c8b942eeca2f117de5eabb7c61be",
+      "branches": {
+        "main": "7148cb1119c9c8b942eeca2f117de5eabb7c61be"
+      }
+    },
+    "nanatot/sp_overpower": {
+      "default_branch": "master",
+      "sha": "48cb43aee09bb10becfaa3e460185e7ab6d7f1d7",
+      "branches": {
+        "master": "48cb43aee09bb10becfaa3e460185e7ab6d7f1d7"
+      }
+    },
+    "necroskillz/smartloot": {
+      "default_branch": "master",
+      "sha": "4e06b1800eeb6298d05c9acae07a6ac160185d36",
+      "branches": {
+        "master": "4e06b1800eeb6298d05c9acae07a6ac160185d36"
+      },
+      "latest_tag": "v1.1"
+    },
+    "nedlinin/necrosis-twow": {
+      "default_branch": "main",
+      "sha": "91a40cb87a8a452c7882e3e2dc32683883f7cc67",
+      "branches": {
+        "main": "91a40cb87a8a452c7882e3e2dc32683883f7cc67"
+      }
+    },
+    "nefalas/gatherer": {
+      "default_branch": "master",
+      "sha": "bf4cccdaf8dde5be933cc28c8c40379f8fdc56a6",
+      "branches": {
+        "master": "bf4cccdaf8dde5be933cc28c8c40379f8fdc56a6"
+      }
+    },
+    "neguszek/sleepypeon": {
+      "default_branch": "main",
+      "sha": "979da6c7e3f6f70c37d1778dcbb00f462d7d4165",
+      "branches": {
+        "main": "979da6c7e3f6f70c37d1778dcbb00f462d7d4165"
+      }
+    },
+    "nehswu/altoholic_vanilla": {
+      "default_branch": "master",
+      "sha": "d6929562ecbcd562dccba285935ecd36ee905435",
+      "branches": {
+        "master": "d6929562ecbcd562dccba285935ecd36ee905435"
+      },
+      "latest_tag": "1.0.9"
+    },
+    "nehswu/minimapbuttonbag-turtlewow": {
+      "default_branch": "master",
+      "sha": "8629d64c329988fdff3db9e221bc1be9ca3d26d1",
+      "branches": {
+        "master": "8629d64c329988fdff3db9e221bc1be9ca3d26d1"
+      },
+      "latest_tag": "v0.508"
+    },
+    "nehswu/zui": {
+      "default_branch": "master",
+      "sha": "575497213b50aa583224a59a44216d04fb0ee1bd",
+      "branches": {
+        "master": "575497213b50aa583224a59a44216d04fb0ee1bd"
+      }
+    },
+    "neimad-mp/framefade": {
+      "default_branch": "main",
+      "sha": "70e00676afb21fcb2be677bbb1bf1af8cf57cb24",
+      "branches": {
+        "main": "70e00676afb21fcb2be677bbb1bf1af8cf57cb24"
+      }
+    },
+    "neimad-mp/hcdeaths": {
+      "default_branch": "main",
+      "sha": "15e16fa4ad80c3b89f4b0dc27318ca6362faa713",
+      "branches": {
+        "main": "15e16fa4ad80c3b89f4b0dc27318ca6362faa713"
+      }
+    },
+    "neimad-mp/hcrank": {
+      "default_branch": "main",
+      "sha": "d28d9bbbc6642de85c34558db963c513177dbec8",
+      "branches": {
+        "main": "d28d9bbbc6642de85c34558db963c513177dbec8"
+      }
+    },
+    "neimad-mp/hcwarn": {
+      "default_branch": "main",
+      "sha": "fa5aff09992d412a6079f5289b0d3b3b81b037b1",
+      "branches": {
+        "main": "fa5aff09992d412a6079f5289b0d3b3b81b037b1"
+      }
+    },
+    "neimad-mp/pizzaslices": {
+      "default_branch": "main",
+      "sha": "59bcdda1e70a7f3f93362fbe4d0778f6c3e9c867",
+      "branches": {
+        "main": "59bcdda1e70a7f3f93362fbe4d0778f6c3e9c867"
+      }
+    },
+    "neimad-mp/turtlecount": {
+      "default_branch": "main",
+      "sha": "f13d103f056431b5073f0ffe40ace550f61f4076",
+      "branches": {
+        "main": "f13d103f056431b5073f0ffe40ace550f61f4076"
+      }
+    },
+    "nelethor/battlemusic": {
+      "default_branch": "main",
+      "sha": "95beea1354136be4e9fcdd6aa2e3d7243d496f61",
+      "branches": {
+        "main": "95beea1354136be4e9fcdd6aa2e3d7243d496f61"
+      }
+    },
+    "nelethor/shagudps": {
+      "default_branch": "master",
+      "sha": "fbf851affe40cd38a4cb6d9e000c5d5defe31c04",
+      "branches": {
+        "master": "fbf851affe40cd38a4cb6d9e000c5d5defe31c04"
+      }
+    },
+    "nemanuel/forged_mapnotes": {
+      "default_branch": "main",
+      "sha": "ef4ee14d1b94a55312d23aab0ddfac8eb9cea1b7",
+      "branches": {
+        "main": "ef4ee14d1b94a55312d23aab0ddfac8eb9cea1b7"
+      }
+    },
+    "nemanuel/forged_pethappiness": {
+      "default_branch": "main",
+      "sha": "989cfebeb5a938e1dc49f7ff1b615063b7c5e53d",
+      "branches": {
+        "main": "989cfebeb5a938e1dc49f7ff1b615063b7c5e53d"
+      }
+    },
+    "nemanuel/forged_sellallgrays": {
+      "default_branch": "main",
+      "sha": "308a2e673f71e398c1e32f30b22c195630da9e6a",
+      "branches": {
+        "main": "308a2e673f71e398c1e32f30b22c195630da9e6a"
+      }
+    },
+    "neolectron/aux-addon": {
+      "default_branch": "master",
+      "sha": "419160eb4ddd3f55c1f570944ef492f51eab7222",
+      "branches": {
+        "master": "419160eb4ddd3f55c1f570944ef492f51eab7222"
+      }
+    },
+    "neolectron/betterhelp": {
+      "default_branch": "master",
+      "sha": "235d6e291e5d24afe9be29a0518dbd005d26f7a1",
+      "branches": {
+        "master": "235d6e291e5d24afe9be29a0518dbd005d26f7a1"
+      }
+    },
+    "nerque/guidecreator": {
+      "default_branch": "master",
+      "sha": "36d92e3e9ec730991e8e65ca11d8310751d6142e",
+      "branches": {
+        "master": "36d92e3e9ec730991e8e65ca11d8310751d6142e"
+      }
+    },
+    "newcomerblack/shootyepgp-sp": {
+      "default_branch": "master",
+      "sha": "ea8c6a5dbd9fe1f94d841a93ff337124831c9fbc",
+      "branches": {
+        "master": "ea8c6a5dbd9fe1f94d841a93ff337124831c9fbc"
+      }
+    },
+    "neyacinu/lazyscript": {
+      "default_branch": "master",
+      "sha": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92",
+      "branches": {
+        "master": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92"
+      }
+    },
+    "niclaseriksen/4hmhelper": {
+      "default_branch": "main",
+      "sha": "2d270895ab5b2e645e70045a60043d4f2bb466da",
+      "branches": {
+        "main": "2d270895ab5b2e645e70045a60043d4f2bb466da"
+      }
+    },
+    "niclaseriksen/bagshui": {
+      "default_branch": "main",
+      "sha": "6104959ea36dcfb7b672d2f25c768faf54de963f",
+      "branches": {
+        "main": "6104959ea36dcfb7b672d2f25c768faf54de963f"
+      }
+    },
+    "niclaseriksen/feid": {
+      "default_branch": "main",
+      "sha": "70bf73a175b3f4f4d837b563fc4fcbdb6419bf4c",
+      "branches": {
+        "main": "70bf73a175b3f4f4d837b563fc4fcbdb6419bf4c"
+      }
+    },
+    "niclaseriksen/profesjonell": {
+      "default_branch": "main",
+      "sha": "5c1c57e5a2f8ebc86a0535c9b776ffc71c525c50",
+      "branches": {
+        "main": "5c1c57e5a2f8ebc86a0535c9b776ffc71c525c50"
+      }
+    },
+    "nicoleharding61-netizen/roll-for-vanilla": {
+      "default_branch": "master",
+      "sha": "05b964006ec4b9dd35decc0581fd84ddf78cb343",
+      "branches": {
+        "master": "05b964006ec4b9dd35decc0581fd84ddf78cb343"
+      }
+    },
+    "nidski-wow/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "d9d071390632054912b058e7400c21d4c77801ef",
+      "branches": {
+        "master": "d9d071390632054912b058e7400c21d4c77801ef"
+      }
+    },
+    "nighttripperid/clevermacro": {
+      "default_branch": "master",
+      "sha": "7b85b4c4e59cfea121e5460dfc19e0dde8c89472",
+      "branches": {
+        "master": "7b85b4c4e59cfea121e5460dfc19e0dde8c89472"
+      }
+    },
+    "nikki1993/lootblare": {
+      "default_branch": "master",
+      "sha": "c4b5031f3f7f41c6c05ced84b9f8d0836acb6de0",
+      "branches": {
+        "master": "c4b5031f3f7f41c6c05ced84b9f8d0836acb6de0"
+      }
+    },
+    "nikki1993/rinse": {
+      "default_branch": "master",
+      "sha": "3e178040e50e4dc584219cdb1cba901dccfae390",
+      "branches": {
+        "master": "3e178040e50e4dc584219cdb1cba901dccfae390"
+      }
+    },
+    "nikoichu/autobuff-turtle": {
+      "default_branch": "main",
+      "sha": "5d9bb8404ac80d344c3b4a8c3cf98015e0170d7b",
+      "branches": {
+        "main": "5d9bb8404ac80d344c3b4a8c3cf98015e0170d7b"
+      }
+    },
+    "nimeral/auctionatorvanilla": {
+      "default_branch": "master",
+      "sha": "90c109351034d59e5987d9efa53989dcfe3eff62",
+      "branches": {
+        "master": "90c109351034d59e5987d9efa53989dcfe3eff62"
+      }
+    },
+    "nishizhumagu/unicodefont": {
+      "default_branch": "master",
+      "sha": "f19092f3bf49b5303f9bba16f45d51397b610c0a",
+      "branches": {
+        "master": "f19092f3bf49b5303f9bba16f45d51397b610c0a"
+      }
+    },
+    "noaf-guild/automasterlooter": {
+      "default_branch": "master",
+      "sha": "813fb146b5f1f98abe7e53461d9a6673b0360ff9",
+      "branches": {
+        "master": "813fb146b5f1f98abe7e53461d9a6673b0360ff9"
+      }
+    },
+    "nobrains21/wiiiui": {
+      "default_branch": "master",
+      "sha": "530ade4ef544e1cf8cb269a579c5c8f2dd9abff2",
+      "branches": {
+        "master": "530ade4ef544e1cf8cb269a579c5c8f2dd9abff2"
+      }
+    },
+    "nocarea/totemtimers-enhanced-totemic-recall": {
+      "default_branch": "master",
+      "sha": "383d05cb08dc32258b568222470204ba80da23f0",
+      "branches": {
+        "master": "383d05cb08dc32258b568222470204ba80da23f0"
+      }
+    },
+    "noeek/quiver": {
+      "default_branch": "main",
+      "sha": "6d153506f4f46cc4331e64674f7789626ea71a7a",
+      "branches": {
+        "main": "6d153506f4f46cc4331e64674f7789626ea71a7a"
+      }
+    },
+    "noo0b1/followmeenhanced": {
+      "default_branch": "master",
+      "sha": "53bf3f88b860ca4bdd184edfa07e08689398fcf0",
+      "branches": {
+        "master": "53bf3f88b860ca4bdd184edfa07e08689398fcf0"
+      }
+    },
+    "noranbits/questtranslator": {
+      "default_branch": "master",
+      "sha": "fd40fc25a4eab5495ac0257305cbb4998cf7777f",
+      "branches": {
+        "master": "fd40fc25a4eab5495ac0257305cbb4998cf7777f"
+      }
+    },
+    "noravar/iwinenhanced": {
+      "default_branch": "main",
+      "sha": "b6c4c558fb37c658b2582819aa4fd1097ed36d7f",
+      "branches": {
+        "main": "b6c4c558fb37c658b2582819aa4fd1097ed36d7f"
+      }
+    },
+    "northyn/chroniclespi": {
+      "default_branch": "master",
+      "sha": "b26612714ace6183b62d5d10726e8d3db126467e",
+      "branches": {
+        "master": "b26612714ace6183b62d5d10726e8d3db126467e"
+      }
+    },
+    "nosrednaski/gfw_feedomatic": {
+      "default_branch": "master",
+      "sha": "b644157b769edc4f2e5afcfd971be1aee6866fd2",
+      "branches": {
+        "master": "b644157b769edc4f2e5afcfd971be1aee6866fd2"
+      }
+    },
+    "nostalgiageek/vanillaguide-plus": {
+      "default_branch": "main",
+      "sha": "104c357e70111433318e11c9f5943ac6b8bd8a43",
+      "branches": {
+        "main": "104c357e70111433318e11c9f5943ac6b8bd8a43"
+      }
+    },
+    "notkayoko/elitewarriorttd": {
+      "default_branch": "main",
+      "sha": "de04aff8771ea76920b2ec89ee9046ee21b9f8ae",
+      "branches": {
+        "main": "de04aff8771ea76920b2ec89ee9046ee21b9f8ae"
+      }
+    },
+    "npeschke/bmloot": {
+      "default_branch": "master",
+      "sha": "73585e353410ea0bbf205fc22ef337ad3c850d5b",
+      "branches": {
+        "master": "73585e353410ea0bbf205fc22ef337ad3c850d5b"
+      }
+    },
+    "numielle/dousereminder": {
+      "default_branch": "master",
+      "sha": "a5b3e2b7366b4b12e12afed3fd788612d381078f",
+      "branches": {
+        "master": "a5b3e2b7366b4b12e12afed3fd788612d381078f"
+      }
+    },
+    "numielle/easycloak": {
+      "default_branch": "master",
+      "sha": "2cf5e3e0a896e63a164e9cde81b00a7492b74f15",
+      "branches": {
+        "master": "2cf5e3e0a896e63a164e9cde81b00a7492b74f15"
+      },
+      "latest_tag": "v0.2"
+    },
+    "numielle/easyloot": {
+      "default_branch": "master",
+      "sha": "c3ee8e6d4970db3df35ae0d5fb7484e29cd9a6f5",
+      "branches": {
+        "master": "c3ee8e6d4970db3df35ae0d5fb7484e29cd9a6f5"
+      }
+    },
+    "numielle/easyress": {
+      "default_branch": "master",
+      "sha": "57d355827c0f36198ade3883f0654f7845091ad6",
+      "branches": {
+        "master": "57d355827c0f36198ade3883f0654f7845091ad6"
+      }
+    },
+    "numielle/priestbinds": {
+      "default_branch": "master",
+      "sha": "3be3a65d19126917bb0aff6e39b0e55ebe76082f",
+      "branches": {
+        "master": "3be3a65d19126917bb0aff6e39b0e55ebe76082f"
+      }
+    },
+    "numielle/worldbossalert": {
+      "default_branch": "master",
+      "sha": "17246aa8f3c73e0f6a357fbbad8ed989dbfffd40",
+      "branches": {
+        "master": "17246aa8f3c73e0f6a357fbbad8ed989dbfffd40"
+      }
+    },
+    "obble/modguide": {
+      "default_branch": "master",
+      "sha": "4863fcefbc84680f05d3d989704b2eb983f216f2",
+      "branches": {
+        "master": "4863fcefbc84680f05d3d989704b2eb983f216f2"
+      }
+    },
+    "obszczymucha/bugsack": {
+      "default_branch": "master",
+      "sha": "055b047896ff60f22dc81de6eb4e0f2a095ec5a6",
+      "branches": {
+        "master": "055b047896ff60f22dc81de6eb4e0f2a095ec5a6"
+      }
+    },
+    "obszczymucha/roll-for-vanilla": {
+      "default_branch": "master",
+      "sha": "e70200790b79a8d8650126d2a5c795d69a0bba44",
+      "branches": {
+        "master": "e70200790b79a8d8650126d2a5c795d69a0bba44"
+      },
+      "latest_tag": "v4.6.5"
+    },
+    "oclavero/guidecreator": {
+      "default_branch": "master",
+      "sha": "36d92e3e9ec730991e8e65ca11d8310751d6142e",
+      "branches": {
+        "master": "36d92e3e9ec730991e8e65ca11d8310751d6142e"
+      }
+    },
+    "ohforest/quiver": {
+      "default_branch": "main",
+      "sha": "8d778d753e749ca4cd317ab80d2241cb24368372",
+      "branches": {
+        "main": "8d778d753e749ca4cd317ab80d2241cb24368372"
+      },
+      "latest_tag": "v2.7.1"
+    },
+    "oldmanalpha/aux-addon": {
+      "default_branch": "master",
+      "sha": "c25ad2baeb2e8fd220166239be6a2f53443f5250",
+      "branches": {
+        "master": "c25ad2baeb2e8fd220166239be6a2f53443f5250"
+      }
+    },
+    "oldmanalpha/fasttot": {
+      "default_branch": "main",
+      "sha": "a001f678d24ac14146c8ee20f73dd54a1fcdfde9",
+      "branches": {
+        "main": "a001f678d24ac14146c8ee20f73dd54a1fcdfde9"
+      },
+      "latest_tag": "v1.0"
+    },
+    "oldmanalpha/healersmate": {
+      "default_branch": "main",
+      "sha": "533636c4f63317d0cca7b576e315dddea27c8201",
+      "branches": {
+        "main": "533636c4f63317d0cca7b576e315dddea27c8201"
+      }
+    },
+    "oldmanalpha/messagebox": {
+      "default_branch": "main",
+      "sha": "d229d8bf01f91c391c9ff4bf3ac2cdb74f3e44ed",
+      "branches": {
+        "main": "d229d8bf01f91c391c9ff4bf3ac2cdb74f3e44ed"
+      }
+    },
+    "oldmanalpha/puppeteer": {
+      "default_branch": "main",
+      "sha": "7fa9db6cc1032852733c0dbf77693c881719dbfd",
+      "branches": {
+        "main": "7fa9db6cc1032852733c0dbf77693c881719dbfd"
+      },
+      "latest_tag": "v1.1.3"
+    },
+    "oldmanalpha/shagutweaks": {
+      "default_branch": "master",
+      "sha": "470e68a239b65d4001fe7d1b145a563413391217",
+      "branches": {
+        "master": "470e68a239b65d4001fe7d1b145a563413391217"
+      }
+    },
+    "oldmanalpha/turtleroleplayinghelper": {
+      "default_branch": "main",
+      "sha": "b044baf0e04ad5551e23cf46d1e42c5cbde9ff75",
+      "branches": {
+        "main": "b044baf0e04ad5551e23cf46d1e42c5cbde9ff75"
+      }
+    },
+    "oldmanalpha/turtlerp": {
+      "default_branch": "main",
+      "sha": "f82cf3ba85dc5a76a342bf1dcc2ac2feb44232d9",
+      "branches": {
+        "main": "f82cf3ba85dc5a76a342bf1dcc2ac2feb44232d9"
+      },
+      "latest_tag": "1.1.1-Optimized"
+    },
+    "oldmanalpha/unitxp_sp3_addon": {
+      "default_branch": "latest",
+      "sha": "dbbf4f0f2fef33c1e50e9a4f2fd3640796ac0999",
+      "branches": {
+        "latest": "dbbf4f0f2fef33c1e50e9a4f2fd3640796ac0999"
+      }
+    },
+    "oleksii-pavlikovskii-eleks-com/omnicc": {
+      "default_branch": "master",
+      "sha": "fd60e8570be099ae4975afb3da4242b48d9a6311",
+      "branches": {
+        "master": "fd60e8570be099ae4975afb3da4242b48d9a6311"
+      }
+    },
+    "oleksii-pavlikovskii-eleks-com/sp_revenge": {
+      "default_branch": "main",
+      "sha": "e19426df9bc586cefd2cc39ae61cfea549b6fd59",
+      "branches": {
+        "main": "e19426df9bc586cefd2cc39ae61cfea549b6fd59"
+      }
+    },
+    "onnateldome/grindspots": {
+      "default_branch": "master",
+      "sha": "23a40786ce3066568c64fbfca500404a593f1db4",
+      "branches": {
+        "master": "23a40786ce3066568c64fbfca500404a593f1db4"
+      }
+    },
+    "oozgul/tframes": {
+      "default_branch": "main",
+      "sha": "1fde9bce6df33f19c8209a778e4767b05a761ce8",
+      "branches": {
+        "main": "1fde9bce6df33f19c8209a778e4767b05a761ce8"
+      }
+    },
+    "opcow/buffreminder": {
+      "default_branch": "master",
+      "sha": "db965f861184db02925fc2e7efdbada46de2a056",
+      "branches": {
+        "master": "db965f861184db02925fc2e7efdbada46de2a056"
+      },
+      "latest_tag": "1.2"
+    },
+    "or0bas/immersivedialogui": {
+      "default_branch": "main",
+      "sha": "6a3eb0afe136921a9bed9fe5fa2c9b7f787b0625",
+      "branches": {
+        "main": "6a3eb0afe136921a9bed9fe5fa2c9b7f787b0625"
+      }
+    },
+    "orange-pig/bubbles": {
+      "default_branch": "main",
+      "sha": "fbce2aa48e1f9e6052d8b613ca79194636906725",
+      "branches": {
+        "main": "fbce2aa48e1f9e6052d8b613ca79194636906725"
+      }
+    },
+    "orange-pig/decursive": {
+      "default_branch": "master",
+      "sha": "53e3ff5110f7c8ffe3401093d8779cc7481f2ef3",
+      "branches": {
+        "master": "53e3ff5110f7c8ffe3401093d8779cc7481f2ef3"
+      }
+    },
+    "orfc/chatlootbidder": {
+      "default_branch": "master",
+      "sha": "faba50a00e66ada8c20e70b542d23081450d2656",
+      "branches": {
+        "master": "faba50a00e66ada8c20e70b542d23081450d2656"
+      }
+    },
+    "orfc/notchatlootbidder": {
+      "default_branch": "master",
+      "sha": "45576166ef12bd33f9c3eba189f8fc337a1d7d0e",
+      "branches": {
+        "master": "45576166ef12bd33f9c3eba189f8fc337a1d7d0e"
       }
     },
     "otari98/_lazypig": {
@@ -15332,75 +9047,25 @@
         "master": "155d892dc5297a46186c66da9046ccc8251abfde"
       }
     },
-    "schaka/getspellinfovanilla": {
+    "otari98/actionbarprofiles": {
       "default_branch": "master",
-      "sha": "670281584e893cf636af59258a237637e076767c",
+      "sha": "b474c145e365466e3b00fc4375489dc7e95a108a",
       "branches": {
-        "master": "670281584e893cf636af59258a237637e076767c"
+        "master": "b474c145e365466e3b00fc4375489dc7e95a108a"
       }
     },
-    "krekog/specialtalentui": {
+    "otari98/artisan": {
       "default_branch": "main",
-      "sha": "7332d3e7fd5377eaabfd547d79dddb3e71381045",
+      "sha": "e0ad216e86764120003388d1219574cad715302a",
       "branches": {
-        "main": "7332d3e7fd5377eaabfd547d79dddb3e71381045"
+        "main": "e0ad216e86764120003388d1219574cad715302a"
       }
     },
-    "laytya/tomtom-twow": {
+    "otari98/atlas": {
       "default_branch": "master",
-      "sha": "a9c8af10c0d17e4705a2be1cb5e4ab3d71a34ba0",
+      "sha": "9179b654672cffcdb1272f29662e44f516e1484c",
       "branches": {
-        "master": "a9c8af10c0d17e4705a2be1cb5e4ab3d71a34ba0"
-      }
-    },
-    "roby-brok/pfquest-octo": {
-      "default_branch": "master",
-      "sha": "c4d29afe690193ad673bd84d1299fa56665a20a2",
-      "branches": {
-        "master": "c4d29afe690193ad673bd84d1299fa56665a20a2"
-      },
-      "latest_tag": "1.3.1"
-    },
-    "c4rcer/atlas-cfm": {
-      "default_branch": "main",
-      "sha": "9a9936a1923fd503ba8abda375371e747a2a2cff",
-      "branches": {
-        "main": "9a9936a1923fd503ba8abda375371e747a2a2cff"
-      }
-    },
-    "eqomdx/atlas-cfm-destinationclick": {
-      "default_branch": "main",
-      "sha": "9d92e187cb327290feccf55542d5d3e05215a2e2",
-      "branches": {
-        "main": "9d92e187cb327290feccf55542d5d3e05215a2e2"
-      }
-    },
-    "jrc13245/_lazypig": {
-      "default_branch": "master",
-      "sha": "9319eeb79bd39d7952bc09ee62e62c303c8deee6",
-      "branches": {
-        "master": "9319eeb79bd39d7952bc09ee62e62c303c8deee6"
-      }
-    },
-    "greendam/theorycraft-turtle": {
-      "default_branch": "master",
-      "sha": "10d128aa3855c3fa10cb3609e121e272fba5b1a0",
-      "branches": {
-        "master": "10d128aa3855c3fa10cb3609e121e272fba5b1a0"
-      }
-    },
-    "roby-brok/mikscrollingbattletext": {
-      "default_branch": "octo",
-      "sha": "6169f104c873e3c90605339a4494b983892c5978",
-      "branches": {
-        "octo": "6169f104c873e3c90605339a4494b983892c5978"
-      }
-    },
-    "karstenbade/simpleactionsets": {
-      "default_branch": "master",
-      "sha": "ac5162e195513d3658fea3f6ff91a90b0a549cb0",
-      "branches": {
-        "master": "ac5162e195513d3658fea3f6ff91a90b0a549cb0"
+        "master": "9179b654672cffcdb1272f29662e44f516e1484c"
       }
     },
     "otari98/atlasquest": {
@@ -15410,159 +9075,379 @@
         "master": "d4e8d00b56aff09a80a3254b0cdee8d5b4842668"
       }
     },
-    "jordanfaz/atlasloot": {
+    "otari98/automasterlooter": {
+      "default_branch": "master",
+      "sha": "d28d1a0873209bb5933a309e46c93ee3bcbb6f68",
+      "branches": {
+        "master": "d28d1a0873209bb5933a309e46c93ee3bcbb6f68"
+      }
+    },
+    "otari98/aux-addon": {
+      "default_branch": "master",
+      "sha": "7d4b7f4591546345e43237684f8f957e5505e415",
+      "branches": {
+        "master": "7d4b7f4591546345e43237684f8f957e5505e415"
+      }
+    },
+    "otari98/bananabar": {
+      "default_branch": "master",
+      "sha": "8ea75d51c39c8a17b48a1d586d859e4887cd17fb",
+      "branches": {
+        "master": "8ea75d51c39c8a17b48a1d586d859e4887cd17fb"
+      }
+    },
+    "otari98/bettercharacterstats": {
       "default_branch": "main",
-      "sha": "4e1a18135b029986af1fd47ac86a2f1b65e20865",
+      "sha": "0d5d84f42267b20263cb1b5aaaa8a55f08b227d4",
       "branches": {
-        "main": "4e1a18135b029986af1fd47ac86a2f1b65e20865"
+        "main": "0d5d84f42267b20263cb1b5aaaa8a55f08b227d4"
       }
     },
-    "thezephyrsong/_lazypig": {
+    "otari98/decursive": {
       "default_branch": "master",
-      "sha": "ee15ba71a9afdf5c8c74904ec07778b9f03d2a7a",
+      "sha": "bc6df9e9b5e3f643b3857d5b9fba8127ab4f8163",
       "branches": {
-        "master": "ee15ba71a9afdf5c8c74904ec07778b9f03d2a7a"
+        "master": "bc6df9e9b5e3f643b3857d5b9fba8127ab4f8163"
       }
     },
-    "brutaliccus/ichalaunch": {
+    "otari98/fullsack": {
       "default_branch": "master",
-      "sha": "5c502023d0ecd077c868f1cde7118e1001601178",
+      "sha": "8ce18159d3a3c3af415252096ad2294205973a6d",
       "branches": {
-        "master": "5c502023d0ecd077c868f1cde7118e1001601178"
-      },
-      "latest_tag": "v1.6.4"
-    },
-    "fiurs-hearth/battlemusic": {
-      "default_branch": "master",
-      "sha": "e92c913c3366dbfb7dc5cd97c67e36dd0d4440c7",
-      "branches": {
-        "master": "e92c913c3366dbfb7dc5cd97c67e36dd0d4440c7"
+        "master": "8ce18159d3a3c3af415252096ad2294205973a6d"
       }
     },
-    "brues-code/auctionator": {
+    "otari98/healcomm": {
+      "default_branch": "master",
+      "sha": "b53baabfa09eeac140980dd2b26f67e3aac76752",
+      "branches": {
+        "master": "b53baabfa09eeac140980dd2b26f67e3aac76752"
+      }
+    },
+    "otari98/masterlootbyclass": {
+      "default_branch": "master",
+      "sha": "3981dbf0f3c108f7ed7d6c4b58a05585cfb90105",
+      "branches": {
+        "master": "3981dbf0f3c108f7ed7d6c4b58a05585cfb90105"
+      }
+    },
+    "otari98/mopgeartooltips": {
+      "default_branch": "master",
+      "sha": "b3af2843dbcd77376671a663d45f996743b35958",
+      "branches": {
+        "master": "b3af2843dbcd77376671a663d45f996743b35958"
+      }
+    },
+    "otari98/mre": {
+      "default_branch": "master",
+      "sha": "139c35fcaf14f6717f723bc7a26aeeab3a7f4067",
+      "branches": {
+        "master": "139c35fcaf14f6717f723bc7a26aeeab3a7f4067"
+      }
+    },
+    "otari98/omnicc": {
+      "default_branch": "master",
+      "sha": "fd60e8570be099ae4975afb3da4242b48d9a6311",
+      "branches": {
+        "master": "fd60e8570be099ae4975afb3da4242b48d9a6311"
+      }
+    },
+    "otari98/overhead": {
+      "default_branch": "master",
+      "sha": "f3d3a9eea8bb5c31fd0e540f414bb8a266d1cd38",
+      "branches": {
+        "master": "f3d3a9eea8bb5c31fd0e540f414bb8a266d1cd38"
+      }
+    },
+    "otari98/quiver": {
       "default_branch": "main",
-      "sha": "b321b95287f300167a85fad636b2bf0ff3380ee8",
+      "sha": "5fd5e208bb4bff191a1b03230af1d74178822a28",
       "branches": {
-        "main": "b321b95287f300167a85fad636b2bf0ff3380ee8"
+        "main": "5fd5e208bb4bff191a1b03230af1d74178822a28"
       },
-      "latest_tag": "v1.0.5"
+      "latest_tag": "v3.1.3"
     },
-    "elesionwow/bigwigs": {
+    "otari98/retarget": {
       "default_branch": "master",
-      "sha": "47b538024cf127346d624ba7b21a8aff56cb4587",
+      "sha": "9c95d89112c96066113afe82ce0b7797c0746204",
       "branches": {
-        "master": "47b538024cf127346d624ba7b21a8aff56cb4587"
+        "master": "9c95d89112c96066113afe82ce0b7797c0746204"
       }
     },
-    "pepopo978/bigwigs": {
+    "otari98/rinse": {
       "default_branch": "master",
-      "sha": "e53a09a4e86170a1a29178f8500e601bdd58e9ce",
+      "sha": "7fc044b901ecffd2724abe21b6502a8e419d6dc2",
       "branches": {
-        "master": "e53a09a4e86170a1a29178f8500e601bdd58e9ce"
+        "master": "7fc044b901ecffd2724abe21b6502a8e419d6dc2"
       }
     },
-    "bagaze/pfui-turtle": {
+    "otari98/shagudps": {
       "default_branch": "master",
-      "sha": "f43019aba2c7816d02a76265cfc827ddc566d064",
+      "sha": "922934eed916ad0e6b37dd0ac1dd9670eeb16453",
       "branches": {
-        "master": "f43019aba2c7816d02a76265cfc827ddc566d064"
+        "master": "922934eed916ad0e6b37dd0ac1dd9670eeb16453"
       }
     },
-    "wierdthing/pfui-turtle": {
+    "otari98/shaguplates": {
       "default_branch": "master",
-      "sha": "fefde810f979bfbcbdccfbe30472de3a68701652",
+      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
       "branches": {
-        "master": "fefde810f979bfbcbdccfbe30472de3a68701652"
+        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
       }
     },
-    "mnemozin/pfui-turtle": {
+    "otari98/shagutweaks": {
       "default_branch": "master",
-      "sha": "48562174a3a1fd861b10ca4c2668625b67ac4e22",
+      "sha": "2a812837ece04b15f15e3a330023b207ff2ba66c",
       "branches": {
-        "master": "48562174a3a1fd861b10ca4c2668625b67ac4e22"
+        "master": "2a812837ece04b15f15e3a330023b207ff2ba66c"
       }
     },
-    "hp-data/pfui-turtle": {
+    "otari98/sortbags": {
       "default_branch": "master",
-      "sha": "f43019aba2c7816d02a76265cfc827ddc566d064",
+      "sha": "ec05747667830b093e5b94d6cf3d9fafc303b42c",
       "branches": {
-        "master": "f43019aba2c7816d02a76265cfc827ddc566d064"
+        "master": "ec05747667830b093e5b94d6cf3d9fafc303b42c"
       }
     },
-    "airfinder/pfui-turtle": {
+    "otari98/sp_overpower": {
       "default_branch": "master",
-      "sha": "f43019aba2c7816d02a76265cfc827ddc566d064",
+      "sha": "b35fded98ffcc86822c36421bc41ceda06e9eec3",
       "branches": {
-        "master": "f43019aba2c7816d02a76265cfc827ddc566d064"
+        "master": "b35fded98ffcc86822c36421bc41ceda06e9eec3"
       }
     },
-    "0ninzya/pfui-turtle": {
+    "otari98/succ-bag": {
       "default_branch": "master",
-      "sha": "ceae89b14544fd87a8449bd4a751802dd118809c",
+      "sha": "167c34673f34c233720d9c642a2854a6d8f08080",
       "branches": {
-        "master": "ceae89b14544fd87a8449bd4a751802dd118809c"
+        "master": "167c34673f34c233720d9c642a2854a6d8f08080"
       }
     },
-    "lxxie1988/pfui-turtle": {
+    "otari98/superignore": {
       "default_branch": "master",
-      "sha": "ceae89b14544fd87a8449bd4a751802dd118809c",
+      "sha": "495527c3a6a979bc66438312fe98100da30fbd53",
       "branches": {
-        "master": "ceae89b14544fd87a8449bd4a751802dd118809c"
+        "master": "495527c3a6a979bc66438312fe98100da30fbd53"
+      }
+    },
+    "otari98/tankhelper": {
+      "default_branch": "master",
+      "sha": "2176bd21652c35a0c5bcd92b7797ad8e1f0e25ca",
+      "branches": {
+        "master": "2176bd21652c35a0c5bcd92b7797ad8e1f0e25ca"
+      }
+    },
+    "otari98/tmog": {
+      "default_branch": "master",
+      "sha": "870da4a34d803607e62f271a003b797fc6cbcf8b",
+      "branches": {
+        "master": "870da4a34d803607e62f271a003b797fc6cbcf8b"
+      }
+    },
+    "otari98/turtlemail": {
+      "default_branch": "master",
+      "sha": "f127bafbda0ed18402d8b515fd098440b1e8d71c",
+      "branches": {
+        "master": "f127bafbda0ed18402d8b515fd098440b1e8d71c"
+      }
+    },
+    "otari98/vf_warrioraddon": {
+      "default_branch": "master",
+      "sha": "fa9a2932ebf1ea10900a70323d5aa53eb565decd",
+      "branches": {
+        "master": "fa9a2932ebf1ea10900a70323d5aa53eb565decd"
+      }
+    },
+    "paenthy/combat": {
+      "default_branch": "main",
+      "sha": "d118c5b259fc925e086c00f5f4db5a77273e6894",
+      "branches": {
+        "main": "d118c5b259fc925e086c00f5f4db5a77273e6894"
+      }
+    },
+    "paenthy/cooldowntracker": {
+      "default_branch": "main",
+      "sha": "36caab96f68d7b4477cab536089d6e8ad51e9d2d",
+      "branches": {
+        "main": "36caab96f68d7b4477cab536089d6e8ad51e9d2d"
+      }
+    },
+    "paenthy/easyloot": {
+      "default_branch": "master",
+      "sha": "e464dff7d1d6104e306cbbcb9cba91b9561c9d0b",
+      "branches": {
+        "master": "e464dff7d1d6104e306cbbcb9cba91b9561c9d0b"
+      }
+    },
+    "paenthy/egnar": {
+      "default_branch": "master",
+      "sha": "edf84647cac6f17fa4c1330d4d8f5bd2c8c0a72c",
+      "branches": {
+        "master": "edf84647cac6f17fa4c1330d4d8f5bd2c8c0a72c"
+      }
+    },
+    "paenthy/guda": {
+      "default_branch": "main",
+      "sha": "c1364abdb83f1419c9e837f248305bfbd61c39ad",
+      "branches": {
+        "main": "c1364abdb83f1419c9e837f248305bfbd61c39ad"
+      }
+    },
+    "paenthy/instancejournal": {
+      "default_branch": "master",
+      "sha": "39612fde087b3bff15b88fd73b9f8d717e2244d6",
+      "branches": {
+        "master": "39612fde087b3bff15b88fd73b9f8d717e2244d6"
+      }
+    },
+    "paenthy/keijinautovendor": {
+      "default_branch": "main",
+      "sha": "4cefadbc99d7c5d452e67c7c151bdf917c8de0cc",
+      "branches": {
+        "main": "4cefadbc99d7c5d452e67c7c151bdf917c8de0cc"
+      }
+    },
+    "paenthy/missingcrafts": {
+      "default_branch": "master",
+      "sha": "e702ce7d781d68c2ead5f8223e59689edb8cfc91",
+      "branches": {
+        "master": "e702ce7d781d68c2ead5f8223e59689edb8cfc91"
+      }
+    },
+    "paenthy/modernspellalert": {
+      "default_branch": "main",
+      "sha": "97486297904a360c0e0fddb4fcbc6ada731a476c",
+      "branches": {
+        "main": "97486297904a360c0e0fddb4fcbc6ada731a476c"
+      }
+    },
+    "paenthy/poisoncharges": {
+      "default_branch": "Classic",
+      "sha": "1afb71e7138986f30bd6c8fa5d31864705a6052c",
+      "branches": {
+        "Classic": "1afb71e7138986f30bd6c8fa5d31864705a6052c"
+      }
+    },
+    "paenthy/questrepeat": {
+      "default_branch": "master",
+      "sha": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf",
+      "branches": {
+        "master": "eb577bd4ac51759ff6c7f5d723ca2d270325a4bf"
+      }
+    },
+    "paenthy/raidsummonplus": {
+      "default_branch": "master",
+      "sha": "8238883684169f6a76057f74f277486657e45ef0",
+      "branches": {
+        "master": "8238883684169f6a76057f74f277486657e45ef0"
+      }
+    },
+    "paenthy/rinse": {
+      "default_branch": "master",
+      "sha": "4319e2e2c58c7e6a66ab61f1eabd8433c57b89a5",
+      "branches": {
+        "master": "4319e2e2c58c7e6a66ab61f1eabd8433c57b89a5"
+      }
+    },
+    "paenthy/roguetick": {
+      "default_branch": "main",
+      "sha": "586ae638e53a0ffc4e6b685030f6d946e4e47790",
+      "branches": {
+        "main": "586ae638e53a0ffc4e6b685030f6d946e4e47790"
+      }
+    },
+    "paenthy/rogueticker": {
+      "default_branch": "master",
+      "sha": "5110f54d89e043fc41fea8343a7e481ca4122d1f",
+      "branches": {
+        "master": "5110f54d89e043fc41fea8343a7e481ca4122d1f"
+      }
+    },
+    "paenthy/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "99b30f48d423afedfc94f0d031854a3e4174a352",
+      "branches": {
+        "master": "99b30f48d423afedfc94f0d031854a3e4174a352"
+      }
+    },
+    "paenthy/vanilla-newlevelframe": {
+      "default_branch": "main",
+      "sha": "ae0a23812409ae3c4dc731136b9cdc25cb44b09c",
+      "branches": {
+        "main": "ae0a23812409ae3c4dc731136b9cdc25cb44b09c"
+      }
+    },
+    "paenthy/yaht-turtlewow": {
+      "default_branch": "master",
+      "sha": "9696db588c5d8ad62c94a695144c6af89aa855b8",
+      "branches": {
+        "master": "9696db588c5d8ad62c94a695144c6af89aa855b8"
+      }
+    },
+    "paleniyacc-oss/lazyspell": {
+      "default_branch": "master",
+      "sha": "63bfb63149b6e5780664ed25851d10d30c79e5ef",
+      "branches": {
+        "master": "63bfb63149b6e5780664ed25851d10d30c79e5ef"
+      }
+    },
+    "panzier32564-cmd/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
+      "branches": {
+        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
+      }
+    },
+    "paokkerkir/attackbar_dragonflightui": {
+      "default_branch": "master",
+      "sha": "f72b15cfad06b6487d9253f26f46d5a624163220",
+      "branches": {
+        "master": "f72b15cfad06b6487d9253f26f46d5a624163220"
+      }
+    },
+    "paokkerkir/buffwatch": {
+      "default_branch": "main",
+      "sha": "e33585c8ff770fb67b83911738c9935830e5a9c5",
+      "branches": {
+        "main": "e33585c8ff770fb67b83911738c9935830e5a9c5"
+      }
+    },
+    "paokkerkir/equipcolor": {
+      "default_branch": "main",
+      "sha": "e403f1a1e0d97ea6b483c4a3e5714635cc76c3e5",
+      "branches": {
+        "main": "e403f1a1e0d97ea6b483c4a3e5714635cc76c3e5"
+      }
+    },
+    "paokkerkir/levelrange-octo": {
+      "default_branch": "main",
+      "sha": "6ae70cad4ee911ba3fe1e297fa84d4bb1b8d6d4a",
+      "branches": {
+        "main": "6ae70cad4ee911ba3fe1e297fa84d4bb1b8d6d4a"
+      }
+    },
+    "paokkerkir/magnify": {
+      "default_branch": "main",
+      "sha": "86d11cbcb9a0e8d5ba3459c5815e392c296213d1",
+      "branches": {
+        "main": "86d11cbcb9a0e8d5ba3459c5815e392c296213d1"
+      }
+    },
+    "paokkerkir/modernmapmarkers-octo": {
+      "default_branch": "main",
+      "sha": "4e6de29ffa6f07c1c2ed7da3bb8f891858ebe2e9",
+      "branches": {
+        "main": "4e6de29ffa6f07c1c2ed7da3bb8f891858ebe2e9"
+      }
+    },
+    "paokkerkir/omnicc": {
+      "default_branch": "master",
+      "sha": "2213b5334dc7fc7e9419b9e32aaedb02b3214f9b",
+      "branches": {
+        "master": "2213b5334dc7fc7e9419b9e32aaedb02b3214f9b"
       }
     },
     "paokkerkir/pfquest": {
-      "default_branch": "main",
-      "sha": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9",
-      "branches": {
-        "main": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9"
-      }
-    },
-    "twapegg/pfquest": {
-      "default_branch": "main",
-      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
-      "branches": {
-        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
-      },
-      "latest_tag": "8.0.0"
-    },
-    "balakethelock/pfquest": {
-      "default_branch": "main",
-      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
-      "branches": {
-        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
-      }
-    },
-    "alandarev/pfquest": {
-      "default_branch": "main",
-      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
-      "branches": {
-        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
-      },
-      "latest_tag": "8.0.0"
-    },
-    "al3xc1985/pfquest": {
-      "default_branch": "main",
-      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
-      "branches": {
-        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
-      }
-    },
-    "hippoom/pfquest": {
-      "default_branch": "main",
-      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
-      "branches": {
-        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
-      }
-    },
-    "copypasteonly/pfquest": {
-      "default_branch": "main",
-      "sha": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9",
-      "branches": {
-        "main": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9"
-      },
-      "latest_tag": "8.0.0"
-    },
-    "ravenofseven/pfquest": {
       "default_branch": "main",
       "sha": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9",
       "branches": {
@@ -15576,32 +9461,622 @@
         "main": "dd3dc1fb80afe7a71e5c8ca8c31ca2a3ef57af67"
       }
     },
-    "ravenofseven/pfui-bettertotems": {
-      "default_branch": "main",
-      "sha": "4bcb23338570476c97db89590a70d102b0438b09",
-      "branches": {
-        "main": "4bcb23338570476c97db89590a70d102b0438b09"
-      }
-    },
-    "whtmst/pfui-bettertotems": {
-      "default_branch": "main",
-      "sha": "4bcb23338570476c97db89590a70d102b0438b09",
-      "branches": {
-        "main": "4bcb23338570476c97db89590a70d102b0438b09"
-      }
-    },
-    "wow-br/blizzplates": {
+    "paokkerkir/shaguplates": {
       "default_branch": "master",
-      "sha": "8aa50c0fe0d50aabeab39472abebb3f5f241672b",
+      "sha": "32799951996277b8be5eed18d6e31546fefe6efa",
       "branches": {
-        "master": "8aa50c0fe0d50aabeab39472abebb3f5f241672b"
+        "master": "32799951996277b8be5eed18d6e31546fefe6efa"
       }
     },
-    "alexpoatato/blizzplates": {
+    "paokkerkir/shagutweaks": {
       "default_branch": "master",
-      "sha": "8aa50c0fe0d50aabeab39472abebb3f5f241672b",
+      "sha": "1d87df1b430473909d79da48108d5d9705394d84",
       "branches": {
-        "master": "8aa50c0fe0d50aabeab39472abebb3f5f241672b"
+        "master": "1d87df1b430473909d79da48108d5d9705394d84"
+      }
+    },
+    "paokkerkir/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "4af510e3dce9d5e615bff34ccdd390719f6e428a",
+      "branches": {
+        "master": "4af510e3dce9d5e615bff34ccdd390719f6e428a"
+      }
+    },
+    "paokkerkir/vanilla-autologin": {
+      "default_branch": "main",
+      "sha": "2665aeb14d9eaaa51f1532c7dc689c6a18b49a73",
+      "branches": {
+        "main": "2665aeb14d9eaaa51f1532c7dc689c6a18b49a73"
+      }
+    },
+    "paokkerkir/wowradio-vanilla": {
+      "default_branch": "main",
+      "sha": "572985067fe04b693cf1684c2dd103fc17632faf",
+      "branches": {
+        "main": "572985067fe04b693cf1684c2dd103fc17632faf"
+      }
+    },
+    "paparogue/mobhealth3-kronos3-edition": {
+      "default_branch": "master",
+      "sha": "198fec86d3213cad69d4fa4c2307355daa1a87e9",
+      "branches": {
+        "master": "198fec86d3213cad69d4fa4c2307355daa1a87e9"
+      }
+    },
+    "paparogue/stopduelbuffer": {
+      "default_branch": "master",
+      "sha": "5f46676befeb26a46beb670241cf622b0bd7c90e",
+      "branches": {
+        "master": "5f46676befeb26a46beb670241cf622b0bd7c90e"
+      }
+    },
+    "parzydelkowiec3-hub/raidsummonplus": {
+      "default_branch": "master",
+      "sha": "4ada883332cebd63cc11635e163020cfeacca4a5",
+      "branches": {
+        "master": "4ada883332cebd63cc11635e163020cfeacca4a5"
+      }
+    },
+    "parzydelkowiec3-hub/roguerota": {
+      "default_branch": "master",
+      "sha": "0538e5494074db3927bdb711065a6dae1083015c",
+      "branches": {
+        "master": "0538e5494074db3927bdb711065a6dae1083015c"
+      }
+    },
+    "parzydelkowiec3-hub/zorlen": {
+      "default_branch": "main",
+      "sha": "bc794631e9e25451773b2803e6f2df46ccce58a5",
+      "branches": {
+        "main": "bc794631e9e25451773b2803e6f2df46ccce58a5"
+      }
+    },
+    "patlamontagne/moveanything": {
+      "default_branch": "main",
+      "sha": "eaf4c5fe9fc55bb10917909424f8e6d1159598e2",
+      "branches": {
+        "main": "eaf4c5fe9fc55bb10917909424f8e6d1159598e2"
+      }
+    },
+    "patlamontagne/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "f5af91f962906ca353e3978b88fbb7263589d7bc",
+      "branches": {
+        "master": "f5af91f962906ca353e3978b88fbb7263589d7bc"
+      }
+    },
+    "paulderaadt/vgsmartunbuff": {
+      "default_branch": "master",
+      "sha": "0bebe678cf2d7b3658bff23c014f857d7a61fd8d",
+      "branches": {
+        "master": "0bebe678cf2d7b3658bff23c014f857d7a61fd8d"
+      }
+    },
+    "peaap/roid-macros": {
+      "default_branch": "master",
+      "sha": "e29e991b00044b0dab130355a3087a7e0660b691",
+      "branches": {
+        "master": "e29e991b00044b0dab130355a3087a7e0660b691"
+      }
+    },
+    "pecheneg95/targetframebuff": {
+      "default_branch": "master",
+      "sha": "68034f1f3c99db2e1ff6806e38adc011ae161a20",
+      "branches": {
+        "master": "68034f1f3c99db2e1ff6806e38adc011ae161a20"
+      }
+    },
+    "pendax/salad_cthun": {
+      "default_branch": "master",
+      "sha": "63f4fe574a761e324b1bab7a9e694505766c3c62",
+      "branches": {
+        "master": "63f4fe574a761e324b1bab7a9e694505766c3c62"
+      }
+    },
+    "pepopo978/adf": {
+      "default_branch": "master",
+      "sha": "389feb7da2854eceeb79b2162f88bd6b17cb4e7e",
+      "branches": {
+        "master": "389feb7da2854eceeb79b2162f88bd6b17cb4e7e"
+      }
+    },
+    "pepopo978/arcanum": {
+      "default_branch": "main",
+      "sha": "00f90fca8e2cbacc8a0e43a8904377c692dc9319",
+      "branches": {
+        "main": "00f90fca8e2cbacc8a0e43a8904377c692dc9319"
+      }
+    },
+    "pepopo978/bigwigs": {
+      "default_branch": "master",
+      "sha": "e53a09a4e86170a1a29178f8500e601bdd58e9ce",
+      "branches": {
+        "master": "e53a09a4e86170a1a29178f8500e601bdd58e9ce"
+      }
+    },
+    "pepopo978/casttimer": {
+      "default_branch": "master",
+      "sha": "774a06f750f468c70dabea2d0b3378c866580b89",
+      "branches": {
+        "master": "774a06f750f468c70dabea2d0b3378c866580b89"
+      }
+    },
+    "pepopo978/cursive": {
+      "default_branch": "master",
+      "sha": "e8d46dff3de8ae14fca72c68766862e32892c6c1",
+      "branches": {
+        "master": "e8d46dff3de8ae14fca72c68766862e32892c6c1"
+      }
+    },
+    "pepopo978/flamestriker": {
+      "default_branch": "master",
+      "sha": "ebcf8bdd1661b5dcc11b107f459c3d5006c44c00",
+      "branches": {
+        "master": "ebcf8bdd1661b5dcc11b107f459c3d5006c44c00"
+      }
+    },
+    "pepopo978/instancetimers": {
+      "default_branch": "master",
+      "sha": "c36612b6d9118a5a78a7caf701aa9307273aa797",
+      "branches": {
+        "master": "c36612b6d9118a5a78a7caf701aa9307273aa797"
+      }
+    },
+    "pepopo978/magehud": {
+      "default_branch": "main",
+      "sha": "45aaf4fb03eb9909b31e9ea80f41f7d2cb000e28",
+      "branches": {
+        "main": "45aaf4fb03eb9909b31e9ea80f41f7d2cb000e28"
+      }
+    },
+    "pepopo978/outfitter": {
+      "default_branch": "master",
+      "sha": "9e8d2c6101280c995118f2195374ffbd8dbcf283",
+      "branches": {
+        "master": "9e8d2c6101280c995118f2195374ffbd8dbcf283"
+      }
+    },
+    "pepopo978/pizzaslices": {
+      "default_branch": "main",
+      "sha": "160df95e2c803b4abc91663b3e474cbfa1090147",
+      "branches": {
+        "main": "160df95e2c803b4abc91663b3e474cbfa1090147"
+      }
+    },
+    "pepopo978/rabuffs": {
+      "default_branch": "master",
+      "sha": "95eed1f4823f34ff7a85fa4bccaf688fb2385045",
+      "branches": {
+        "master": "95eed1f4823f34ff7a85fa4bccaf688fb2385045"
+      }
+    },
+    "pepopo978/roid-macros": {
+      "default_branch": "master",
+      "sha": "6d5db631481bed2a08acfcf24de29b4b6cdc5abf",
+      "branches": {
+        "master": "6d5db631481bed2a08acfcf24de29b4b6cdc5abf"
+      }
+    },
+    "pepopo978/simpleactionsets": {
+      "default_branch": "master",
+      "sha": "e2486ad2169333c1e69f18815224fb7962269ca0",
+      "branches": {
+        "master": "e2486ad2169333c1e69f18815224fb7962269ca0"
+      }
+    },
+    "pepopo978/sorgis_raid_marks": {
+      "default_branch": "master",
+      "sha": "ccaf9725161db0dd7b5a71c4e1c1cce109645027",
+      "branches": {
+        "master": "ccaf9725161db0dd7b5a71c4e1c1cce109645027"
+      }
+    },
+    "pepopo978/superwowcombatlogger": {
+      "default_branch": "master",
+      "sha": "c67e198a8a0921747ed4d487d25aa25eb4317779",
+      "branches": {
+        "master": "c67e198a8a0921747ed4d487d25aa25eb4317779"
+      }
+    },
+    "pepopo978/talentsaver": {
+      "default_branch": "master",
+      "sha": "af400696c16e0e0959f6d31861579142db96be86",
+      "branches": {
+        "master": "af400696c16e0e0959f6d31861579142db96be86"
+      }
+    },
+    "pepordev/consoleexperienceclassic": {
+      "default_branch": "main",
+      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
+      "branches": {
+        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
+      },
+      "latest_tag": "v0.17.3"
+    },
+    "perks/cursive": {
+      "default_branch": "master",
+      "sha": "f2b06221d790d3b6748a17a96646f406df7e25ca",
+      "branches": {
+        "master": "f2b06221d790d3b6748a17a96646f406df7e25ca"
+      }
+    },
+    "perks/sundernp": {
+      "default_branch": "main",
+      "sha": "606d69cdf80ee3d139256585773da6d7f078fbfd",
+      "branches": {
+        "main": "606d69cdf80ee3d139256585773da6d7f078fbfd"
+      }
+    },
+    "pfmiles/lazyscript": {
+      "default_branch": "master",
+      "sha": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92",
+      "branches": {
+        "master": "cf3b7c7220cf2f0fa7062af8033e3e30f8e87a92"
+      }
+    },
+    "phaestas323/lockport": {
+      "default_branch": "main",
+      "sha": "5842b3793959653565cc3ddfbfd470abea56ab60",
+      "branches": {
+        "main": "5842b3793959653565cc3ddfbfd470abea56ab60"
+      }
+    },
+    "phobos-programmer/twbuypoisons": {
+      "default_branch": "master",
+      "sha": "e69c62e0a8285b6bc63894900a6ccfb2af10996f",
+      "branches": {
+        "master": "e69c62e0a8285b6bc63894900a6ccfb2af10996f"
+      }
+    },
+    "phoenixrisinghost/shootyepgp": {
+      "default_branch": "master",
+      "sha": "b819e4bd063a40531d8ce48e08ce9de242135afa",
+      "branches": {
+        "master": "b819e4bd063a40531d8ce48e08ce9de242135afa"
+      }
+    },
+    "phrxqt/combatplates": {
+      "default_branch": "main",
+      "sha": "79343791e4871feb3222d66b592292eede7260a8",
+      "branches": {
+        "main": "79343791e4871feb3222d66b592292eede7260a8"
+      },
+      "latest_tag": "v1.0"
+    },
+    "phrxqt/targetsoundrestore": {
+      "default_branch": "main",
+      "sha": "7a3a32630fbc62e2c036192a250e0be29921f651",
+      "branches": {
+        "main": "7a3a32630fbc62e2c036192a250e0be29921f651"
+      },
+      "latest_tag": "v1.0"
+    },
+    "phytotoma/shagudelgado-3.3.5": {
+      "default_branch": "master",
+      "sha": "0e2e00de90dcabca30ae807d9fd44c41d521cb9b",
+      "branches": {
+        "master": "0e2e00de90dcabca30ae807d9fd44c41d521cb9b"
+      }
+    },
+    "phyx1u5/meeting": {
+      "default_branch": "master",
+      "sha": "1d35a221559f15d70e461cb1628858ddea4b5b0c",
+      "branches": {
+        "master": "1d35a221559f15d70e461cb1628858ddea4b5b0c"
+      }
+    },
+    "picardebooks/turtletranslator": {
+      "default_branch": "main",
+      "sha": "d246dbbca5f94195b646e39e2a509eb0eba92fb3",
+      "branches": {
+        "main": "d246dbbca5f94195b646e39e2a509eb0eba92fb3"
+      }
+    },
+    "player-doite/doiteauras": {
+      "default_branch": "main",
+      "sha": "cbb3e01b82bb84122bc5ccdf35a06ae803edd6df",
+      "branches": {
+        "main": "cbb3e01b82bb84122bc5ccdf35a06ae803edd6df"
+      }
+    },
+    "player-doite/tactica": {
+      "default_branch": "main",
+      "sha": "f85e7fb0ded1a9178f207d3940c153e6e06f5e48",
+      "branches": {
+        "main": "f85e7fb0ded1a9178f207d3940c153e6e06f5e48"
+      }
+    },
+    "plokertonne/cursive": {
+      "default_branch": "master",
+      "sha": "dc4fc8b794f386e92c0173e6b39341927f6af636",
+      "branches": {
+        "master": "dc4fc8b794f386e92c0173e6b39341927f6af636"
+      }
+    },
+    "pokerbhind/roguepoker": {
+      "default_branch": "main",
+      "sha": "a7786ed09c548d4930d0d64715591a2c6c33ef97",
+      "branches": {
+        "main": "a7786ed09c548d4930d0d64715591a2c6c33ef97"
+      },
+      "latest_tag": "v1.2.1"
+    },
+    "porkfriedlumpia/porknotes": {
+      "default_branch": "main",
+      "sha": "229e81106cc1c9da39c200d68999f345a69febf9",
+      "branches": {
+        "main": "229e81106cc1c9da39c200d68999f345a69febf9"
+      },
+      "latest_tag": "0.4.1"
+    },
+    "pre-elysium/hordeironfoe": {
+      "default_branch": "master",
+      "sha": "a8e6fd1719c9e36d269405ce2566c08bb2d0f478",
+      "branches": {
+        "master": "a8e6fd1719c9e36d269405ce2566c08bb2d0f478"
+      }
+    },
+    "proadran/sellvalue": {
+      "default_branch": "master",
+      "sha": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e",
+      "branches": {
+        "master": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e"
+      }
+    },
+    "prodigystudios/akkio_consume_helper": {
+      "default_branch": "main",
+      "sha": "9af15e3c236d14d6d704d4db78cb210620849b24",
+      "branches": {
+        "main": "9af15e3c236d14d6d704d4db78cb210620849b24"
+      }
+    },
+    "profiler781/autoturnin": {
+      "default_branch": "main",
+      "sha": "af79320ed201332dd63e2439bfb72c10e890f6d0",
+      "branches": {
+        "main": "af79320ed201332dd63e2439bfb72c10e890f6d0"
+      }
+    },
+    "profiler781/iwinenhanced": {
+      "default_branch": "main",
+      "sha": "e5908a2ea43c6a4bcc0ab7cb1759b95aeca2839d",
+      "branches": {
+        "main": "e5908a2ea43c6a4bcc0ab7cb1759b95aeca2839d"
+      }
+    },
+    "profiler781/rabuffs": {
+      "default_branch": "master",
+      "sha": "7466f394673835073fd5def734856de702ec4c2d",
+      "branches": {
+        "master": "7466f394673835073fd5def734856de702ec4c2d"
+      }
+    },
+    "pseja/roguetick": {
+      "default_branch": "main",
+      "sha": "586ae638e53a0ffc4e6b685030f6d946e4e47790",
+      "branches": {
+        "main": "586ae638e53a0ffc4e6b685030f6d946e4e47790"
+      }
+    },
+    "purple-bloom/rabuffs": {
+      "default_branch": "master",
+      "sha": "66243fdb1574434bbaa8b91dcd961b501591680b",
+      "branches": {
+        "master": "66243fdb1574434bbaa8b91dcd961b501591680b"
+      }
+    },
+    "pushxd/jim_cooldownpulse": {
+      "default_branch": "master",
+      "sha": "bacb53bdee96dec5054193f5a69d22cb3e920c15",
+      "branches": {
+        "master": "bacb53bdee96dec5054193f5a69d22cb3e920c15"
+      }
+    },
+    "pushxd/jim_toolbox": {
+      "default_branch": "master",
+      "sha": "e37354207820a739a878892aa2d6cb0f3f897822",
+      "branches": {
+        "master": "e37354207820a739a878892aa2d6cb0f3f897822"
+      }
+    },
+    "pylebecq/necrosis-twow": {
+      "default_branch": "main",
+      "sha": "8d05b2c7adce1f1849b18cffb46a1635087caf82",
+      "branches": {
+        "main": "8d05b2c7adce1f1849b18cffb46a1635087caf82"
+      },
+      "latest_tag": "1.8.0"
+    },
+    "qeynos/quiver": {
+      "default_branch": "main",
+      "sha": "e281abda6fce4db282683aa7f07b0781ab9c3bd4",
+      "branches": {
+        "main": "e281abda6fce4db282683aa7f07b0781ab9c3bd4"
+      },
+      "latest_tag": "v3.0.0"
+    },
+    "qrospars/holyshiftmiio": {
+      "default_branch": "master",
+      "sha": "9cb60822a0cf6391dd34828802b0c0965b752016",
+      "branches": {
+        "master": "9cb60822a0cf6391dd34828802b0c0965b752016"
+      }
+    },
+    "qrospars/shaguscanlongrange": {
+      "default_branch": "master",
+      "sha": "6b256283f02e0316b67ab42cd387028871101080",
+      "branches": {
+        "master": "6b256283f02e0316b67ab42cd387028871101080"
+      }
+    },
+    "quakerzz/dkpauctionbidder": {
+      "default_branch": "master",
+      "sha": "8b38ae52ac3a3613216fb7dc37cfaddc73627c34",
+      "branches": {
+        "master": "8b38ae52ac3a3613216fb7dc37cfaddc73627c34"
+      }
+    },
+    "quakerzz/dkplist": {
+      "default_branch": "master",
+      "sha": "5c1b387e10d53eb246c0374536918b5b88ecd64e",
+      "branches": {
+        "master": "5c1b387e10d53eb246c0374536918b5b88ecd64e"
+      }
+    },
+    "ragedunicorn/wow-pvpwarn": {
+      "default_branch": "master",
+      "sha": "9b26bb247e34209ec73d3858443738ace551c3f6",
+      "branches": {
+        "master": "9b26bb247e34209ec73d3858443738ace551c3f6"
+      },
+      "latest_tag": "v1.1.1"
+    },
+    "ragedunicorn/wow-vanilla-gearmenu": {
+      "default_branch": "master",
+      "sha": "06f9edc3d84835f9ec818a7b8e951ebc92c0ca71",
+      "branches": {
+        "master": "06f9edc3d84835f9ec818a7b8e951ebc92c0ca71"
+      },
+      "latest_tag": "v1.2.2"
+    },
+    "ralliartse/lfghelper": {
+      "default_branch": "main",
+      "sha": "4a2c42668e859585c73642e12a03bd1bd3a7636f",
+      "branches": {
+        "main": "4a2c42668e859585c73642e12a03bd1bd3a7636f"
+      }
+    },
+    "ramodemir/samuel": {
+      "default_branch": "master",
+      "sha": "22e5869ca3fce7dd535443bbca575da609273579",
+      "branches": {
+        "master": "22e5869ca3fce7dd535443bbca575da609273579"
+      }
+    },
+    "randall05/lockport_plus": {
+      "default_branch": "main",
+      "sha": "1642962c3f3603f87c324815cf5ab6b1f13c1f4b",
+      "branches": {
+        "main": "1642962c3f3603f87c324815cf5ab6b1f13c1f4b"
+      }
+    },
+    "rankxuan/gryllsswingtimer": {
+      "default_branch": "main",
+      "sha": "292d0d9a72293a4e8f0790711cf2ee2ca328017e",
+      "branches": {
+        "main": "292d0d9a72293a4e8f0790711cf2ee2ca328017e"
+      }
+    },
+    "raphaelantoniocampos/twtrans": {
+      "default_branch": "main",
+      "sha": "1bcef7f3f2631cf3a13bbf63cd91da14a7b6f06c",
+      "branches": {
+        "main": "1bcef7f3f2631cf3a13bbf63cd91da14a7b6f06c"
+      }
+    },
+    "ratkosrb/unicodefont": {
+      "default_branch": "master",
+      "sha": "fd408c8656078afbd72f4f8911ef197e1c934a75",
+      "branches": {
+        "master": "fd408c8656078afbd72f4f8911ef197e1c934a75"
+      }
+    },
+    "ratkosrb/wiiiui": {
+      "default_branch": "master",
+      "sha": "530ade4ef544e1cf8cb269a579c5c8f2dd9abff2",
+      "branches": {
+        "master": "530ade4ef544e1cf8cb269a579c5c8f2dd9abff2"
+      }
+    },
+    "ravenofseven/aux-revamped-opaque": {
+      "default_branch": "master",
+      "sha": "10ca3b7dfc32b81f30f8fc1c6fa83d1472d1949d",
+      "branches": {
+        "master": "10ca3b7dfc32b81f30f8fc1c6fa83d1472d1949d"
+      }
+    },
+    "ravenofseven/bettercharacterpanel": {
+      "default_branch": "main",
+      "sha": "6f98ab5460fc6e697d6e2660a8f89affd124a8e4",
+      "branches": {
+        "main": "6f98ab5460fc6e697d6e2660a8f89affd124a8e4"
+      }
+    },
+    "ravenofseven/goblinbrainwashinghelper": {
+      "default_branch": "master",
+      "sha": "26159e4ef29e0af7259ae92b66dde3da4c68f7d2",
+      "branches": {
+        "master": "26159e4ef29e0af7259ae92b66dde3da4c68f7d2"
+      }
+    },
+    "ravenofseven/guda": {
+      "default_branch": "main",
+      "sha": "c1364abdb83f1419c9e837f248305bfbd61c39ad",
+      "branches": {
+        "main": "c1364abdb83f1419c9e837f248305bfbd61c39ad"
+      }
+    },
+    "ravenofseven/instancejournal": {
+      "default_branch": "master",
+      "sha": "39612fde087b3bff15b88fd73b9f8d717e2244d6",
+      "branches": {
+        "master": "39612fde087b3bff15b88fd73b9f8d717e2244d6"
+      }
+    },
+    "ravenofseven/messagebox": {
+      "default_branch": "main",
+      "sha": "0c63f1d624782163349a1100e46bc604f4117a32",
+      "branches": {
+        "main": "0c63f1d624782163349a1100e46bc604f4117a32"
+      }
+    },
+    "ravenofseven/minimapbuttonbag": {
+      "default_branch": "master",
+      "sha": "a3ae16a352889ec491b8d917297aecb262d0b437",
+      "branches": {
+        "master": "a3ae16a352889ec491b8d917297aecb262d0b437"
+      }
+    },
+    "ravenofseven/modernmapmarkers": {
+      "default_branch": "main",
+      "sha": "5311be6a24979d4119ed59e9f48f90beb41ecfb4",
+      "branches": {
+        "main": "5311be6a24979d4119ed59e9f48f90beb41ecfb4"
+      }
+    },
+    "ravenofseven/modernspellbook": {
+      "default_branch": "master",
+      "sha": "33ada544a85eb97fea4401e8cb25ebce4f93895b",
+      "branches": {
+        "master": "33ada544a85eb97fea4401e8cb25ebce4f93895b"
+      }
+    },
+    "ravenofseven/pfextend": {
+      "default_branch": "main",
+      "sha": "7281b5d3747591f7b043ccb5656283ce5dec8c7f",
+      "branches": {
+        "main": "7281b5d3747591f7b043ccb5656283ce5dec8c7f"
+      }
+    },
+    "ravenofseven/pfquest": {
+      "default_branch": "main",
+      "sha": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9",
+      "branches": {
+        "main": "2a64fbf296c2dafd19f468997cdb9cf2600dddf9"
+      }
+    },
+    "ravenofseven/pfquest-icons": {
+      "default_branch": "master",
+      "sha": "709ba275b7198b93713b5b06cf896dc9006ebeea",
+      "branches": {
+        "master": "709ba275b7198b93713b5b06cf896dc9006ebeea"
+      }
+    },
+    "ravenofseven/pfquest-turtle": {
+      "default_branch": "main",
+      "sha": "df24087b9f958cd4e4b057b58805233e820c9981",
+      "branches": {
+        "main": "df24087b9f958cd4e4b057b58805233e820c9981"
       }
     },
     "ravenofseven/pfui-addonskinner": {
@@ -15611,60 +10086,11 @@
         "main": "f9873f69b656c9cb717febbb536beee51b7f910f"
       }
     },
-    "blehz-be/pfui-addonskinner": {
+    "ravenofseven/pfui-bettertotems": {
       "default_branch": "main",
-      "sha": "f9873f69b656c9cb717febbb536beee51b7f910f",
+      "sha": "4bcb23338570476c97db89590a70d102b0438b09",
       "branches": {
-        "main": "f9873f69b656c9cb717febbb536beee51b7f910f"
-      }
-    },
-    "mazdur/pfui-addonskinner": {
-      "default_branch": "main",
-      "sha": "f9873f69b656c9cb717febbb536beee51b7f910f",
-      "branches": {
-        "main": "f9873f69b656c9cb717febbb536beee51b7f910f"
-      }
-    },
-    "zedris/pfui-addonskinner": {
-      "default_branch": "main",
-      "sha": "86e8962b94af6bc057b3c697553ec67577569c4c",
-      "branches": {
-        "main": "86e8962b94af6bc057b3c697553ec67577569c4c"
-      }
-    },
-    "mr-rosh/pfui-addonskinner": {
-      "default_branch": "main",
-      "sha": "2c9d3e84131dcc12c3f2844b8d369fbde048398f",
-      "branches": {
-        "main": "2c9d3e84131dcc12c3f2844b8d369fbde048398f"
-      }
-    },
-    "dirty-git/pfui-addonskinner": {
-      "default_branch": "main",
-      "sha": "48cd30bff231add81b7d892b4fc1c9d40912c57e",
-      "branches": {
-        "main": "48cd30bff231add81b7d892b4fc1c9d40912c57e"
-      }
-    },
-    "jiangxt316/pfui-addonskinner": {
-      "default_branch": "main",
-      "sha": "8cc036f32f67ace0baf749f2e67163460374c5a8",
-      "branches": {
-        "main": "8cc036f32f67ace0baf749f2e67163460374c5a8"
-      }
-    },
-    "shigemunekurogane/pfui-addonskinner": {
-      "default_branch": "main",
-      "sha": "a499442783df407737a914e63718e26ec3b74a31",
-      "branches": {
-        "main": "a499442783df407737a914e63718e26ec3b74a31"
-      }
-    },
-    "commandersouza/pfui-autoinvite": {
-      "default_branch": "main",
-      "sha": "e67988f1f28478c2df1163e3b8a2a1b50656ad0a",
-      "branches": {
-        "main": "e67988f1f28478c2df1163e3b8a2a1b50656ad0a"
+        "main": "4bcb23338570476c97db89590a70d102b0438b09"
       }
     },
     "ravenofseven/pfui-custommedia": {
@@ -15674,49 +10100,7 @@
         "main": "701bee8b249fbe91050e6e3645bf810841704696"
       }
     },
-    "macumbafeh/pfui-eliteoverlay": {
-      "default_branch": "master",
-      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
-      "branches": {
-        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
-      }
-    },
-    "amonra/pfui-eliteoverlay": {
-      "default_branch": "master",
-      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
-      "branches": {
-        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
-      }
-    },
-    "dwbclz/pfui-eliteoverlay": {
-      "default_branch": "master",
-      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
-      "branches": {
-        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
-      }
-    },
-    "jiangxt316/pfui-eliteoverlay": {
-      "default_branch": "master",
-      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
-      "branches": {
-        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
-      }
-    },
     "ravenofseven/pfui-eliteoverlay": {
-      "default_branch": "master",
-      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
-      "branches": {
-        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
-      }
-    },
-    "spawnedc/pfui-eliteoverlay": {
-      "default_branch": "master",
-      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
-      "branches": {
-        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
-      }
-    },
-    "yani9o/pfui-eliteoverlay": {
       "default_branch": "master",
       "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
       "branches": {
@@ -15737,12 +10121,816 @@
         "master": "5447b2a3e3ed9071a79240d52664884f0706903d"
       }
     },
-    "sica42/callofelements": {
-      "default_branch": "master",
-      "sha": "afc5398aef1f2f31ed34732ec89eaf77bce06d2f",
+    "ravenofseven/pizzaworldbuffs": {
+      "default_branch": "main",
+      "sha": "72d6861926c1a2106c8773e8e251da27ab617471",
       "branches": {
-        "master": "afc5398aef1f2f31ed34732ec89eaf77bce06d2f"
+        "main": "72d6861926c1a2106c8773e8e251da27ab617471"
       }
+    },
+    "ravenofseven/rallyhelper": {
+      "default_branch": "main",
+      "sha": "9819101ea22d0ffbbee7221accf6601a7321c1c8",
+      "branches": {
+        "main": "9819101ea22d0ffbbee7221accf6601a7321c1c8"
+      }
+    },
+    "ravenofseven/ringmenu": {
+      "default_branch": "master",
+      "sha": "23db580b0ddc04b8650afdf50179302fbb67128f",
+      "branches": {
+        "master": "23db580b0ddc04b8650afdf50179302fbb67128f"
+      }
+    },
+    "ravenofseven/shaguplates": {
+      "default_branch": "master",
+      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
+      "branches": {
+        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
+      }
+    },
+    "ravenofseven/sortbags-vanilla": {
+      "default_branch": "master",
+      "sha": "1b59767ca41749e70d72f2991c27054beebcdfcd",
+      "branches": {
+        "master": "1b59767ca41749e70d72f2991c27054beebcdfcd"
+      }
+    },
+    "ravenofseven/succ-bag": {
+      "default_branch": "master",
+      "sha": "167c34673f34c233720d9c642a2854a6d8f08080",
+      "branches": {
+        "master": "167c34673f34c233720d9c642a2854a6d8f08080"
+      }
+    },
+    "ravenofseven/succ-ecb": {
+      "default_branch": "master",
+      "sha": "0bafc3cfa1dfdbbf32405707e2e2cfb526252da8",
+      "branches": {
+        "master": "0bafc3cfa1dfdbbf32405707e2e2cfb526252da8"
+      }
+    },
+    "ravenofseven/turtlecalendar": {
+      "default_branch": "main",
+      "sha": "d469a685d5746bbcce57399a3e7e92413bc568af",
+      "branches": {
+        "main": "d469a685d5746bbcce57399a3e7e92413bc568af"
+      }
+    },
+    "ravenofseven/turtlehonorspyenhanced": {
+      "default_branch": "master",
+      "sha": "85f3b67a7f1d5100c165045d02f2a845ab39102d",
+      "branches": {
+        "master": "85f3b67a7f1d5100c165045d02f2a845ab39102d"
+      }
+    },
+    "ravenofseven/turtlemail": {
+      "default_branch": "master",
+      "sha": "322429e143db1f1f00afe0d1074678a844bf8c7c",
+      "branches": {
+        "master": "322429e143db1f1f00afe0d1074678a844bf8c7c"
+      }
+    },
+    "ravenofseven/turtlerestedxp": {
+      "default_branch": "main",
+      "sha": "a125622f7391cb6e39be953306a7b58ed7fd8c60",
+      "branches": {
+        "main": "a125622f7391cb6e39be953306a7b58ed7fd8c60"
+      }
+    },
+    "ravenofseven/zoneslevel": {
+      "default_branch": "master",
+      "sha": "971eb5938524f0007ad2aab8eb2cf7a5e71d60ca",
+      "branches": {
+        "master": "971eb5938524f0007ad2aab8eb2cf7a5e71d60ca"
+      }
+    },
+    "raymondsvendsen/zorlentw": {
+      "default_branch": "main",
+      "sha": "bc794631e9e25451773b2803e6f2df46ccce58a5",
+      "branches": {
+        "main": "bc794631e9e25451773b2803e6f2df46ccce58a5"
+      }
+    },
+    "razzeee/aux-addon": {
+      "default_branch": "master",
+      "sha": "09728c5a5a4c9b30c05a25d4fc23a9247683fadc",
+      "branches": {
+        "master": "09728c5a5a4c9b30c05a25d4fc23a9247683fadc"
+      }
+    },
+    "razzeee/cursive": {
+      "default_branch": "master",
+      "sha": "4daa3bc25b07142aed8d2900a74d77b6cefa9f2e",
+      "branches": {
+        "master": "4daa3bc25b07142aed8d2900a74d77b6cefa9f2e"
+      }
+    },
+    "razzeee/puppeteer": {
+      "default_branch": "main",
+      "sha": "aa732a6c44f0dbba3c0803bc70243bf0fdb23060",
+      "branches": {
+        "main": "aa732a6c44f0dbba3c0803bc70243bf0fdb23060"
+      }
+    },
+    "razzeee/shaguscore": {
+      "default_branch": "master",
+      "sha": "b07d25e6a1fa30391d9dca0dd728e33a762c6711",
+      "branches": {
+        "master": "b07d25e6a1fa30391d9dca0dd728e33a762c6711"
+      }
+    },
+    "redbu11dev/cartographer": {
+      "default_branch": "master",
+      "sha": "f90b5b4db54a3ad65846454a93ca98e5a8d90ed6",
+      "branches": {
+        "master": "f90b5b4db54a3ad65846454a93ca98e5a8d90ed6"
+      }
+    },
+    "redbu11dev/coolhealthbar": {
+      "default_branch": "main",
+      "sha": "f8146269b5b09954b0fa356dbd9c0b4a194844b5",
+      "branches": {
+        "main": "f8146269b5b09954b0fa356dbd9c0b4a194844b5"
+      }
+    },
+    "redbu11dev/shaguplates-extra": {
+      "default_branch": "master",
+      "sha": "0567d1f849418ba1a3962abf02f484e676f6cc04",
+      "branches": {
+        "master": "0567d1f849418ba1a3962abf02f484e676f6cc04"
+      }
+    },
+    "redbu11dev/sortbybuyout": {
+      "default_branch": "main",
+      "sha": "4c437a3c05777fd6b207d721bf5a7f6fc394279a",
+      "branches": {
+        "main": "4c437a3c05777fd6b207d721bf5a7f6fc394279a"
+      }
+    },
+    "redbu11dev/unitplates": {
+      "default_branch": "main",
+      "sha": "1d7cd29b6a196bccafd0d68e6932db4372bd5d0d",
+      "branches": {
+        "main": "1d7cd29b6a196bccafd0d68e6932db4372bd5d0d"
+      }
+    },
+    "redbu11dev/x-perl-unitframes": {
+      "default_branch": "main",
+      "sha": "11a423763c17531b0957f909967f3ca1e9ace959",
+      "branches": {
+        "main": "11a423763c17531b0957f909967f3ca1e9ace959"
+      }
+    },
+    "redcloak/puppeteer": {
+      "default_branch": "main",
+      "sha": "a79777ffb123ec4f732e8d9f468d8e80abce715f",
+      "branches": {
+        "main": "a79777ffb123ec4f732e8d9f468d8e80abce715f"
+      }
+    },
+    "redmondgiant/groupfinder": {
+      "default_branch": "main",
+      "sha": "4776f0f2d1c144317cac2f4df281aa9b1e23da87",
+      "branches": {
+        "main": "4776f0f2d1c144317cac2f4df281aa9b1e23da87"
+      }
+    },
+    "redshadowz/groupfinder": {
+      "default_branch": "main",
+      "sha": "51ebb9beca1b0880ea15f3e293132d10488b9450",
+      "branches": {
+        "main": "51ebb9beca1b0880ea15f3e293132d10488b9450"
+      }
+    },
+    "reece844/lootmonitor": {
+      "default_branch": "main",
+      "sha": "8db67f4a8c99714cbb0b17a07fbdfa271b3cdb3b",
+      "branches": {
+        "main": "8db67f4a8c99714cbb0b17a07fbdfa271b3cdb3b"
+      }
+    },
+    "refaim/auldlangsyne": {
+      "default_branch": "master",
+      "sha": "5263f9feac9598d356104e0f949851102a1e73e6",
+      "branches": {
+        "master": "5263f9feac9598d356104e0f949851102a1e73e6"
+      }
+    },
+    "refaim/autodb2": {
+      "default_branch": "main",
+      "sha": "30969e81d98def1e948426f405e7f510563d78c8",
+      "branches": {
+        "main": "30969e81d98def1e948426f405e7f510563d78c8"
+      }
+    },
+    "refaim/bugsack": {
+      "default_branch": "master",
+      "sha": "68115c8e9f02e924773860fed66c18734ef45f93",
+      "branches": {
+        "master": "68115c8e9f02e924773860fed66c18734ef45f93"
+      }
+    },
+    "refaim/classicons": {
+      "default_branch": "master",
+      "sha": "8c8f26181ba8eddbd2f5b14e2b2932a7f9d01e6c",
+      "branches": {
+        "master": "8c8f26181ba8eddbd2f5b14e2b2932a7f9d01e6c"
+      }
+    },
+    "refaim/cleanchat": {
+      "default_branch": "master",
+      "sha": "84e0e57e306265ae4f5ace596678cefd27ff4475",
+      "branches": {
+        "master": "84e0e57e306265ae4f5ace596678cefd27ff4475"
+      }
+    },
+    "refaim/friend-o-tron": {
+      "default_branch": "master",
+      "sha": "70b9e118d59bb25224b3b386e2e03c7665d07089",
+      "branches": {
+        "master": "70b9e118d59bb25224b3b386e2e03c7665d07089"
+      }
+    },
+    "refaim/itemtooltipicons": {
+      "default_branch": "master",
+      "sha": "819e7565cc105cf58f54c6193d49b350a66a87c6",
+      "branches": {
+        "master": "819e7565cc105cf58f54c6193d49b350a66a87c6"
+      }
+    },
+    "refaim/kethodoc": {
+      "default_branch": "master",
+      "sha": "b7756d1395867ef87aa4f73d1a63443bc1510651",
+      "branches": {
+        "master": "b7756d1395867ef87aa4f73d1a63443bc1510651"
+      }
+    },
+    "refaim/mastertradeskills": {
+      "default_branch": "master",
+      "sha": "3c79aa916488a1703ccd83bdc6ca653c5db99436",
+      "branches": {
+        "master": "3c79aa916488a1703ccd83bdc6ca653c5db99436"
+      }
+    },
+    "refaim/missingcrafts": {
+      "default_branch": "master",
+      "sha": "e702ce7d781d68c2ead5f8223e59689edb8cfc91",
+      "branches": {
+        "master": "e702ce7d781d68c2ead5f8223e59689edb8cfc91"
+      }
+    },
+    "refaim/missingtradeskillslist": {
+      "default_branch": "master",
+      "sha": "807469745ce1ad1133073d814e2bb513666300ac",
+      "branches": {
+        "master": "807469745ce1ad1133073d814e2bb513666300ac"
+      }
+    },
+    "refaim/mobstats": {
+      "default_branch": "master",
+      "sha": "8835e8ebb554c3b5f3f2a74a0f4fd1c3e4ff4647",
+      "branches": {
+        "master": "8835e8ebb554c3b5f3f2a74a0f4fd1c3e4ff4647"
+      }
+    },
+    "refaim/petxpbar": {
+      "default_branch": "master",
+      "sha": "2a28c86848d4a6f8e6dd60d78d60d884e82c7493",
+      "branches": {
+        "master": "2a28c86848d4a6f8e6dd60d78d60d884e82c7493"
+      }
+    },
+    "refaim/possessions": {
+      "default_branch": "master",
+      "sha": "71be69c850328e2bfdaa6176a295937a210a20b2",
+      "branches": {
+        "master": "71be69c850328e2bfdaa6176a295937a210a20b2"
+      }
+    },
+    "refaim/reagentdata": {
+      "default_branch": "master",
+      "sha": "546f00fd43ae30f77f62ed3465dfafcebbfffffb",
+      "branches": {
+        "master": "546f00fd43ae30f77f62ed3465dfafcebbfffffb"
+      }
+    },
+    "refaim/reciperadar": {
+      "default_branch": "master",
+      "sha": "db200dae1f2d349e8f3fba83188e3950c73307af",
+      "branches": {
+        "master": "db200dae1f2d349e8f3fba83188e3950c73307af"
+      }
+    },
+    "refaim/restbar": {
+      "default_branch": "main",
+      "sha": "b77a74f633f84f84fa8c43ce0a9d5d49b5f9560b",
+      "branches": {
+        "main": "b77a74f633f84f84fa8c43ce0a9d5d49b5f9560b"
+      }
+    },
+    "refaim/shaguinventory": {
+      "default_branch": "master",
+      "sha": "b27840c425b665a3e8c0c9cd6fe3ddf0f72eeb6e",
+      "branches": {
+        "master": "b27840c425b665a3e8c0c9cd6fe3ddf0f72eeb6e"
+      }
+    },
+    "refaim/soloraidtargeticons": {
+      "default_branch": "master",
+      "sha": "6bfda6cb0a7ba487eb674c15fc67fd6cec599297",
+      "branches": {
+        "master": "6bfda6cb0a7ba487eb674c15fc67fd6cec599297"
+      }
+    },
+    "refaim/sortbags": {
+      "default_branch": "master",
+      "sha": "d1860047f1cd9ee73de84d96c46cbabb41639c16",
+      "branches": {
+        "master": "d1860047f1cd9ee73de84d96c46cbabb41639c16"
+      }
+    },
+    "refaim/soulshardmanager": {
+      "default_branch": "master",
+      "sha": "e2d124d5657a8b00f72218735b6c12137c8f6756",
+      "branches": {
+        "master": "e2d124d5657a8b00f72218735b6c12137c8f6756"
+      }
+    },
+    "refaim/succ-bag": {
+      "default_branch": "master",
+      "sha": "8e0b52194d91f14bf90a457c1778509eb86db8a3",
+      "branches": {
+        "master": "8e0b52194d91f14bf90a457c1778509eb86db8a3"
+      }
+    },
+    "refaim/superignore": {
+      "default_branch": "master",
+      "sha": "da02d908e753d717a52714d2d54907709f997d50",
+      "branches": {
+        "master": "da02d908e753d717a52714d2d54907709f997d50"
+      }
+    },
+    "refaim/tne-fivesec": {
+      "default_branch": "master",
+      "sha": "ba7edc3fb5b03cad24ebca9d71d63792e451d3b8",
+      "branches": {
+        "master": "ba7edc3fb5b03cad24ebca9d71d63792e451d3b8"
+      }
+    },
+    "refaim/tradeskillsdata": {
+      "default_branch": "master",
+      "sha": "262734ac1703dd93c4990458e08c52f175bde6ea",
+      "branches": {
+        "master": "262734ac1703dd93c4990458e08c52f175bde6ea"
+      }
+    },
+    "refaim/tradeskillsdata-turtle": {
+      "default_branch": "master",
+      "sha": "a3a09fea9e753d85907fdd7b80b70b742c180950",
+      "branches": {
+        "master": "a3a09fea9e753d85907fdd7b80b70b742c180950"
+      }
+    },
+    "refaim/trainerskills-vanilla": {
+      "default_branch": "master",
+      "sha": "2ee09ea012ba493505772c56162bc61feed7c2dc",
+      "branches": {
+        "master": "2ee09ea012ba493505772c56162bc61feed7c2dc"
+      }
+    },
+    "refaim/turtlehardcorechattamer": {
+      "default_branch": "master",
+      "sha": "d75592277db26e57cdd73445fa1d29477b695ea0",
+      "branches": {
+        "master": "d75592277db26e57cdd73445fa1d29477b695ea0"
+      }
+    },
+    "refaim/vanillagraphicboost": {
+      "default_branch": "master",
+      "sha": "0fc8a161e8bbfd84c4afebe9c0013e46c9ba9e5e",
+      "branches": {
+        "master": "0fc8a161e8bbfd84c4afebe9c0013e46c9ba9e5e"
+      }
+    },
+    "refaim/wim": {
+      "default_branch": "master",
+      "sha": "83498bba3333a96d1fd59415c11be21c2de3df6b",
+      "branches": {
+        "master": "83498bba3333a96d1fd59415c11be21c2de3df6b"
+      }
+    },
+    "reilly00/roll-for-group-therapy": {
+      "default_branch": "master",
+      "sha": "f10e9f682a88612c176ea9bb2021026ad9f1dbc5",
+      "branches": {
+        "master": "f10e9f682a88612c176ea9bb2021026ad9f1dbc5"
+      }
+    },
+    "rengoua/inspector": {
+      "default_branch": "master",
+      "sha": "e5070e2d528a697541bf8faad28b71fdf9081c4f",
+      "branches": {
+        "master": "e5070e2d528a697541bf8faad28b71fdf9081c4f"
+      }
+    },
+    "retherz/retherztargettracker": {
+      "default_branch": "master",
+      "sha": "4f9d4c7851e5bb92d51c7201a3c2d97b6f1fee7a",
+      "branches": {
+        "master": "4f9d4c7851e5bb92d51c7201a3c2d97b6f1fee7a"
+      }
+    },
+    "retrocro/turtlewow-mods": {
+      "default_branch": "main",
+      "sha": "aeb405ef9f207bfbd7fb63afb4ffc4e58f3589f9",
+      "branches": {
+        "main": "aeb405ef9f207bfbd7fb63afb4ffc4e58f3589f9"
+      }
+    },
+    "retrocro/unitscan-turtle-hc": {
+      "default_branch": "master",
+      "sha": "0a1002827b611c6cfbefe186329e9e412530f012",
+      "branches": {
+        "master": "0a1002827b611c6cfbefe186329e9e412530f012"
+      }
+    },
+    "retrospectx/cycircled": {
+      "default_branch": "master",
+      "sha": "67b8954972240dee686feb118de15fb42ac7e783",
+      "branches": {
+        "master": "67b8954972240dee686feb118de15fb42ac7e783"
+      }
+    },
+    "rfelleto/mlooklock": {
+      "default_branch": "main",
+      "sha": "c47a7598c4139cef7420b99da1ad063073f08e73",
+      "branches": {
+        "main": "c47a7598c4139cef7420b99da1ad063073f08e73"
+      }
+    },
+    "rgd87/nugcombobar": {
+      "default_branch": "master",
+      "sha": "96638740c04f0532bf098a262006115bf2baeb7d",
+      "branches": {
+        "master": "96638740c04f0532bf098a262006115bf2baeb7d"
+      },
+      "latest_tag": "11.0.7"
+    },
+    "rgd87/nugenergy": {
+      "default_branch": "master",
+      "sha": "8d169f83b4d85834d2d648c62f3256195bd2556f",
+      "branches": {
+        "master": "8d169f83b4d85834d2d648c62f3256195bd2556f"
+      },
+      "latest_tag": "11.0.3"
+    },
+    "riqqqque/impulse-booster": {
+      "default_branch": "master",
+      "sha": "c8ca66210b07a4a1bf1ed5ff5c877f36ae868b52",
+      "branches": {
+        "master": "c8ca66210b07a4a1bf1ed5ff5c877f36ae868b52"
+      },
+      "latest_tag": "v3.1.2"
+    },
+    "rivi-s/pfquest": {
+      "default_branch": "master",
+      "sha": "a7093c72434bb12dd5c6d5a528be8640d53436e4",
+      "branches": {
+        "master": "a7093c72434bb12dd5c6d5a528be8640d53436e4"
+      }
+    },
+    "rmarc29/etl_minute": {
+      "default_branch": "master",
+      "sha": "2c399c409438194c07acf4985167b6c02ad6b8f4",
+      "branches": {
+        "master": "2c399c409438194c07acf4985167b6c02ad6b8f4"
+      }
+    },
+    "rmarc29/unifiedtalentguides": {
+      "default_branch": "main",
+      "sha": "186691f8d98ef084e7e1c483380b27d9474a66bf",
+      "branches": {
+        "main": "186691f8d98ef084e7e1c483380b27d9474a66bf"
+      }
+    },
+    "rnorden/chaosreserves": {
+      "default_branch": "master",
+      "sha": "d4f84111c69b54ed1aa8223714c709bad086a42c",
+      "branches": {
+        "master": "d4f84111c69b54ed1aa8223714c709bad086a42c"
+      },
+      "latest_tag": "0.72"
+    },
+    "road-block/auldlangsyne": {
+      "default_branch": "master",
+      "sha": "e77bebedb909cc6defd946b49e456362c7825ceb",
+      "branches": {
+        "master": "e77bebedb909cc6defd946b49e456362c7825ceb"
+      },
+      "latest_tag": "1.1"
+    },
+    "road-block/autoprofit": {
+      "default_branch": "master",
+      "sha": "19ae2d47818c8405fd3ded54b2b5bbb74d443039",
+      "branches": {
+        "master": "19ae2d47818c8405fd3ded54b2b5bbb74d443039"
+      },
+      "latest_tag": "3.11a-11200"
+    },
+    "road-block/calltoarms": {
+      "default_branch": "master",
+      "sha": "aef2cef25340a270b1f889f8ea4429409da78aa5",
+      "branches": {
+        "master": "aef2cef25340a270b1f889f8ea4429409da78aa5"
+      },
+      "latest_tag": "R12.5"
+    },
+    "road-block/chatemote": {
+      "default_branch": "master",
+      "sha": "8a8e8dee15ce89ae0cc3ed380a76de76e2653c47",
+      "branches": {
+        "master": "8a8e8dee15ce89ae0cc3ed380a76de76e2653c47"
+      },
+      "latest_tag": "1.11-11200"
+    },
+    "road-block/classicsnowfall": {
+      "default_branch": "master",
+      "sha": "fd802c10662198d03a1dbe1ccc72aa314da515c6",
+      "branches": {
+        "master": "fd802c10662198d03a1dbe1ccc72aa314da515c6"
+      },
+      "latest_tag": "0.5-11200"
+    },
+    "road-block/closeup": {
+      "default_branch": "master",
+      "sha": "01c0c296b0840b5732690716156c9958744248c0",
+      "branches": {
+        "master": "01c0c296b0840b5732690716156c9958744248c0"
+      },
+      "latest_tag": "11200"
+    },
+    "road-block/colorsocialframe": {
+      "default_branch": "master",
+      "sha": "723fe40b9635fc96c48960cbb9b8bd189a4a4f06",
+      "branches": {
+        "master": "723fe40b9635fc96c48960cbb9b8bd189a4a4f06"
+      },
+      "latest_tag": "1.30"
+    },
+    "road-block/cooldowntimers": {
+      "default_branch": "master",
+      "sha": "c7fca4a1dddabd69c61ee0590a80100707b2bbe6",
+      "branches": {
+        "master": "c7fca4a1dddabd69c61ee0590a80100707b2bbe6"
+      },
+      "latest_tag": "1.3-11200"
+    },
+    "road-block/fubar_possessionsfu": {
+      "default_branch": "master",
+      "sha": "3911af9ab97be76e0bd5a2fa7a22eb5b853ebb73",
+      "branches": {
+        "master": "3911af9ab97be76e0bd5a2fa7a22eb5b853ebb73"
+      },
+      "latest_tag": "11200.3"
+    },
+    "road-block/fubar_tofu": {
+      "default_branch": "master",
+      "sha": "18838b126bd3417b8d32778961dc1e72590b33ab",
+      "branches": {
+        "master": "18838b126bd3417b8d32778961dc1e72590b33ab"
+      },
+      "latest_tag": "r15647"
+    },
+    "road-block/guildbank": {
+      "default_branch": "master",
+      "sha": "186dd49ab08936973902216d8a41e2418e2b0cf3",
+      "branches": {
+        "master": "186dd49ab08936973902216d8a41e2418e2b0cf3"
+      },
+      "latest_tag": "2.10-11200"
+    },
+    "road-block/interruptor": {
+      "default_branch": "master",
+      "sha": "777585a52a447fc59f42a625c8a38b7d411e1052",
+      "branches": {
+        "master": "777585a52a447fc59f42a625c8a38b7d411e1052"
+      }
+    },
+    "road-block/itemhints": {
+      "default_branch": "master",
+      "sha": "4e33174b1fc403d395671eefcbbc70a57fb6e52a",
+      "branches": {
+        "master": "4e33174b1fc403d395671eefcbbc70a57fb6e52a"
+      },
+      "latest_tag": "1.11"
+    },
+    "road-block/itemsofpower": {
+      "default_branch": "master",
+      "sha": "265fe97786de235ded987d984d853acec8740087",
+      "branches": {
+        "master": "265fe97786de235ded987d984d853acec8740087"
+      },
+      "latest_tag": "1.01-11200"
+    },
+    "road-block/killlog": {
+      "default_branch": "master",
+      "sha": "4e7b4b36433a5b1d20c5336d1ef57965dbc183a1",
+      "branches": {
+        "master": "4e7b4b36433a5b1d20c5336d1ef57965dbc183a1"
+      },
+      "latest_tag": "2.6.3-11200"
+    },
+    "road-block/languagefilter": {
+      "default_branch": "master",
+      "sha": "a64db8572ec0912e31b446bb6fd8168a1539f60e",
+      "branches": {
+        "master": "a64db8572ec0912e31b446bb6fd8168a1539f60e"
+      }
+    },
+    "road-block/loottracker": {
+      "default_branch": "master",
+      "sha": "889856f11922954c04dd179d9fd969d8e4445cb0",
+      "branches": {
+        "master": "889856f11922954c04dd179d9fd969d8e4445cb0"
+      },
+      "latest_tag": "1.38rb"
+    },
+    "road-block/losecontrol": {
+      "default_branch": "master",
+      "sha": "26f5e1db3aa74565dab0f620795949f2f346f44e",
+      "branches": {
+        "master": "26f5e1db3aa74565dab0f620795949f2f346f44e"
+      }
+    },
+    "road-block/masterlootremind": {
+      "default_branch": "master",
+      "sha": "ef9e73f27e13095b358897e223f20b626a91d9ed",
+      "branches": {
+        "master": "ef9e73f27e13095b358897e223f20b626a91d9ed"
+      },
+      "latest_tag": "1.21"
+    },
+    "road-block/nauticus": {
+      "default_branch": "master",
+      "sha": "a70898e2db91fdca139c336663a0fb3efe7a6890",
+      "branches": {
+        "master": "a70898e2db91fdca139c336663a0fb3efe7a6890"
+      },
+      "latest_tag": "2.01-11200"
+    },
+    "road-block/pingomatic": {
+      "default_branch": "master",
+      "sha": "9f20a088971d43b1152344ddb5a19fea0d65319c",
+      "branches": {
+        "master": "9f20a088971d43b1152344ddb5a19fea0d65319c"
+      },
+      "latest_tag": "1.12-11200"
+    },
+    "road-block/playerstates": {
+      "default_branch": "master",
+      "sha": "48c53ef9cdd03fcb490b4f50f3cfe8ebfa903ec8",
+      "branches": {
+        "master": "48c53ef9cdd03fcb490b4f50f3cfe8ebfa903ec8"
+      },
+      "latest_tag": "1.1-11200"
+    },
+    "road-block/questsoundbits": {
+      "default_branch": "master",
+      "sha": "2ddce3ae7d854b37cb4d11df227b796be510ddbe",
+      "branches": {
+        "master": "2ddce3ae7d854b37cb4d11df227b796be510ddbe"
+      },
+      "latest_tag": "2.11-11200"
+    },
+    "road-block/ragetracker": {
+      "default_branch": "master",
+      "sha": "caede7e5c6acf6bc118e45323dd7996c46cc89e7",
+      "branches": {
+        "master": "caede7e5c6acf6bc118e45323dd7996c46cc89e7"
+      },
+      "latest_tag": "1.0.0m"
+    },
+    "road-block/roguefocus": {
+      "default_branch": "master",
+      "sha": "1f0b166192dc8ace0cb42d321eb6b5289b141a49",
+      "branches": {
+        "master": "1f0b166192dc8ace0cb42d321eb6b5289b141a49"
+      },
+      "latest_tag": "1.04.11200"
+    },
+    "road-block/shootyepgp": {
+      "default_branch": "master",
+      "sha": "402d96b72234ff3a3adbb6e1d56dc6d32e96ffb8",
+      "branches": {
+        "master": "402d96b72234ff3a3adbb6e1d56dc6d32e96ffb8"
+      },
+      "latest_tag": "3.60"
+    },
+    "road-block/simplecombatlog": {
+      "default_branch": "master",
+      "sha": "2f4b6035c07d3e09fe15e33c2e9fe8e00fa739b3",
+      "branches": {
+        "master": "2f4b6035c07d3e09fe15e33c2e9fe8e00fa739b3"
+      }
+    },
+    "road-block/simpleraidtargeticons": {
+      "default_branch": "master",
+      "sha": "d3fc111d31165da561be9b71e42e90aa01d8322b",
+      "branches": {
+        "master": "d3fc111d31165da561be9b71e42e90aa01d8322b"
+      },
+      "latest_tag": "2.11"
+    },
+    "road-block/tourguide_professions": {
+      "default_branch": "master",
+      "sha": "3a03ed5ba31329b7c30e85238c3f07911108f725",
+      "branches": {
+        "master": "3a03ed5ba31329b7c30e85238c3f07911108f725"
+      },
+      "latest_tag": "1.0.0-beta"
+    },
+    "road-block/whofavorites": {
+      "default_branch": "master",
+      "sha": "04fd2b9eaca0d297a24d1daed103c534c344c921",
+      "branches": {
+        "master": "04fd2b9eaca0d297a24d1daed103c534c344c921"
+      },
+      "latest_tag": "1.0-11200"
+    },
+    "road-block/whohas": {
+      "default_branch": "master",
+      "sha": "cf4cc4e7d4b724f711fd34d1d03af54592346b2f",
+      "branches": {
+        "master": "cf4cc4e7d4b724f711fd34d1d03af54592346b2f"
+      },
+      "latest_tag": "2.33-11200"
+    },
+    "road-block/whokicksnow": {
+      "default_branch": "master",
+      "sha": "cdebe08fd20d8057fc3ca787bdd1fe250b6cdb64",
+      "branches": {
+        "master": "cdebe08fd20d8057fc3ca787bdd1fe250b6cdb64"
+      }
+    },
+    "road-block/xloot_addons": {
+      "default_branch": "master",
+      "sha": "4b7eab944828b061862f1fefb9b95f2f94f836c0",
+      "branches": {
+        "master": "4b7eab944828b061862f1fefb9b95f2f94f836c0"
+      },
+      "latest_tag": "0.93"
+    },
+    "roagosh/silverdragon": {
+      "default_branch": "master",
+      "sha": "ab6a890bd91b2d946fae440a2f220062d51df606",
+      "branches": {
+        "master": "ab6a890bd91b2d946fae440a2f220062d51df606"
+      }
+    },
+    "robs898/mobinfo2turtle": {
+      "default_branch": "master",
+      "sha": "72f07f7a5c55f84e7436bb192b3ed0f29297a476",
+      "branches": {
+        "master": "72f07f7a5c55f84e7436bb192b3ed0f29297a476"
+      }
+    },
+    "robs898/shaguinventory": {
+      "default_branch": "master",
+      "sha": "251b678d80dccb972cdde48820e0ff88b583aaaf",
+      "branches": {
+        "master": "251b678d80dccb972cdde48820e0ff88b583aaaf"
+      }
+    },
+    "roby-brok/mikscrollingbattletext": {
+      "default_branch": "octo",
+      "sha": "6169f104c873e3c90605339a4494b983892c5978",
+      "branches": {
+        "octo": "6169f104c873e3c90605339a4494b983892c5978"
+      }
+    },
+    "roby-brok/octomail": {
+      "default_branch": "master",
+      "sha": "3bc9470f5e76e4bca84ce278184ccd65a3f09f96",
+      "branches": {
+        "master": "3bc9470f5e76e4bca84ce278184ccd65a3f09f96"
+      }
+    },
+    "roby-brok/pfextend": {
+      "default_branch": "main",
+      "sha": "27c56f5ea75eced6249b349d4a61c86fd5ff9bcb",
+      "branches": {
+        "main": "27c56f5ea75eced6249b349d4a61c86fd5ff9bcb"
+      },
+      "latest_tag": "1.0.8"
+    },
+    "roby-brok/pfquest": {
+      "default_branch": "master",
+      "sha": "a71931538988b930ee51f115a7d5683fe914ec21",
+      "branches": {
+        "master": "a71931538988b930ee51f115a7d5683fe914ec21"
+      },
+      "latest_tag": "8.1.0"
     },
     "roby-brok/pfquest-classicapi": {
       "default_branch": "master",
@@ -15751,6 +10939,4192 @@
         "master": "a71931538988b930ee51f115a7d5683fe914ec21"
       },
       "latest_tag": "8.1.0"
+    },
+    "roby-brok/pfquest-octo": {
+      "default_branch": "master",
+      "sha": "c4d29afe690193ad673bd84d1299fa56665a20a2",
+      "branches": {
+        "master": "c4d29afe690193ad673bd84d1299fa56665a20a2"
+      },
+      "latest_tag": "1.3.1"
+    },
+    "roby-brok/pfui": {
+      "default_branch": "octo",
+      "sha": "3df77210ad68543dcce39dff96e5d664677acd98",
+      "branches": {
+        "octo": "3df77210ad68543dcce39dff96e5d664677acd98"
+      },
+      "latest_tag": "v9.0.21"
+    },
+    "roby-brok/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "73d1743e1096940fa8c4e039361bb047dff6877a",
+      "branches": {
+        "main": "73d1743e1096940fa8c4e039361bb047dff6877a"
+      }
+    },
+    "roby-brok/pfui-bettertotems": {
+      "default_branch": "main",
+      "sha": "9daab8d844a493b4f5435d1151cb276bc21c8de0",
+      "branches": {
+        "main": "9daab8d844a493b4f5435d1151cb276bc21c8de0"
+      }
+    },
+    "rogolist/whisperbind": {
+      "default_branch": "main",
+      "sha": "c09d2bc88736fc0e44255b87305ad6ea99d43290",
+      "branches": {
+        "main": "c09d2bc88736fc0e44255b87305ad6ea99d43290"
+      }
+    },
+    "roland-rwl/gatherer": {
+      "default_branch": "master",
+      "sha": "b6d5bc9df917ba2a2050f28d71fcaa0222653f99",
+      "branches": {
+        "master": "b6d5bc9df917ba2a2050f28d71fcaa0222653f99"
+      }
+    },
+    "rollingsmile/guildroll": {
+      "default_branch": "main",
+      "sha": "cb5ccbb40cd81ab586e77d515e92a58883ff2176",
+      "branches": {
+        "main": "cb5ccbb40cd81ab586e77d515e92a58883ff2176"
+      }
+    },
+    "ronjebara/wiiiui_redux": {
+      "default_branch": "master",
+      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
+      "branches": {
+        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
+      }
+    },
+    "rouzihiro/unleashedtracker": {
+      "default_branch": "main",
+      "sha": "8422f5f9d5809b9f99ab1e38e1579189b3a3380d",
+      "branches": {
+        "main": "8422f5f9d5809b9f99ab1e38e1579189b3a3380d"
+      }
+    },
+    "rptb1/hunterswissknife": {
+      "default_branch": "master",
+      "sha": "206043ebfaa51ccdec19c6ef5b851c87335d03db",
+      "branches": {
+        "master": "206043ebfaa51ccdec19c6ef5b851c87335d03db"
+      },
+      "latest_tag": "v1.1"
+    },
+    "rsheep/zgtracker": {
+      "default_branch": "master",
+      "sha": "b6dee9ff1d670adbd95643b7eff3fea1e5d18bae",
+      "branches": {
+        "master": "b6dee9ff1d670adbd95643b7eff3fea1e5d18bae"
+      },
+      "latest_tag": "v0.095"
+    },
+    "rudaznoe/dragonflightui-reforged": {
+      "default_branch": "main",
+      "sha": "3e692803af230a4f5fc81a5fc9cd39dba848aa11",
+      "branches": {
+        "main": "3e692803af230a4f5fc81a5fc9cd39dba848aa11"
+      }
+    },
+    "rumchiller/em_critbam": {
+      "default_branch": "master",
+      "sha": "01c93b5ed63af6bf3d2140317a51e81ceb2bd1b6",
+      "branches": {
+        "master": "01c93b5ed63af6bf3d2140317a51e81ceb2bd1b6"
+      }
+    },
+    "rumchiller/em_monkeybuddy": {
+      "default_branch": "master",
+      "sha": "07137f6d32f67c5ffac9b35de6e150e1845f676d",
+      "branches": {
+        "master": "07137f6d32f67c5ffac9b35de6e150e1845f676d"
+      }
+    },
+    "rumchiller/em_monkeyquest": {
+      "default_branch": "master",
+      "sha": "e5bc0ce47d3ae5a61ebdfd449ece7c485446cb2a",
+      "branches": {
+        "master": "e5bc0ce47d3ae5a61ebdfd449ece7c485446cb2a"
+      }
+    },
+    "rumchiller/em_wowquote": {
+      "default_branch": "master",
+      "sha": "8529606a5be5926bec4630ec63d48b9864fb01c8",
+      "branches": {
+        "master": "8529606a5be5926bec4630ec63d48b9864fb01c8"
+      },
+      "latest_tag": "0.2"
+    },
+    "rumchiller/em_yatlas": {
+      "default_branch": "master",
+      "sha": "5147dcb566afd42bcc1c694b004bdc7d6a6f0579",
+      "branches": {
+        "master": "5147dcb566afd42bcc1c694b004bdc7d6a6f0579"
+      }
+    },
+    "ruskemiahahn/cursive": {
+      "default_branch": "master",
+      "sha": "2174684775cf149112b0d52912b88165657de759",
+      "branches": {
+        "master": "2174684775cf149112b0d52912b88165657de759"
+      }
+    },
+    "ruskemiahahn/ezpoison": {
+      "default_branch": "main",
+      "sha": "7092059a8652d944b5c09aedfe140895857eff0e",
+      "branches": {
+        "main": "7092059a8652d944b5c09aedfe140895857eff0e"
+      }
+    },
+    "russlando/zui": {
+      "default_branch": "master",
+      "sha": "d984370471ab64ede453ea9549fa3d64099dfd09",
+      "branches": {
+        "master": "d984370471ab64ede453ea9549fa3d64099dfd09"
+      }
+    },
+    "ruvaro-ahol/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
+      "branches": {
+        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
+      }
+    },
+    "ryanhope/cheebajunk": {
+      "default_branch": "master",
+      "sha": "a845c99d55166d52c3df8008d109f3ee7df86c85",
+      "branches": {
+        "master": "a845c99d55166d52c3df8008d109f3ee7df86c85"
+      }
+    },
+    "s4intzzz/bearcastbar": {
+      "default_branch": "master",
+      "sha": "626d6648f135b27efe674520632ecffb9b62211e",
+      "branches": {
+        "master": "626d6648f135b27efe674520632ecffb9b62211e"
+      }
+    },
+    "sabinewren/quiver": {
+      "default_branch": "main",
+      "sha": "5a8ecd852efab6b4b0ef74573e33d855f39d1006",
+      "branches": {
+        "main": "5a8ecd852efab6b4b0ef74573e33d855f39d1006"
+      },
+      "latest_tag": "v3.1.5"
+    },
+    "saegiru/channel_monitor": {
+      "default_branch": "master",
+      "sha": "febfc02bccfc33214131d822cef75520c70f464c",
+      "branches": {
+        "master": "febfc02bccfc33214131d822cef75520c70f464c"
+      }
+    },
+    "samahee/grayautosell": {
+      "default_branch": "master",
+      "sha": "7e431551d535fdc57b66721659c107c7b6e2326c",
+      "branches": {
+        "master": "7e431551d535fdc57b66721659c107c7b6e2326c"
+      },
+      "latest_tag": "1.0"
+    },
+    "samahee/instancejournal": {
+      "default_branch": "master",
+      "sha": "b58ebe0ffd9bd7bc1c18d0a7d009795d1c2a942c",
+      "branches": {
+        "master": "b58ebe0ffd9bd7bc1c18d0a7d009795d1c2a942c"
+      }
+    },
+    "samahee/pfquest-turtle": {
+      "default_branch": "master",
+      "sha": "08d9a117dabfbf9db0a7c2e0da47ee995302785f",
+      "branches": {
+        "master": "08d9a117dabfbf9db0a7c2e0da47ee995302785f"
+      }
+    },
+    "samahee/puppeteer": {
+      "default_branch": "main",
+      "sha": "119a2381c6af3da4014ec2b50b9a33c7d56d02e7",
+      "branches": {
+        "main": "119a2381c6af3da4014ec2b50b9a33c7d56d02e7"
+      }
+    },
+    "sandelarma/gudaplates": {
+      "default_branch": "main",
+      "sha": "a51dc61ccfd1be21185882d61a8ac9cbe0138ac5",
+      "branches": {
+        "main": "a51dc61ccfd1be21185882d61a8ac9cbe0138ac5"
+      }
+    },
+    "sandreasub/questie-octo": {
+      "default_branch": "main",
+      "sha": "7b33aee91bcdce4e387559222a1428768c08643f",
+      "branches": {
+        "main": "7b33aee91bcdce4e387559222a1428768c08643f"
+      }
+    },
+    "sandworlds-mmo/modifiedpowerauras": {
+      "default_branch": "master",
+      "sha": "faf26552df05146251866a092dd6812999ed578d",
+      "branches": {
+        "master": "faf26552df05146251866a092dd6812999ed578d"
+      }
+    },
+    "sandworlds-mmo/quiver": {
+      "default_branch": "main",
+      "sha": "b56546408b0163ac7439cd2a6fd28da38108bdf7",
+      "branches": {
+        "main": "b56546408b0163ac7439cd2a6fd28da38108bdf7"
+      }
+    },
+    "sandworlds-mmo/rested": {
+      "default_branch": "master",
+      "sha": "8bcc360ddec4b3ca56a89d1cd445c5d19484d0b2",
+      "branches": {
+        "master": "8bcc360ddec4b3ca56a89d1cd445c5d19484d0b2"
+      }
+    },
+    "sandworlds-mmo/shagudps": {
+      "default_branch": "master",
+      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
+      "branches": {
+        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
+      }
+    },
+    "sandworlds-mmo/shaguplates": {
+      "default_branch": "master",
+      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
+      "branches": {
+        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
+      }
+    },
+    "sandworlds-mmo/sw-decursive2": {
+      "default_branch": "master",
+      "sha": "bc6df9e9b5e3f643b3857d5b9fba8127ab4f8163",
+      "branches": {
+        "master": "bc6df9e9b5e3f643b3857d5b9fba8127ab4f8163"
+      }
+    },
+    "sandworlds-mmo/sw-reciperadar": {
+      "default_branch": "master",
+      "sha": "db200dae1f2d349e8f3fba83188e3950c73307af",
+      "branches": {
+        "master": "db200dae1f2d349e8f3fba83188e3950c73307af"
+      }
+    },
+    "sandworlds-mmo/sw-simpleraidtargeticons": {
+      "default_branch": "master",
+      "sha": "d3fc111d31165da561be9b71e42e90aa01d8322b",
+      "branches": {
+        "master": "d3fc111d31165da561be9b71e42e90aa01d8322b"
+      }
+    },
+    "satan666/lazyspell": {
+      "default_branch": "master",
+      "sha": "3e9a5eee251fca2bd6bcede98f71270fdb955dae",
+      "branches": {
+        "master": "3e9a5eee251fca2bd6bcede98f71270fdb955dae"
+      }
+    },
+    "satan666/reckcounter-fix": {
+      "default_branch": "master",
+      "sha": "f3d3714df928af06858090e0ea78fd3dec079d87",
+      "branches": {
+        "master": "f3d3714df928af06858090e0ea78fd3dec079d87"
+      }
+    },
+    "satan666/sraidframes_improved": {
+      "default_branch": "master",
+      "sha": "4642e662aeb628b1df510666407ace422def6a16",
+      "branches": {
+        "master": "4642e662aeb628b1df510666407ace422def6a16"
+      }
+    },
+    "saulfire/dialogui-turtlelatam": {
+      "default_branch": "main",
+      "sha": "c82da045147a534a0526a7b602a17d8940b73557",
+      "branches": {
+        "main": "c82da045147a534a0526a7b602a17d8940b73557"
+      }
+    },
+    "saxxonpike/cleanup": {
+      "default_branch": "master",
+      "sha": "4c83ecb84f376979a0ac6b4747a0bed467cb9b90",
+      "branches": {
+        "master": "4c83ecb84f376979a0ac6b4747a0bed467cb9b90"
+      }
+    },
+    "saxxonpike/sortbags": {
+      "default_branch": "master",
+      "sha": "1b59767ca41749e70d72f2991c27054beebcdfcd",
+      "branches": {
+        "master": "1b59767ca41749e70d72f2991c27054beebcdfcd"
+      }
+    },
+    "sc4r15/roguerota": {
+      "default_branch": "master",
+      "sha": "270af53189c0b14ca5320366f2b50b775687c065",
+      "branches": {
+        "master": "270af53189c0b14ca5320366f2b50b775687c065"
+      },
+      "latest_tag": "b1"
+    },
+    "schaka/buffhook": {
+      "default_branch": "master",
+      "sha": "3e40ae1c218f27521c99754b43b7b506d8348391",
+      "branches": {
+        "master": "3e40ae1c218f27521c99754b43b7b506d8348391"
+      }
+    },
+    "schaka/getspellinfovanilla": {
+      "default_branch": "master",
+      "sha": "670281584e893cf636af59258a237637e076767c",
+      "branches": {
+        "master": "670281584e893cf636af59258a237637e076767c"
+      }
+    },
+    "scheffmr/guda": {
+      "default_branch": "main",
+      "sha": "bf83de013863c9bb007fcc1db98165fb4e85808c",
+      "branches": {
+        "main": "bf83de013863c9bb007fcc1db98165fb4e85808c"
+      }
+    },
+    "scoboose/grimoirekeeper": {
+      "default_branch": "main",
+      "sha": "05f70668d425d0c5073538c3ac8e85b6380ccd5b",
+      "branches": {
+        "main": "05f70668d425d0c5073538c3ac8e85b6380ccd5b"
+      }
+    },
+    "scoboose/mobinfo2-turtle": {
+      "default_branch": "master",
+      "sha": "e0b192b7f22586d1262be3b3d4de73508e14faaf",
+      "branches": {
+        "master": "e0b192b7f22586d1262be3b3d4de73508e14faaf"
+      }
+    },
+    "scoboose/notesuneed-turtle": {
+      "default_branch": "master",
+      "sha": "0f35ca358bc0ea052bd4ce38bd1a13f977dd37ef",
+      "branches": {
+        "master": "0f35ca358bc0ea052bd4ce38bd1a13f977dd37ef"
+      }
+    },
+    "scotthamper/chatsuey": {
+      "default_branch": "master",
+      "sha": "c63bbef38a3f8989546f254c3867168567072fb0",
+      "branches": {
+        "master": "c63bbef38a3f8989546f254c3867168567072fb0"
+      },
+      "latest_tag": "1.2.0"
+    },
+    "scumbucky/sellvalue": {
+      "default_branch": "master",
+      "sha": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e",
+      "branches": {
+        "master": "5683c445bd08e0fd46dc090b2c5a8e235989ec7e"
+      }
+    },
+    "seacrabsam/lockport": {
+      "default_branch": "main",
+      "sha": "24c61e42b683d3b422d5c8744feb195e0137e04a",
+      "branches": {
+        "main": "24c61e42b683d3b422d5c8744feb195e0137e04a"
+      }
+    },
+    "seacrabsam/patch-herb": {
+      "default_branch": "main",
+      "sha": "c252bbdc2aef1ac928eb237cf4d28edc21806ed8",
+      "branches": {
+        "main": "c252bbdc2aef1ac928eb237cf4d28edc21806ed8"
+      }
+    },
+    "sei444/decursive": {
+      "default_branch": "master",
+      "sha": "9891d3378ce44bfdfa6b5f7f085536a4fc960494",
+      "branches": {
+        "master": "9891d3378ce44bfdfa6b5f7f085536a4fc960494"
+      }
+    },
+    "selfinterest/bagshui": {
+      "default_branch": "main",
+      "sha": "96d143dbe81e57c350994a93a5fc9b05d1b2e4da",
+      "branches": {
+        "main": "96d143dbe81e57c350994a93a5fc9b05d1b2e4da"
+      }
+    },
+    "sentilix/capslock": {
+      "default_branch": "master",
+      "sha": "2960f9fc9d0fdef39949729fbc71fbc4ea84a67d",
+      "branches": {
+        "master": "2960f9fc9d0fdef39949729fbc71fbc4ea84a67d"
+      },
+      "latest_tag": "0.3.1"
+    },
+    "sentilix/pitty": {
+      "default_branch": "master",
+      "sha": "a6f7ee211029d9adbe9f0c7130a7361e44a19a13",
+      "branches": {
+        "master": "a6f7ee211029d9adbe9f0c7130a7361e44a19a13"
+      },
+      "latest_tag": "pitty-1.2.0-rc1"
+    },
+    "sentilix/sota": {
+      "default_branch": "master",
+      "sha": "bb7f8d172cc5c9885d2c40c4701e6df78fcf05ab",
+      "branches": {
+        "master": "bb7f8d172cc5c9885d2c40c4701e6df78fcf05ab"
+      },
+      "latest_tag": "sota-1.2.0"
+    },
+    "sentilix/thaliz": {
+      "default_branch": "master",
+      "sha": "501cdab796a711bb4c0a7e22e8fdd360b4d095fe",
+      "branches": {
+        "master": "501cdab796a711bb4c0a7e22e8fdd360b4d095fe"
+      },
+      "latest_tag": "thaliz-1.5.0"
+    },
+    "seraphic8x2244/akkio_consume_helper": {
+      "default_branch": "main",
+      "sha": "919898418d579bf1478832f29bca7d2066aab72a",
+      "branches": {
+        "main": "919898418d579bf1478832f29bca7d2066aab72a"
+      }
+    },
+    "seraphic8x2244/cooline": {
+      "default_branch": "master",
+      "sha": "b63b5ac4066b7067bf2d9cf12108da46992b1ea7",
+      "branches": {
+        "master": "b63b5ac4066b7067bf2d9cf12108da46992b1ea7"
+      }
+    },
+    "seset/puppeteer": {
+      "default_branch": "main",
+      "sha": "899408c4e97ea19165ea0c049e70046966f3ad25",
+      "branches": {
+        "main": "899408c4e97ea19165ea0c049e70046966f3ad25"
+      }
+    },
+    "seven7000/fishingbuddy": {
+      "default_branch": "main",
+      "sha": "de057d0b6ed86f8a8bcfb5588c793dadd35cc53d",
+      "branches": {
+        "main": "de057d0b6ed86f8a8bcfb5588c793dadd35cc53d"
+      }
+    },
+    "shagu/antispam": {
+      "default_branch": "master",
+      "sha": "c1efb663f2fd722c23eef8c6087ec081bd151125",
+      "branches": {
+        "master": "c1efb663f2fd722c23eef8c6087ec081bd151125"
+      }
+    },
+    "shagu/cartographer": {
+      "default_branch": "master",
+      "sha": "9b2997bf85f2758e9d3a94028fa0ad158b001245",
+      "branches": {
+        "master": "9b2997bf85f2758e9d3a94028fa0ad158b001245"
+      }
+    },
+    "shagu/clique": {
+      "default_branch": "master",
+      "sha": "87717adc0ba5456aadfb88cb9fa0a2189c241763",
+      "branches": {
+        "master": "87717adc0ba5456aadfb88cb9fa0a2189c241763"
+      },
+      "latest_tag": "14063"
+    },
+    "shagu/gmblacklist": {
+      "default_branch": "master",
+      "sha": "46ee64b772f809fd5d78a7773ddcc2a2335240c4",
+      "branches": {
+        "master": "46ee64b772f809fd5d78a7773ddcc2a2335240c4"
+      }
+    },
+    "shagu/pfdebug": {
+      "default_branch": "master",
+      "sha": "6f305a9b141cead0d2d141e81dc4e860db3acbbc",
+      "branches": {
+        "master": "6f305a9b141cead0d2d141e81dc4e860db3acbbc"
+      }
+    },
+    "shagu/pfdesktop": {
+      "default_branch": "master",
+      "sha": "7d65013e01838d96c8750127850da7d517859141",
+      "branches": {
+        "master": "7d65013e01838d96c8750127850da7d517859141"
+      }
+    },
+    "shagu/pfquest": {
+      "default_branch": "master",
+      "sha": "104f35678ca39ab1fb78b655f815cc7016f5e0c8",
+      "branches": {
+        "master": "104f35678ca39ab1fb78b655f815cc7016f5e0c8"
+      },
+      "latest_tag": "7.0.1"
+    },
+    "shagu/pfquest-icons": {
+      "default_branch": "master",
+      "sha": "709ba275b7198b93713b5b06cf896dc9006ebeea",
+      "branches": {
+        "master": "709ba275b7198b93713b5b06cf896dc9006ebeea"
+      }
+    },
+    "shagu/pfquest-turtle": {
+      "default_branch": "master",
+      "sha": "0bc7bf4e55d8867a065354da6f386461255e4801",
+      "branches": {
+        "master": "0bc7bf4e55d8867a065354da6f386461255e4801"
+      }
+    },
+    "shagu/pfstudio": {
+      "default_branch": "master",
+      "sha": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78",
+      "branches": {
+        "master": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78"
+      }
+    },
+    "shagu/pfui": {
+      "default_branch": "master",
+      "sha": "b2f6df84a93a4ce6adbe1fd8f0372454795151f1",
+      "branches": {
+        "master": "b2f6df84a93a4ce6adbe1fd8f0372454795151f1"
+      }
+    },
+    "shagu/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
+      "branches": {
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
+      }
+    },
+    "shagu/pfui-fonts": {
+      "default_branch": "master",
+      "sha": "21000056503a71c349584c34b159e1a04974de78",
+      "branches": {
+        "master": "21000056503a71c349584c34b159e1a04974de78"
+      }
+    },
+    "shagu/shaguactions": {
+      "default_branch": "master",
+      "sha": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8",
+      "branches": {
+        "master": "b775fee8974e4ef7876b3a4d8bbd1580871e3da8"
+      }
+    },
+    "shagu/shagubam": {
+      "default_branch": "master",
+      "sha": "5fd6bc33e1b0b4d1999a2470d651295163daeab2",
+      "branches": {
+        "master": "5fd6bc33e1b0b4d1999a2470d651295163daeab2"
+      }
+    },
+    "shagu/shaguboat": {
+      "default_branch": "master",
+      "sha": "e2b3877a31cefdc36cf6fe46f4ef7a2f98dc228a",
+      "branches": {
+        "master": "e2b3877a31cefdc36cf6fe46f4ef7a2f98dc228a"
+      }
+    },
+    "shagu/shagubop": {
+      "default_branch": "master",
+      "sha": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9",
+      "branches": {
+        "master": "0aa413780b8e2c3e3ed88b195b4fd2e284f158b9"
+      }
+    },
+    "shagu/shaguchat": {
+      "default_branch": "master",
+      "sha": "01c37853c5e714b218837d24932c316f68b2728f",
+      "branches": {
+        "master": "01c37853c5e714b218837d24932c316f68b2728f"
+      }
+    },
+    "shagu/shaguclock": {
+      "default_branch": "master",
+      "sha": "3ca9d1d41c9e7327d4c638dd19a65df15e8dbc68",
+      "branches": {
+        "master": "3ca9d1d41c9e7327d4c638dd19a65df15e8dbc68"
+      }
+    },
+    "shagu/shagucolor": {
+      "default_branch": "master",
+      "sha": "b4fd1b82b665c36ea6ef5879ec3707d34585bc62",
+      "branches": {
+        "master": "b4fd1b82b665c36ea6ef5879ec3707d34585bc62"
+      }
+    },
+    "shagu/shagucombat": {
+      "default_branch": "master",
+      "sha": "04e7a81a58d0e45d0529737d35a1d62dd3204f0c",
+      "branches": {
+        "master": "04e7a81a58d0e45d0529737d35a1d62dd3204f0c"
+      }
+    },
+    "shagu/shagucopy": {
+      "default_branch": "master",
+      "sha": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182",
+      "branches": {
+        "master": "f6a7e741c7050478306b8eb13d00bbdd5cd0e182"
+      }
+    },
+    "shagu/shagudelgado": {
+      "default_branch": "master",
+      "sha": "cbe2dd666f1c0f388d5133412e6b151cb6abb4e7",
+      "branches": {
+        "master": "cbe2dd666f1c0f388d5133412e6b151cb6abb4e7"
+      }
+    },
+    "shagu/shagudps": {
+      "default_branch": "master",
+      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
+      "branches": {
+        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
+      }
+    },
+    "shagu/shaguerror": {
+      "default_branch": "master",
+      "sha": "da847ea462dd6c3f8c009267ccf8eb9ef35b5916",
+      "branches": {
+        "master": "da847ea462dd6c3f8c009267ccf8eb9ef35b5916"
+      }
+    },
+    "shagu/shaguinventory": {
+      "default_branch": "master",
+      "sha": "00eeeb2da84d33bb2f51f1a5bda97dc08978772c",
+      "branches": {
+        "master": "00eeeb2da84d33bb2f51f1a5bda97dc08978772c"
+      }
+    },
+    "shagu/shagujunk": {
+      "default_branch": "master",
+      "sha": "9a91065d8ef9078a9ea8b7d254e88605e8367567",
+      "branches": {
+        "master": "9a91065d8ef9078a9ea8b7d254e88605e8367567"
+      }
+    },
+    "shagu/shagukill": {
+      "default_branch": "master",
+      "sha": "498e2db84d2d666717d04538641add7ebca967cd",
+      "branches": {
+        "master": "498e2db84d2d666717d04538641add7ebca967cd"
+      }
+    },
+    "shagu/shagumount": {
+      "default_branch": "master",
+      "sha": "e688d31e6f7792728d2e9adf5c33bc8d48f72e75",
+      "branches": {
+        "master": "e688d31e6f7792728d2e9adf5c33bc8d48f72e75"
+      }
+    },
+    "shagu/shagunotify": {
+      "default_branch": "master",
+      "sha": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49",
+      "branches": {
+        "master": "2ecb31ec07b4e815c320c0e4f461adaabb7eca49"
+      }
+    },
+    "shagu/shaguplates": {
+      "default_branch": "master",
+      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
+      "branches": {
+        "master": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
+      }
+    },
+    "shagu/shaguscan": {
+      "default_branch": "master",
+      "sha": "93de72eef2527cae356d28274afed8f819dc45c1",
+      "branches": {
+        "master": "93de72eef2527cae356d28274afed8f819dc45c1"
+      }
+    },
+    "shagu/shaguscore": {
+      "default_branch": "master",
+      "sha": "b07d25e6a1fa30391d9dca0dd728e33a762c6711",
+      "branches": {
+        "master": "b07d25e6a1fa30391d9dca0dd728e33a762c6711"
+      }
+    },
+    "shagu/shagustance": {
+      "default_branch": "master",
+      "sha": "26cde9d5049018b9b8de745177a79c972f9f78f8",
+      "branches": {
+        "master": "26cde9d5049018b9b8de745177a79c972f9f78f8"
+      }
+    },
+    "shagu/shagutooltips": {
+      "default_branch": "master",
+      "sha": "85abb17f4181b514ef6848e380aafd0616bad12e",
+      "branches": {
+        "master": "85abb17f4181b514ef6848e380aafd0616bad12e"
+      }
+    },
+    "shagu/shagutweaks": {
+      "default_branch": "master",
+      "sha": "7d670218a9b1e0a6a9a9062c0f458508398f2e48",
+      "branches": {
+        "master": "7d670218a9b1e0a6a9a9062c0f458508398f2e48"
+      }
+    },
+    "shagu/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
+      "branches": {
+        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
+      }
+    },
+    "shagu/shaguvalue": {
+      "default_branch": "master",
+      "sha": "debbde88b68a941b13a614612a7aa867cadbe542",
+      "branches": {
+        "master": "debbde88b68a941b13a614612a7aa867cadbe542"
+      }
+    },
+    "shagu/shaguwidget": {
+      "default_branch": "master",
+      "sha": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0",
+      "branches": {
+        "master": "c37db5e2609e748eafb05b663cf8eb4a3439ebd0"
+      }
+    },
+    "sheed90/eavesdrop-turtlewow": {
+      "default_branch": "master",
+      "sha": "e7e5e265c2c82b026e778dceecf51d6c3140c57a",
+      "branches": {
+        "master": "e7e5e265c2c82b026e778dceecf51d6c3140c57a"
+      }
+    },
+    "shellyoung/advancedtradeskillwindow2": {
+      "default_branch": "main",
+      "sha": "9f35415ce20fdea6b42e19b944c17547f2d93f31",
+      "branches": {
+        "main": "9f35415ce20fdea6b42e19b944c17547f2d93f31"
+      },
+      "latest_tag": "2.1.16"
+    },
+    "shellyoung/fubar_population": {
+      "default_branch": "main",
+      "sha": "9bf2673f876fb9700a6cef4265144e832d0f4b29",
+      "branches": {
+        "main": "9bf2673f876fb9700a6cef4265144e832d0f4b29"
+      },
+      "latest_tag": "2.3"
+    },
+    "shellyoung/ocb-superwow": {
+      "default_branch": "main",
+      "sha": "4a0d93c5be8dce813dfccf6c167344441f2fabe9",
+      "branches": {
+        "main": "4a0d93c5be8dce813dfccf6c167344441f2fabe9"
+      },
+      "latest_tag": "3.8.3"
+    },
+    "shigemunekurogane/mastertradeskills": {
+      "default_branch": "master",
+      "sha": "46bd70ceb60a30a671e9da3caf092a057e2abf17",
+      "branches": {
+        "master": "46bd70ceb60a30a671e9da3caf092a057e2abf17"
+      }
+    },
+    "shigemunekurogane/missingcrafts": {
+      "default_branch": "master",
+      "sha": "cda4bdac4eb9a29e4a1baa1bfbe56104b89e8962",
+      "branches": {
+        "master": "cda4bdac4eb9a29e4a1baa1bfbe56104b89e8962"
+      }
+    },
+    "shigemunekurogane/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "a499442783df407737a914e63718e26ec3b74a31",
+      "branches": {
+        "main": "a499442783df407737a914e63718e26ec3b74a31"
+      }
+    },
+    "shigemunekurogane/shagudps": {
+      "default_branch": "master",
+      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
+      "branches": {
+        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
+      }
+    },
+    "shigemunekurogane/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
+      "branches": {
+        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
+      }
+    },
+    "shikawalepaladin/shikaswap": {
+      "default_branch": "main",
+      "sha": "fb28ae9bceac50fc75a7d70b732c1692d1fe0f86",
+      "branches": {
+        "main": "fb28ae9bceac50fc75a7d70b732c1692d1fe0f86"
+      }
+    },
+    "shikulja/decursive": {
+      "default_branch": "master",
+      "sha": "9164fa25dc9eca70dae86321f226ddb34714f2f5",
+      "branches": {
+        "master": "9164fa25dc9eca70dae86321f226ddb34714f2f5"
+      }
+    },
+    "shikulja/fubar_tofu": {
+      "default_branch": "master",
+      "sha": "cd17532c32125651ae7f78f9d34266a514f6a3d1",
+      "branches": {
+        "master": "cd17532c32125651ae7f78f9d34266a514f6a3d1"
+      },
+      "latest_tag": "r15647"
+    },
+    "shikulja/hcspy": {
+      "default_branch": "master",
+      "sha": "840c80c2f6309aae1e8ba410ca4ec1351ab343f1",
+      "branches": {
+        "master": "840c80c2f6309aae1e8ba410ca4ec1351ab343f1"
+      }
+    },
+    "shikulja/magehud": {
+      "default_branch": "main",
+      "sha": "acb108b45963c79ec2a4bc710383ff8980a0ac7f",
+      "branches": {
+        "main": "acb108b45963c79ec2a4bc710383ff8980a0ac7f"
+      }
+    },
+    "shikulja/mastertradeskills": {
+      "default_branch": "master",
+      "sha": "18535fe277dcda131789e3be5d2b8d8c6950a5e4",
+      "branches": {
+        "master": "18535fe277dcda131789e3be5d2b8d8c6950a5e4"
+      }
+    },
+    "shikulja/quickheal": {
+      "default_branch": "master",
+      "sha": "8c974e9f1da0f1e439b087d2743f12891d7b585d",
+      "branches": {
+        "master": "8c974e9f1da0f1e439b087d2743f12891d7b585d"
+      },
+      "latest_tag": "hc01"
+    },
+    "shikulja/reagentdata": {
+      "default_branch": "master",
+      "sha": "42602d2ca183612168c23e20d6c19afa032b6feb",
+      "branches": {
+        "master": "42602d2ca183612168c23e20d6c19afa032b6feb"
+      }
+    },
+    "shikulja/shaguplates": {
+      "default_branch": "master",
+      "sha": "ae9834da2c39272a859af8e6d90c82ecb04770bb",
+      "branches": {
+        "master": "ae9834da2c39272a859af8e6d90c82ecb04770bb"
+      }
+    },
+    "shikulja/shaguscan": {
+      "default_branch": "master",
+      "sha": "94f113b74e7432f8562f23da413f628d098852aa",
+      "branches": {
+        "master": "94f113b74e7432f8562f23da413f628d098852aa"
+      }
+    },
+    "shikulja/spamthrottle": {
+      "default_branch": "master",
+      "sha": "9e2a2520150a021a0295ea12eaff2d4369eded6a",
+      "branches": {
+        "master": "9e2a2520150a021a0295ea12eaff2d4369eded6a"
+      }
+    },
+    "shikulja/tankplates": {
+      "default_branch": "master",
+      "sha": "c271b882b6f39f7f2f68d5f5403e17b5e2226767",
+      "branches": {
+        "master": "c271b882b6f39f7f2f68d5f5403e17b5e2226767"
+      }
+    },
+    "shikulja/thaliz": {
+      "default_branch": "master",
+      "sha": "301c0cfa08974bd4082bc561842195bf6feedeff",
+      "branches": {
+        "master": "301c0cfa08974bd4082bc561842195bf6feedeff"
+      },
+      "latest_tag": "thaliz-1.5.0"
+    },
+    "shikulja/trainerskills-vanilla": {
+      "default_branch": "master",
+      "sha": "3d7e4c6edd7526b123261c000a9d8f4db559ca54",
+      "branches": {
+        "master": "3d7e4c6edd7526b123261c000a9d8f4db559ca54"
+      }
+    },
+    "shikulja/vanillagraphicboost": {
+      "default_branch": "master",
+      "sha": "bfc1ea885909b4ca7688fbd5223fe13b89feccd9",
+      "branches": {
+        "master": "bfc1ea885909b4ca7688fbd5223fe13b89feccd9"
+      }
+    },
+    "shirsig/attack": {
+      "default_branch": "master",
+      "sha": "2b6aa85fe9693f540fee8dfa3b90e6e0768237a3",
+      "branches": {
+        "master": "2b6aa85fe9693f540fee8dfa3b90e6e0768237a3"
+      }
+    },
+    "shirsig/aux_merchant_prices": {
+      "default_branch": "master",
+      "sha": "dc3b12d9f6ed4b37df78fdd84721552d00f5025e",
+      "branches": {
+        "master": "dc3b12d9f6ed4b37df78fdd84721552d00f5025e"
+      },
+      "latest_tag": "1"
+    },
+    "shirsig/ccwatch": {
+      "default_branch": "master",
+      "sha": "b88c980aca96632a61406f525e776095be21a2bb",
+      "branches": {
+        "master": "b88c980aca96632a61406f525e776095be21a2bb"
+      }
+    },
+    "shirsig/cdframes": {
+      "default_branch": "master",
+      "sha": "e3242a6144f60e6e468430311ac070a2f6e1a43c",
+      "branches": {
+        "master": "e3242a6144f60e6e468430311ac070a2f6e1a43c"
+      }
+    },
+    "shirsig/channel_monitor": {
+      "default_branch": "master",
+      "sha": "ed4297565efeb67c8bb743571e2280b79d2f05f7",
+      "branches": {
+        "master": "ed4297565efeb67c8bb743571e2280b79d2f05f7"
+      }
+    },
+    "shirsig/clean_up": {
+      "default_branch": "master",
+      "sha": "285498f571c445e6ec126165fdeb3ec491575513",
+      "branches": {
+        "master": "285498f571c445e6ec126165fdeb3ec491575513"
+      }
+    },
+    "shirsig/cleanup-vanilla": {
+      "default_branch": "master",
+      "sha": "4c83ecb84f376979a0ac6b4747a0bed467cb9b90",
+      "branches": {
+        "master": "4c83ecb84f376979a0ac6b4747a0bed467cb9b90"
+      }
+    },
+    "shirsig/cooline": {
+      "default_branch": "master",
+      "sha": "ee097857089e1573a6e6e12cde82035096db2b7f",
+      "branches": {
+        "master": "ee097857089e1573a6e6e12cde82035096db2b7f"
+      }
+    },
+    "shirsig/crafty": {
+      "default_branch": "master",
+      "sha": "06ec40f0c4820ae14a1d959fbeb1492fe2b44fe5",
+      "branches": {
+        "master": "06ec40f0c4820ae14a1d959fbeb1492fe2b44fe5"
+      }
+    },
+    "shirsig/etl": {
+      "default_branch": "master",
+      "sha": "a50f6a9e4b25a0e3fb8ace1e11cf6ed5b7595b57",
+      "branches": {
+        "master": "a50f6a9e4b25a0e3fb8ace1e11cf6ed5b7595b57"
+      }
+    },
+    "shirsig/inspect": {
+      "default_branch": "master",
+      "sha": "a91c16ebfe09a0ef8bfb92e4b593c8da795346e9",
+      "branches": {
+        "master": "a91c16ebfe09a0ef8bfb92e4b593c8da795346e9"
+      }
+    },
+    "shirsig/linkmend": {
+      "default_branch": "master",
+      "sha": "d9e96234f589e9d38cdb60bf8e7d53477946e5bf",
+      "branches": {
+        "master": "d9e96234f589e9d38cdb60bf8e7d53477946e5bf"
+      }
+    },
+    "shirsig/mouseover": {
+      "default_branch": "master",
+      "sha": "f93b536ad1036f4dced21aa7c1b600e52b58f7ff",
+      "branches": {
+        "master": "f93b536ad1036f4dced21aa7c1b600e52b58f7ff"
+      }
+    },
+    "shirsig/mre": {
+      "default_branch": "master",
+      "sha": "f3b5b43b61c83df106439f0b7ac0f2b4f948600d",
+      "branches": {
+        "master": "f3b5b43b61c83df106439f0b7ac0f2b4f948600d"
+      }
+    },
+    "shirsig/profession_query": {
+      "default_branch": "master",
+      "sha": "5386fc98ec9b3cdf3c68a7e47a1fcebe286f5ac6",
+      "branches": {
+        "master": "5386fc98ec9b3cdf3c68a7e47a1fcebe286f5ac6"
+      }
+    },
+    "shirsig/retarget": {
+      "default_branch": "master",
+      "sha": "6ec740eb7b120898426b989a32e410a51c3e0c61",
+      "branches": {
+        "master": "6ec740eb7b120898426b989a32e410a51c3e0c61"
+      }
+    },
+    "shirsig/rwsync": {
+      "default_branch": "master",
+      "sha": "798e17d47b24b688e486b23a51d85d2395f609d3",
+      "branches": {
+        "master": "798e17d47b24b688e486b23a51d85d2395f609d3"
+      }
+    },
+    "shirsig/sentry": {
+      "default_branch": "master",
+      "sha": "4632082624c6c20f445f4c4f26af6a9f96238d8b",
+      "branches": {
+        "master": "4632082624c6c20f445f4c4f26af6a9f96238d8b"
+      }
+    },
+    "shirsig/snipe": {
+      "default_branch": "master",
+      "sha": "bbd83684f7e18e38b41c74ee64a256792e4aa5e0",
+      "branches": {
+        "master": "bbd83684f7e18e38b41c74ee64a256792e4aa5e0"
+      }
+    },
+    "shirsig/sortbags-vanilla": {
+      "default_branch": "master",
+      "sha": "1b59767ca41749e70d72f2991c27054beebcdfcd",
+      "branches": {
+        "master": "1b59767ca41749e70d72f2991c27054beebcdfcd"
+      }
+    },
+    "shkarlsson/buffwatch": {
+      "default_branch": "main",
+      "sha": "926f3924e1860f0b7f95458194fb65dc23350e28",
+      "branches": {
+        "main": "926f3924e1860f0b7f95458194fb65dc23350e28"
+      }
+    },
+    "shnibble/vanillahealingassignments": {
+      "default_branch": "master",
+      "sha": "e7cf4e9976f2a0fc874fdf95f6b2442e066fd139",
+      "branches": {
+        "master": "e7cf4e9976f2a0fc874fdf95f6b2442e066fd139"
+      }
+    },
+    "shotoverpick/consoleexperienceclassic": {
+      "default_branch": "main",
+      "sha": "10e0fcea0815285b93c21325797b4f61c0811d16",
+      "branches": {
+        "main": "10e0fcea0815285b93c21325797b4f61c0811d16"
+      }
+    },
+    "siand/healersmate": {
+      "default_branch": "main",
+      "sha": "4db32f472cc520c7ecd93e11dd02d3528e21b3ea",
+      "branches": {
+        "main": "4db32f472cc520c7ecd93e11dd02d3528e21b3ea"
+      },
+      "latest_tag": "v2.0.0-alpha4.1"
+    },
+    "sica42/callofelements": {
+      "default_branch": "master",
+      "sha": "afc5398aef1f2f31ed34732ec89eaf77bce06d2f",
+      "branches": {
+        "master": "afc5398aef1f2f31ed34732ec89eaf77bce06d2f"
+      }
+    },
+    "sica42/companionmanager": {
+      "default_branch": "main",
+      "sha": "9efb42eb8c98a44c20918687c146374cceb4d56d",
+      "branches": {
+        "main": "9efb42eb8c98a44c20918687c146374cceb4d56d"
+      }
+    },
+    "sica42/guildalts": {
+      "default_branch": "main",
+      "sha": "fe11010738b58565b97e8f382f7577ae942c2f9f",
+      "branches": {
+        "main": "fe11010738b58565b97e8f382f7577ae942c2f9f"
+      }
+    },
+    "sica42/guildrecipes": {
+      "default_branch": "main",
+      "sha": "ee10a84da53f5e85fac4da48a98d6fd9adfdde51",
+      "branches": {
+        "main": "ee10a84da53f5e85fac4da48a98d6fd9adfdde51"
+      }
+    },
+    "sica42/killtrack": {
+      "default_branch": "main",
+      "sha": "4e6132ddffd2669ae7855ef241cb18d839183f83",
+      "branches": {
+        "main": "4e6132ddffd2669ae7855ef241cb18d839183f83"
+      }
+    },
+    "sica42/outfitter": {
+      "default_branch": "master",
+      "sha": "c6d42c7d96ad9555ebbc739d520928d15501cb75",
+      "branches": {
+        "master": "c6d42c7d96ad9555ebbc739d520928d15501cb75"
+      }
+    },
+    "sica42/possessions": {
+      "default_branch": "master",
+      "sha": "71be69c850328e2bfdaa6176a295937a210a20b2",
+      "branches": {
+        "master": "71be69c850328e2bfdaa6176a295937a210a20b2"
+      }
+    },
+    "sica42/raidcalendar": {
+      "default_branch": "main",
+      "sha": "0e822dce563bd05886759e9d20cd53592305f5c1",
+      "branches": {
+        "main": "0e822dce563bd05886759e9d20cd53592305f5c1"
+      },
+      "latest_tag": "v0.1"
+    },
+    "sica42/roll-for-vanilla": {
+      "default_branch": "master",
+      "sha": "b833a9699242816a947f844e182754ef32961042",
+      "branches": {
+        "master": "b833a9699242816a947f844e182754ef32961042"
+      },
+      "latest_tag": "v4.8.1"
+    },
+    "sica42/titlerotator": {
+      "default_branch": "main",
+      "sha": "37247bb3903227ad87a745c725178c14bde37f6b",
+      "branches": {
+        "main": "37247bb3903227ad87a745c725178c14bde37f6b"
+      }
+    },
+    "sica42/turtlecalendar": {
+      "default_branch": "main",
+      "sha": "aad7b6a628992ea7d96e59982215e0bcd6901135",
+      "branches": {
+        "main": "aad7b6a628992ea7d96e59982215e0bcd6901135"
+      }
+    },
+    "sica42/turtlemail": {
+      "default_branch": "master",
+      "sha": "322429e143db1f1f00afe0d1074678a844bf8c7c",
+      "branches": {
+        "master": "322429e143db1f1f00afe0d1074678a844bf8c7c"
+      }
+    },
+    "sica42/twbuypoisons": {
+      "default_branch": "master",
+      "sha": "4aba9ed37164030c084a968670303cd767cb1314",
+      "branches": {
+        "master": "4aba9ed37164030c084a968670303cd767cb1314"
+      }
+    },
+    "simon3/smartdebuffcheck": {
+      "default_branch": "master",
+      "sha": "2e9e292cb56284138fca06038ec26e56c7e46508",
+      "branches": {
+        "master": "2e9e292cb56284138fca06038ec26e56c7e46508"
+      }
+    },
+    "simonfrankeoctolearn/ezpoison": {
+      "default_branch": "main",
+      "sha": "51ffe613b17b890ed2f2a1b99180087602325468",
+      "branches": {
+        "main": "51ffe613b17b890ed2f2a1b99180087602325468"
+      }
+    },
+    "simsal/ezpoison": {
+      "default_branch": "main",
+      "sha": "f32dcf0bf19f70ba712f1aa4f9af0f4f8a1215de",
+      "branches": {
+        "main": "f32dcf0bf19f70ba712f1aa4f9af0f4f8a1215de"
+      }
+    },
+    "siventt/actionbarprofiles": {
+      "default_branch": "master",
+      "sha": "b62477f279799808cdfa7398967c43437cff762d",
+      "branches": {
+        "master": "b62477f279799808cdfa7398967c43437cff762d"
+      }
+    },
+    "siventt/attackbar-twow": {
+      "default_branch": "master",
+      "sha": "9227d13c58c0b723678e69f79603aaff31e90a7f",
+      "branches": {
+        "master": "9227d13c58c0b723678e69f79603aaff31e90a7f"
+      }
+    },
+    "siventt/lootblare": {
+      "default_branch": "master",
+      "sha": "7a17a8d1e617cbd61bcd363ff7bb1e2c9e09eb93",
+      "branches": {
+        "master": "7a17a8d1e617cbd61bcd363ff7bb1e2c9e09eb93"
+      }
+    },
+    "siyy/succ-bag": {
+      "default_branch": "master",
+      "sha": "2d79d8a2e3c0431b55d6a81f5f32246a0311d431",
+      "branches": {
+        "master": "2d79d8a2e3c0431b55d6a81f5f32246a0311d431"
+      }
+    },
+    "skllskll/shaguplates": {
+      "default_branch": "master",
+      "sha": "0f9f598489c3abf4bb06fe1cb07748b5e3d77c43",
+      "branches": {
+        "master": "0f9f598489c3abf4bb06fe1cb07748b5e3d77c43"
+      }
+    },
+    "skllskll/zui": {
+      "default_branch": "master",
+      "sha": "d984370471ab64ede453ea9549fa3d64099dfd09",
+      "branches": {
+        "master": "d984370471ab64ede453ea9549fa3d64099dfd09"
+      }
+    },
+    "skrymsli/puppeteer": {
+      "default_branch": "main",
+      "sha": "2d3fdc5bb2c70fc02bc5f1c4f7d832a14f70d792",
+      "branches": {
+        "main": "2d3fdc5bb2c70fc02bc5f1c4f7d832a14f70d792"
+      }
+    },
+    "slimewizzard/buffblock-tw": {
+      "default_branch": "master",
+      "sha": "3425bcb6fd1b5e89b78638dddb6b4fb0687bd2b6",
+      "branches": {
+        "master": "3425bcb6fd1b5e89b78638dddb6b4fb0687bd2b6"
+      }
+    },
+    "slimewizzard/difficultbulletinboard": {
+      "default_branch": "master",
+      "sha": "a4aa1aba13a511b42b6102d7d55be48c4b4f974f",
+      "branches": {
+        "master": "a4aa1aba13a511b42b6102d7d55be48c4b4f974f"
+      }
+    },
+    "slimewizzard/roll-for-vanilla-tsc": {
+      "default_branch": "master",
+      "sha": "05b964006ec4b9dd35decc0581fd84ddf78cb343",
+      "branches": {
+        "master": "05b964006ec4b9dd35decc0581fd84ddf78cb343"
+      }
+    },
+    "smilewhenyoudie/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "3fa612f93cc494fcd4caa15425bd2cf653c2610a",
+      "branches": {
+        "master": "3fa612f93cc494fcd4caa15425bd2cf653c2610a"
+      }
+    },
+    "smirgeli/es": {
+      "default_branch": "main",
+      "sha": "2782b20acce0beea71902ee0113858619456d0f7",
+      "branches": {
+        "main": "2782b20acce0beea71902ee0113858619456d0f7"
+      }
+    },
+    "software-eugeneer/shagubam": {
+      "default_branch": "master",
+      "sha": "87b654a54e80befed9f4d8dc1be86cfd8cd7ee66",
+      "branches": {
+        "master": "87b654a54e80befed9f4d8dc1be86cfd8cd7ee66"
+      }
+    },
+    "sohlk/roid-macros": {
+      "default_branch": "master",
+      "sha": "69032749d8782bd2dc1ee631aeef27969cc8ac61",
+      "branches": {
+        "master": "69032749d8782bd2dc1ee631aeef27969cc8ac61"
+      }
+    },
+    "sondli/blockvalue": {
+      "default_branch": "main",
+      "sha": "7f65aed87e78ab0c85640cb909472e78c2a0e245",
+      "branches": {
+        "main": "7f65aed87e78ab0c85640cb909472e78c2a0e245"
+      },
+      "latest_tag": "1.0.0"
+    },
+    "sorgis-sorgis/sorgis_raid_marks": {
+      "default_branch": "master",
+      "sha": "eb3433adb40ffc20b019d36327973767f42e5de6",
+      "branches": {
+        "master": "eb3433adb40ffc20b019d36327973767f42e5de6"
+      },
+      "latest_tag": "1.2.0"
+    },
+    "sourini/flyout": {
+      "default_branch": "main",
+      "sha": "4d27bdafe76d8a107510417ab4e83bbab46786cb",
+      "branches": {
+        "main": "4d27bdafe76d8a107510417ab4e83bbab46786cb"
+      }
+    },
+    "sovietcanuckistan/consoleexperienceclassic": {
+      "default_branch": "main",
+      "sha": "96c65e3399a80e84dbaeb7678599a1cd3d3d4d67",
+      "branches": {
+        "main": "96c65e3399a80e84dbaeb7678599a1cd3d3d4d67"
+      },
+      "latest_tag": "v0.17.1"
+    },
+    "spartelfant/levelrange-turtle": {
+      "default_branch": "main",
+      "sha": "f280a18abe9b32ffd901050c5934f0e60df25f3a",
+      "branches": {
+        "main": "f280a18abe9b32ffd901050c5934f0e60df25f3a"
+      }
+    },
+    "spawnedc/pfdebug": {
+      "default_branch": "master",
+      "sha": "6f305a9b141cead0d2d141e81dc4e860db3acbbc",
+      "branches": {
+        "master": "6f305a9b141cead0d2d141e81dc4e860db3acbbc"
+      }
+    },
+    "spawnedc/pfstudio": {
+      "default_branch": "master",
+      "sha": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78",
+      "branches": {
+        "master": "01e1dacf6c63d7920dcbb22dc32c624f6bc36f78"
+      }
+    },
+    "spawnedc/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
+      "branches": {
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
+      }
+    },
+    "spronkets/ringmenu-tbc": {
+      "default_branch": "master",
+      "sha": "6c0ab1161ecbd4715386ddc37e33bf7a034d2d44",
+      "branches": {
+        "master": "6c0ab1161ecbd4715386ddc37e33bf7a034d2d44"
+      },
+      "latest_tag": "v2.2.1"
+    },
+    "spuxx1701/fulluitoggle": {
+      "default_branch": "master",
+      "sha": "944192f198880d7d8b3786652f58ff16e697d71e",
+      "branches": {
+        "master": "944192f198880d7d8b3786652f58ff16e697d71e"
+      }
+    },
+    "srazdokunebil/fury": {
+      "default_branch": "master",
+      "sha": "3a184d75ccae8f35dbf58bf9c4e1eab5e228446f",
+      "branches": {
+        "master": "3a184d75ccae8f35dbf58bf9c4e1eab5e228446f"
+      },
+      "latest_tag": "fury_1_15"
+    },
+    "srazdokunebil/onebuttonhunter": {
+      "default_branch": "master",
+      "sha": "f1f5b440014059df63042df8584abc3bac809bfe",
+      "branches": {
+        "master": "f1f5b440014059df63042df8584abc3bac809bfe"
+      }
+    },
+    "srazdokunebil/quiver": {
+      "default_branch": "main",
+      "sha": "1c42f68b614d67560629fbd21d83c67dc5012067",
+      "branches": {
+        "main": "1c42f68b614d67560629fbd21d83c67dc5012067"
+      }
+    },
+    "srazdokunebil/tankbuddy": {
+      "default_branch": "main",
+      "sha": "a005cdabc24c2938ca4ad6fe77b1fb3d1be68863",
+      "branches": {
+        "main": "a005cdabc24c2938ca4ad6fe77b1fb3d1be68863"
+      }
+    },
+    "staforddev/poisoncharges": {
+      "default_branch": "Classic",
+      "sha": "1afb71e7138986f30bd6c8fa5d31864705a6052c",
+      "branches": {
+        "Classic": "1afb71e7138986f30bd6c8fa5d31864705a6052c"
+      },
+      "latest_tag": "v1.1"
+    },
+    "starburtmr/wiiiui": {
+      "default_branch": "master",
+      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
+      "branches": {
+        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
+      }
+    },
+    "starnuik/levelrange-turtle": {
+      "default_branch": "main",
+      "sha": "8611a0f10df98dcb11fc08918c343dd071ef18c6",
+      "branches": {
+        "main": "8611a0f10df98dcb11fc08918c343dd071ef18c6"
+      }
+    },
+    "starnuik/zorlen": {
+      "default_branch": "main",
+      "sha": "bc794631e9e25451773b2803e6f2df46ccce58a5",
+      "branches": {
+        "main": "bc794631e9e25451773b2803e6f2df46ccce58a5"
+      }
+    },
+    "steelbash/restbar": {
+      "default_branch": "main",
+      "sha": "cd36a894369711bf86e20ad29a624f921922bcae",
+      "branches": {
+        "main": "cd36a894369711bf86e20ad29a624f921922bcae"
+      },
+      "latest_tag": "1.2.1"
+    },
+    "stevensnoeijen/metamap-vanilla": {
+      "default_branch": "master",
+      "sha": "8dcc99d182480cac3e44efd9b4ac2ccb9f441e14",
+      "branches": {
+        "master": "8dcc99d182480cac3e44efd9b4ac2ccb9f441e14"
+      }
+    },
+    "stevensnoeijen/minimapbuttonbag-turtlewow": {
+      "default_branch": "master",
+      "sha": "825268ec882de6651dc8fde1f6f9b8252159292a",
+      "branches": {
+        "master": "825268ec882de6651dc8fde1f6f9b8252159292a"
+      }
+    },
+    "stokbaek/resurrectionannounce": {
+      "default_branch": "master",
+      "sha": "58a2c8a0d18ea42e4797e86b4bb89782a417c413",
+      "branches": {
+        "master": "58a2c8a0d18ea42e4797e86b4bb89782a417c413"
+      },
+      "latest_tag": "v1.1"
+    },
+    "stonneke/spellpowermulti": {
+      "default_branch": "master",
+      "sha": "f3a18600c24999896143a9edb5ba57a1237ea88b",
+      "branches": {
+        "master": "f3a18600c24999896143a9edb5ba57a1237ea88b"
+      }
+    },
+    "stormhand-dev/dragonflightui-reforged": {
+      "default_branch": "main",
+      "sha": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8",
+      "branches": {
+        "main": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8"
+      },
+      "latest_tag": "1.3.4"
+    },
+    "stormhand81/finezoom": {
+      "default_branch": "main",
+      "sha": "bb9b18688ef6a764b6e721c2a3d712285a487de1",
+      "branches": {
+        "main": "bb9b18688ef6a764b6e721c2a3d712285a487de1"
+      },
+      "latest_tag": "1.3"
+    },
+    "stormhand81/immersion": {
+      "default_branch": "main",
+      "sha": "e87aa4b025da9b810866f64f769af1fb48e3ffe6",
+      "branches": {
+        "main": "e87aa4b025da9b810866f64f769af1fb48e3ffe6"
+      },
+      "latest_tag": "1.4"
+    },
+    "subbydk/tradedispenser": {
+      "default_branch": "master",
+      "sha": "81882960a6d0548f2447eee990a57c7f4d613729",
+      "branches": {
+        "master": "81882960a6d0548f2447eee990a57c7f4d613729"
+      }
+    },
+    "sulpitz/hcspy": {
+      "default_branch": "master",
+      "sha": "840c80c2f6309aae1e8ba410ca4ec1351ab343f1",
+      "branches": {
+        "master": "840c80c2f6309aae1e8ba410ca4ec1351ab343f1"
+      }
+    },
+    "sulpitz/quickheal": {
+      "default_branch": "master",
+      "sha": "33a3172bbcfa930b57bb3f0b9002eb09f99d4760",
+      "branches": {
+        "master": "33a3172bbcfa930b57bb3f0b9002eb09f99d4760"
+      },
+      "latest_tag": "hc01"
+    },
+    "sulpitz/smartloot": {
+      "default_branch": "master",
+      "sha": "1013cede392e2d8a4af98dbc1e9556bf7618fde2",
+      "branches": {
+        "master": "1013cede392e2d8a4af98dbc1e9556bf7618fde2"
+      },
+      "latest_tag": "v1.3-bcc"
+    },
+    "sumowares/killpro": {
+      "default_branch": "master",
+      "sha": "c20362378be481dc445aedddf9769eee197bba21",
+      "branches": {
+        "master": "c20362378be481dc445aedddf9769eee197bba21"
+      }
+    },
+    "superyoung9208/pfquest-turtle": {
+      "default_branch": "master",
+      "sha": "2188e4dcda172954007227aa37fd87d7ea534812",
+      "branches": {
+        "master": "2188e4dcda172954007227aa37fd87d7ea534812"
+      }
+    },
+    "sureshchouksey8/wiiiui": {
+      "default_branch": "master",
+      "sha": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18",
+      "branches": {
+        "master": "e17c352d21585fbacfbc2a0b7b2a422595d4cf18"
+      }
+    },
+    "swizzpop/chickenjockey": {
+      "default_branch": "main",
+      "sha": "7ba0158232cc1faabdbb412bc70bec74937fb9ea",
+      "branches": {
+        "main": "7ba0158232cc1faabdbb412bc70bec74937fb9ea"
+      }
+    },
+    "sxe/lazyscript-turtle": {
+      "default_branch": "master",
+      "sha": "d98aac01e934fcd2adb7dd70f697e94384d0a4b9",
+      "branches": {
+        "master": "d98aac01e934fcd2adb7dd70f697e94384d0a4b9"
+      }
+    },
+    "szalor/cursive": {
+      "default_branch": "master",
+      "sha": "648328399160841612f608e310bc6547edd54b5b",
+      "branches": {
+        "master": "648328399160841612f608e310bc6547edd54b5b"
+      }
+    },
+    "szalor/unleashedtracker": {
+      "default_branch": "main",
+      "sha": "8422f5f9d5809b9f99ab1e38e1579189b3a3380d",
+      "branches": {
+        "main": "8422f5f9d5809b9f99ab1e38e1579189b3a3380d"
+      }
+    },
+    "taabu-git/notesuneed-turtle": {
+      "default_branch": "master",
+      "sha": "fc3ce8c9607bd58069a9748671c0e46042ccd2f9",
+      "branches": {
+        "master": "fc3ce8c9607bd58069a9748671c0e46042ccd2f9"
+      }
+    },
+    "taeko-ar/cursive-3.3.5a": {
+      "default_branch": "master",
+      "sha": "ab73680c1e91e7e2275a4efa3d9972640682b967",
+      "branches": {
+        "master": "ab73680c1e91e7e2275a4efa3d9972640682b967"
+      }
+    },
+    "taeko-ar/quickturtledblookup": {
+      "default_branch": "master",
+      "sha": "3b5923f304cc31a2c20a1105780e2af4fd68dd68",
+      "branches": {
+        "master": "3b5923f304cc31a2c20a1105780e2af4fd68dd68"
+      }
+    },
+    "talex00/pfquest-turtle": {
+      "default_branch": "master",
+      "sha": "dce1ad0d6a0e55b25f6b9b9a52f7bee611c756fc",
+      "branches": {
+        "master": "dce1ad0d6a0e55b25f6b9b9a52f7bee611c756fc"
+      }
+    },
+    "tanoh/omnicc": {
+      "default_branch": "master",
+      "sha": "fbf883e5a1d65de9abdfbb45807b70071c2e1232",
+      "branches": {
+        "master": "fbf883e5a1d65de9abdfbb45807b70071c2e1232"
+      }
+    },
+    "tarkusx/consoleexperienceclassic": {
+      "default_branch": "main",
+      "sha": "10e0fcea0815285b93c21325797b4f61c0811d16",
+      "branches": {
+        "main": "10e0fcea0815285b93c21325797b4f61c0811d16"
+      }
+    },
+    "tarkusx/customicons": {
+      "default_branch": "main",
+      "sha": "694a3508a0a5994587bfb0d5a9e7645d08101b7f",
+      "branches": {
+        "main": "694a3508a0a5994587bfb0d5a9e7645d08101b7f"
+      }
+    },
+    "tarkusx/ffxivcrosshotbar": {
+      "default_branch": "main",
+      "sha": "7408d6b40d78bb28850cfe291d02836bfa95d14e",
+      "branches": {
+        "main": "7408d6b40d78bb28850cfe291d02836bfa95d14e"
+      }
+    },
+    "tcavemant/benecast": {
+      "default_branch": "main",
+      "sha": "f6b875c385302f1c9015448c4f4a3ad8ad5c20c4",
+      "branches": {
+        "main": "f6b875c385302f1c9015448c4f4a3ad8ad5c20c4"
+      }
+    },
+    "tec10101/rightclickmodifier-ascension": {
+      "default_branch": "master",
+      "sha": "dc40936c0991230c8e92bc099b26c022510603a1",
+      "branches": {
+        "master": "dc40936c0991230c8e92bc099b26c022510603a1"
+      }
+    },
+    "teranveril/shootyepgp": {
+      "default_branch": "master",
+      "sha": "39948dcd6bb0bd54857b8567c32f34df6c6b9431",
+      "branches": {
+        "master": "39948dcd6bb0bd54857b8567c32f34df6c6b9431"
+      }
+    },
+    "terdong/fastbinding": {
+      "default_branch": "main",
+      "sha": "ffb36d68265b42330ecc2126b09d05fbf597951f",
+      "branches": {
+        "main": "ffb36d68265b42330ecc2126b09d05fbf597951f"
+      }
+    },
+    "terongorus/architotem-teron": {
+      "default_branch": "master",
+      "sha": "3a9cef182a84873ea3c23268dbb9c53c61efbf0b",
+      "branches": {
+        "master": "3a9cef182a84873ea3c23268dbb9c53c61efbf0b"
+      }
+    },
+    "terongorus/teronadvancedmacrotooltips": {
+      "default_branch": "master",
+      "sha": "daee1d39cae771ac55f5202907eae107f03b707e",
+      "branches": {
+        "master": "daee1d39cae771ac55f5202907eae107f03b707e"
+      }
+    },
+    "terrabaddie/onebuttonhunter-vanillaplus": {
+      "default_branch": "master",
+      "sha": "8c67900528813ce76263027891b48640f29a7f1c",
+      "branches": {
+        "master": "8c67900528813ce76263027891b48640f29a7f1c"
+      }
+    },
+    "terrub/samuel": {
+      "default_branch": "master",
+      "sha": "22e5869ca3fce7dd535443bbca575da609273579",
+      "branches": {
+        "master": "22e5869ca3fce7dd535443bbca575da609273579"
+      },
+      "latest_tag": "latest"
+    },
+    "thaerlo/procdoc": {
+      "default_branch": "main",
+      "sha": "c2eec0c5ab5b6d6d93da60e1971d9b21db4b37cd",
+      "branches": {
+        "main": "c2eec0c5ab5b6d6d93da60e1971d9b21db4b37cd"
+      }
+    },
+    "the-kludge-bureau/accountant": {
+      "default_branch": "main",
+      "sha": "9078a7cd0f30b328aa939cb63c636c818c4af204",
+      "branches": {
+        "main": "9078a7cd0f30b328aa939cb63c636c818c4af204"
+      },
+      "latest_tag": "3.1"
+    },
+    "the-kludge-bureau/bagshui": {
+      "default_branch": "main",
+      "sha": "137cf69a83eb9c3e21780cbfff628f24f07bd3e3",
+      "branches": {
+        "main": "137cf69a83eb9c3e21780cbfff628f24f07bd3e3"
+      },
+      "latest_tag": "2.0.4"
+    },
+    "the-kludge-bureau/pfquest": {
+      "default_branch": "main",
+      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
+      "branches": {
+        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
+      },
+      "latest_tag": "8.0.0"
+    },
+    "the-kludge-bureau/pfquest-turtle": {
+      "default_branch": "main",
+      "sha": "d11e7631774f390edb5b26b86cd84cf43aee5e20",
+      "branches": {
+        "main": "d11e7631774f390edb5b26b86cd84cf43aee5e20"
+      }
+    },
+    "thedarklordsunderland/lootblare": {
+      "default_branch": "master",
+      "sha": "4eda417fbb2ff30cc16b157e00ecec42b223de3d",
+      "branches": {
+        "master": "4eda417fbb2ff30cc16b157e00ecec42b223de3d"
+      }
+    },
+    "thekk1/zgloot": {
+      "default_branch": "master",
+      "sha": "b711c3e1cc8b90ae16fa3dc8cbac0caef6bd85b8",
+      "branches": {
+        "master": "b711c3e1cc8b90ae16fa3dc8cbac0caef6bd85b8"
+      }
+    },
+    "thelilmagi/partyplus": {
+      "default_branch": "main",
+      "sha": "23341d2f5acaf845c7f7702d51db6b5a0112204a",
+      "branches": {
+        "main": "23341d2f5acaf845c7f7702d51db6b5a0112204a"
+      }
+    },
+    "thencl/consoleexperienceclassic": {
+      "default_branch": "main",
+      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
+      "branches": {
+        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
+      }
+    },
+    "thenuclei/twbuypoisonsjin": {
+      "default_branch": "master",
+      "sha": "19414909316521e6f57b94e0fe2d6b4ba071b7b8",
+      "branches": {
+        "master": "19414909316521e6f57b94e0fe2d6b4ba071b7b8"
+      }
+    },
+    "theoix/shagudps": {
+      "default_branch": "master",
+      "sha": "1408a70005374f4d5022f828db4f21a2f5e41379",
+      "branches": {
+        "master": "1408a70005374f4d5022f828db4f21a2f5e41379"
+      }
+    },
+    "theonereed/evtcalendar": {
+      "default_branch": "master",
+      "sha": "772c9201ace228edca2d1a5c0ae65b15a3abb286",
+      "branches": {
+        "master": "772c9201ace228edca2d1a5c0ae65b15a3abb286"
+      },
+      "latest_tag": "1.3"
+    },
+    "thepparker/antispamstopcast": {
+      "default_branch": "master",
+      "sha": "fe861706d738d7fc3ec1389e29e70e2842c23d86",
+      "branches": {
+        "master": "fe861706d738d7fc3ec1389e29e70e2842c23d86"
+      }
+    },
+    "therealfayz/arcanum": {
+      "default_branch": "main",
+      "sha": "337f500abeeeb126e54a7bce90e65add4bec56e8",
+      "branches": {
+        "main": "337f500abeeeb126e54a7bce90e65add4bec56e8"
+      }
+    },
+    "therealfayz/automarker": {
+      "default_branch": "master",
+      "sha": "4b59021b4039735565ff0c1812960a63e0a92ed2",
+      "branches": {
+        "master": "4b59021b4039735565ff0c1812960a63e0a92ed2"
+      }
+    },
+    "therealfayz/bossmechanicshelper": {
+      "default_branch": "main",
+      "sha": "20f4487b8fb302291bcad45e8d40bce2c17ffb69",
+      "branches": {
+        "main": "20f4487b8fb302291bcad45e8d40bce2c17ffb69"
+      }
+    },
+    "therealfayz/gentlegc": {
+      "default_branch": "master",
+      "sha": "85626006c5c7022057c0ae5ce99db77811172626",
+      "branches": {
+        "master": "85626006c5c7022057c0ae5ce99db77811172626"
+      }
+    },
+    "therealfayz/shaguscan": {
+      "default_branch": "master",
+      "sha": "7c7618953aca8fed69fef2755dc9b48f0170a24b",
+      "branches": {
+        "master": "7c7618953aca8fed69fef2755dc9b48f0170a24b"
+      }
+    },
+    "therealfayz/shootyepgp": {
+      "default_branch": "master",
+      "sha": "37700c9c5889633b1931e83f4731e735ba9ac861",
+      "branches": {
+        "master": "37700c9c5889633b1931e83f4731e735ba9ac861"
+      }
+    },
+    "therealfayz/totemnesia": {
+      "default_branch": "main",
+      "sha": "13a14ee37e95482f6369d12f358f425cfe502bca",
+      "branches": {
+        "main": "13a14ee37e95482f6369d12f358f425cfe502bca"
+      }
+    },
+    "therealfayz/turtle-hub": {
+      "default_branch": "master",
+      "sha": "42692d59e49dde713e26d245e4698e769e9f9b80",
+      "branches": {
+        "master": "42692d59e49dde713e26d245e4698e769e9f9b80"
+      }
+    },
+    "therealfayz/vanilla-iconic": {
+      "default_branch": "main",
+      "sha": "2ec0a7350cb91f4156c77e178e60e5c938a01e69",
+      "branches": {
+        "main": "2ec0a7350cb91f4156c77e178e60e5c938a01e69"
+      }
+    },
+    "theunprofessionalgamer/vanillaguide": {
+      "default_branch": "main",
+      "sha": "3c839a71607ad6957a5766333ab3e844edf7db40",
+      "branches": {
+        "main": "3c839a71607ad6957a5766333ab3e844edf7db40"
+      }
+    },
+    "thezephyrsong/_lazypig": {
+      "default_branch": "master",
+      "sha": "ee15ba71a9afdf5c8c74904ec07778b9f03d2a7a",
+      "branches": {
+        "master": "ee15ba71a9afdf5c8c74904ec07778b9f03d2a7a"
+      }
+    },
+    "thezephyrsong/akkio_consume_helper": {
+      "default_branch": "main",
+      "sha": "85e730dabbaad3cba35421f0bc539780b3d69f31",
+      "branches": {
+        "main": "85e730dabbaad3cba35421f0bc539780b3d69f31"
+      }
+    },
+    "thezephyrsong/difficultbulletinboard": {
+      "default_branch": "master",
+      "sha": "78b78354dc51a75aa63058ad90ab3530ed64e9b1",
+      "branches": {
+        "master": "78b78354dc51a75aa63058ad90ab3530ed64e9b1"
+      },
+      "latest_tag": "V2.40"
+    },
+    "thezephyrsong/dragonflightui-capybara": {
+      "default_branch": "main",
+      "sha": "014defeb8acec1b5e4a6a9985bfc1579c31c5ec6",
+      "branches": {
+        "main": "014defeb8acec1b5e4a6a9985bfc1579c31c5ec6"
+      },
+      "latest_tag": "1.3.3"
+    },
+    "thezephyrsong/guda": {
+      "default_branch": "main",
+      "sha": "cf53686a53115c2020452595c0a02db63510788a",
+      "branches": {
+        "main": "cf53686a53115c2020452595c0a02db63510788a"
+      }
+    },
+    "thezephyrsong/gudaplates": {
+      "default_branch": "main",
+      "sha": "ac0114987cf403345baed3d98ef1482e0cdcc1af",
+      "branches": {
+        "main": "ac0114987cf403345baed3d98ef1482e0cdcc1af"
+      }
+    },
+    "thezephyrsong/pizzaworldbuffs": {
+      "default_branch": "main",
+      "sha": "d65a510f7567f8f7fdaea0633731907330e2b17f",
+      "branches": {
+        "main": "d65a510f7567f8f7fdaea0633731907330e2b17f"
+      }
+    },
+    "thezephyrsong/procdoc": {
+      "default_branch": "main",
+      "sha": "7c29a57a9ce28749782dc26aa938bf85ef4e4dc0",
+      "branches": {
+        "main": "7c29a57a9ce28749782dc26aa938bf85ef4e4dc0"
+      }
+    },
+    "thezephyrsong/questprogressshare": {
+      "default_branch": "main",
+      "sha": "331b538af655c6cc129d68232871d5a9eb1a9b34",
+      "branches": {
+        "main": "331b538af655c6cc129d68232871d5a9eb1a9b34"
+      },
+      "latest_tag": "1.5.1"
+    },
+    "thezephyrsong/rested": {
+      "default_branch": "master",
+      "sha": "be900d29fb1dbe3fbf53555174be33827f93edb1",
+      "branches": {
+        "master": "be900d29fb1dbe3fbf53555174be33827f93edb1"
+      }
+    },
+    "thezephyrsong/rollfor": {
+      "default_branch": "master",
+      "sha": "64c83f89dfb11cc156ff6c47c55d752865b0c57e",
+      "branches": {
+        "master": "64c83f89dfb11cc156ff6c47c55d752865b0c57e"
+      },
+      "latest_tag": "v4.6.5"
+    },
+    "thezephyrsong/tactica": {
+      "default_branch": "main",
+      "sha": "f85e7fb0ded1a9178f207d3940c153e6e06f5e48",
+      "branches": {
+        "main": "f85e7fb0ded1a9178f207d3940c153e6e06f5e48"
+      }
+    },
+    "thezephyrsong/targetframebuff": {
+      "default_branch": "master",
+      "sha": "830519bbc70433b4a26c586724868749390b7efc",
+      "branches": {
+        "master": "830519bbc70433b4a26c586724868749390b7efc"
+      }
+    },
+    "thezephyrsong/vanillaratingbuster": {
+      "default_branch": "master",
+      "sha": "4843891d684f63193b734e4d5c508498848f313d",
+      "branches": {
+        "master": "4843891d684f63193b734e4d5c508498848f313d"
+      }
+    },
+    "thrunk112/mail": {
+      "default_branch": "master",
+      "sha": "035ec1602581935674e1d7539e92f979f201d42c",
+      "branches": {
+        "master": "035ec1602581935674e1d7539e92f979f201d42c"
+      }
+    },
+    "thrunk112/tankplates": {
+      "default_branch": "master",
+      "sha": "8f5c98fed26d3a90e0653db96a64fa9852fc055c",
+      "branches": {
+        "master": "8f5c98fed26d3a90e0653db96a64fa9852fc055c"
+      }
+    },
+    "tiffanyplus/sp_overpower": {
+      "default_branch": "master",
+      "sha": "3136f7cfc9a7674b49b9a17f0eccda74c887ae5b",
+      "branches": {
+        "master": "3136f7cfc9a7674b49b9a17f0eccda74c887ae5b"
+      },
+      "latest_tag": "3.0.0"
+    },
+    "tilare/flighttracker": {
+      "default_branch": "main",
+      "sha": "a28d3bdfe6c6e03da70657ef412ff4a423e59824",
+      "branches": {
+        "main": "a28d3bdfe6c6e03da70657ef412ff4a423e59824"
+      }
+    },
+    "tilare/messagebox": {
+      "default_branch": "main",
+      "sha": "eede932b062a764b7ff1b548106e2d95a9925737",
+      "branches": {
+        "main": "eede932b062a764b7ff1b548106e2d95a9925737"
+      }
+    },
+    "tilare/modernmapmarkers": {
+      "default_branch": "main",
+      "sha": "5311be6a24979d4119ed59e9f48f90beb41ecfb4",
+      "branches": {
+        "main": "5311be6a24979d4119ed59e9f48f90beb41ecfb4"
+      }
+    },
+    "tilare/movementtracker": {
+      "default_branch": "main",
+      "sha": "fb0ac54c3e9a615b766ddcc3cc805ce14b8fb305",
+      "branches": {
+        "main": "fb0ac54c3e9a615b766ddcc3cc805ce14b8fb305"
+      }
+    },
+    "timanaku/hastedisplay": {
+      "default_branch": "main",
+      "sha": "7f9a7a11161af69402ce17a3ae5fc5855fa10005",
+      "branches": {
+        "main": "7f9a7a11161af69402ce17a3ae5fc5855fa10005"
+      }
+    },
+    "timanaku/quartz": {
+      "default_branch": "main",
+      "sha": "3a5000c782a3d456abf5904c39b99df2e7a5decd",
+      "branches": {
+        "main": "3a5000c782a3d456abf5904c39b99df2e7a5decd"
+      }
+    },
+    "tinukedaya/stopwatch": {
+      "default_branch": "master",
+      "sha": "d267430f855f4e9ff616d28564a7218628eacf5d",
+      "branches": {
+        "master": "d267430f855f4e9ff616d28564a7218628eacf5d"
+      },
+      "latest_tag": "b1"
+    },
+    "tisette01/lootblare": {
+      "default_branch": "master",
+      "sha": "5bea9c10cc617467d904db2aec4ae083986e1bf3",
+      "branches": {
+        "master": "5bea9c10cc617467d904db2aec4ae083986e1bf3"
+      }
+    },
+    "tlplayer/betterquest": {
+      "default_branch": "main",
+      "sha": "73d67930f718bef6fc595495af4099866b04c137",
+      "branches": {
+        "main": "73d67930f718bef6fc595495af4099866b04c137"
+      },
+      "latest_tag": "0.2"
+    },
+    "tokensworth/shagutweaks-mods": {
+      "default_branch": "main",
+      "sha": "b782e1e17fcfd68ec77f9ca96df797a6a977d2e8",
+      "branches": {
+        "main": "b782e1e17fcfd68ec77f9ca96df797a6a977d2e8"
+      }
+    },
+    "tolle44/engbags": {
+      "default_branch": "main",
+      "sha": "a73ae68a1b4f9ce0f63260a2a57316603903336b",
+      "branches": {
+        "main": "a73ae68a1b4f9ce0f63260a2a57316603903336b"
+      }
+    },
+    "tolle44/flightmap": {
+      "default_branch": "main",
+      "sha": "ea81e52a833be28f8b3c10db3a20c6b51ef02152",
+      "branches": {
+        "main": "ea81e52a833be28f8b3c10db3a20c6b51ef02152"
+      }
+    },
+    "tomek7667/aux-addon": {
+      "default_branch": "master",
+      "sha": "816df9e510b8e3d5eb9d7303581ed18f6e924f8b",
+      "branches": {
+        "master": "816df9e510b8e3d5eb9d7303581ed18f6e924f8b"
+      }
+    },
+    "tomek7667/pfquest-turtle": {
+      "default_branch": "master",
+      "sha": "271448449840e7cc6a862f89962f767eb4507978",
+      "branches": {
+        "master": "271448449840e7cc6a862f89962f767eb4507978"
+      },
+      "latest_tag": "v0.0.1"
+    },
+    "tomek7667/speed-o-meter": {
+      "default_branch": "master",
+      "sha": "95eb9f99a9cabf73d57870bed0b897cdf0b36cf7",
+      "branches": {
+        "master": "95eb9f99a9cabf73d57870bed0b897cdf0b36cf7"
+      }
+    },
+    "topfreestyle/avbars": {
+      "default_branch": "main",
+      "sha": "4f86368f80da3cb52c6fd5bd05cb9f3e968e4cfa",
+      "branches": {
+        "main": "4f86368f80da3cb52c6fd5bd05cb9f3e968e4cfa"
+      }
+    },
+    "torchlite-bit/aegis_courier": {
+      "default_branch": "main",
+      "sha": "c78fdcfe0b1bc3de300126c3ee7549c648c6033c",
+      "branches": {
+        "main": "c78fdcfe0b1bc3de300126c3ee7549c648c6033c"
+      }
+    },
+    "torchlite-bit/aegis_exchange": {
+      "default_branch": "main",
+      "sha": "0c4b11dc8b8d16be3c6b6abee57ace38d2a537ca",
+      "branches": {
+        "main": "0c4b11dc8b8d16be3c6b6abee57ace38d2a537ca"
+      }
+    },
+    "torchlite-bit/aegis_rallypower": {
+      "default_branch": "main",
+      "sha": "8f1ba229ce018c23811dbeaa3e93f0b6368fb563",
+      "branches": {
+        "main": "8f1ba229ce018c23811dbeaa3e93f0b6368fb563"
+      }
+    },
+    "torchlite-bit/aegis_sbr": {
+      "default_branch": "main",
+      "sha": "c99a0e8dbd47e9d38e24fe579f56b87a6e6650bf",
+      "branches": {
+        "main": "c99a0e8dbd47e9d38e24fe579f56b87a6e6650bf"
+      }
+    },
+    "totemrecall1/ringmenu": {
+      "default_branch": "master",
+      "sha": "cfb9ba7f84a85252599aca7d314d27ff35700c13",
+      "branches": {
+        "master": "cfb9ba7f84a85252599aca7d314d27ff35700c13"
+      }
+    },
+    "towneh/buffblock": {
+      "default_branch": "master",
+      "sha": "cbcd2d23d6860049bad69f52574f193fbeb3c93d",
+      "branches": {
+        "master": "cbcd2d23d6860049bad69f52574f193fbeb3c93d"
+      },
+      "latest_tag": "v1.0"
+    },
+    "tperraut/fury": {
+      "default_branch": "master",
+      "sha": "e6a78fb22e8657db8f582b614604e544817742a5",
+      "branches": {
+        "master": "e6a78fb22e8657db8f582b614604e544817742a5"
+      }
+    },
+    "tperraut/shagudps": {
+      "default_branch": "master",
+      "sha": "ac95a4759dc7ce259dccb0b3ee11166204217d32",
+      "branches": {
+        "master": "ac95a4759dc7ce259dccb0b3ee11166204217d32"
+      }
+    },
+    "tperraut/shootyepgp": {
+      "default_branch": "master",
+      "sha": "4d4b4098fe9e00671b8ab6c8420d2407eaa0a4b9",
+      "branches": {
+        "master": "4d4b4098fe9e00671b8ab6c8420d2407eaa0a4b9"
+      }
+    },
+    "tr00dudu/shieldbuddy": {
+      "default_branch": "main",
+      "sha": "091c2b3061ada43555b9c668b891488eea4b3167",
+      "branches": {
+        "main": "091c2b3061ada43555b9c668b891488eea4b3167"
+      }
+    },
+    "tr0812/questprogressshare": {
+      "default_branch": "main",
+      "sha": "11e0164ea2f3a4aeab420259b7cf71b0fa2567f6",
+      "branches": {
+        "main": "11e0164ea2f3a4aeab420259b7cf71b0fa2567f6"
+      }
+    },
+    "trangoul/equipcolor": {
+      "default_branch": "main",
+      "sha": "94894163ec7a3aa1717bd8652554273ffe632b9b",
+      "branches": {
+        "main": "94894163ec7a3aa1717bd8652554273ffe632b9b"
+      }
+    },
+    "trangoul/flightmap": {
+      "default_branch": "main",
+      "sha": "8231f8f95de2f361774bb55162a731702409a26c",
+      "branches": {
+        "main": "8231f8f95de2f361774bb55162a731702409a26c"
+      }
+    },
+    "trangoul/globalfriendslist": {
+      "default_branch": "main",
+      "sha": "00c2d8234097f0c72326820e131190d68491ea27",
+      "branches": {
+        "main": "00c2d8234097f0c72326820e131190d68491ea27"
+      }
+    },
+    "trangoul/lookup": {
+      "default_branch": "master",
+      "sha": "4584b55e864f419f6774a52a8620aa86e9ad98f0",
+      "branches": {
+        "master": "4584b55e864f419f6774a52a8620aa86e9ad98f0"
+      }
+    },
+    "trangoul/monkeyspeed": {
+      "default_branch": "main",
+      "sha": "0f87c5d4e1916d0d055146106f58fe457867be1b",
+      "branches": {
+        "main": "0f87c5d4e1916d0d055146106f58fe457867be1b"
+      }
+    },
+    "trangoul/turtlemenagerie": {
+      "default_branch": "main",
+      "sha": "025952539801894d37bc5cc899315a87aa9e769d",
+      "branches": {
+        "main": "025952539801894d37bc5cc899315a87aa9e769d"
+      },
+      "latest_tag": "v2.3.1"
+    },
+    "trashcanhands/explorermap": {
+      "default_branch": "master",
+      "sha": "3f943992dafb32fbcf0cff31260dc7806db2277d",
+      "branches": {
+        "master": "3f943992dafb32fbcf0cff31260dc7806db2277d"
+      }
+    },
+    "trite2k3/gatherer": {
+      "default_branch": "master",
+      "sha": "bf4cccdaf8dde5be933cc28c8c40379f8fdc56a6",
+      "branches": {
+        "master": "bf4cccdaf8dde5be933cc28c8c40379f8fdc56a6"
+      }
+    },
+    "trumpetx/chatlootbidder": {
+      "default_branch": "master",
+      "sha": "bc6c2f807d2c7790308f8abf503b00d83dbc6988",
+      "branches": {
+        "master": "bc6c2f807d2c7790308f8abf503b00d83dbc6988"
+      },
+      "latest_tag": "v1.11.2"
+    },
+    "trumpetx/combatloggingreminder": {
+      "default_branch": "master",
+      "sha": "12aa83d21401fe3cb655258ddf4f5859e18e3f4d",
+      "branches": {
+        "master": "12aa83d21401fe3cb655258ddf4f5859e18e3f4d"
+      }
+    },
+    "trumpetx/flyertimer": {
+      "default_branch": "master",
+      "sha": "58a1a62caae40c6e4a0147352cc425f5611fe31d",
+      "branches": {
+        "master": "58a1a62caae40c6e4a0147352cc425f5611fe31d"
+      }
+    },
+    "trumpetx/gethead": {
+      "default_branch": "master",
+      "sha": "296fbc2bddc6bd043b29f359b80cb518c9890ce2",
+      "branches": {
+        "master": "296fbc2bddc6bd043b29f359b80cb518c9890ce2"
+      }
+    },
+    "trumpetx/notchatlootbidder": {
+      "default_branch": "master",
+      "sha": "3a450b58d3d05bf2fa7efade1d9bc0ba63fe2c1a",
+      "branches": {
+        "master": "3a450b58d3d05bf2fa7efade1d9bc0ba63fe2c1a"
+      },
+      "latest_tag": "v1.9.4"
+    },
+    "trumpetx/turtlehcfilter": {
+      "default_branch": "main",
+      "sha": "bf24747d1a18fde163ecefe0c5cc1b07fb1a7696",
+      "branches": {
+        "main": "bf24747d1a18fde163ecefe0c5cc1b07fb1a7696"
+      }
+    },
+    "trust-wow/modernmapmarkers-german": {
+      "default_branch": "main",
+      "sha": "184184a5925db272dd76a8395e1cb7c5e84a0d7b",
+      "branches": {
+        "main": "184184a5925db272dd76a8395e1cb7c5e84a0d7b"
+      }
+    },
+    "ttcremers/grayautosell": {
+      "default_branch": "master",
+      "sha": "a53ac93bfbe12a1a0b77b588060051e19123697f",
+      "branches": {
+        "master": "a53ac93bfbe12a1a0b77b588060051e19123697f"
+      },
+      "latest_tag": "v0.1.4"
+    },
+    "tubtubs/comix": {
+      "default_branch": "main",
+      "sha": "0c1fb1c38260babf4194a4342f1f954ecce37a95",
+      "branches": {
+        "main": "0c1fb1c38260babf4194a4342f1f954ecce37a95"
+      }
+    },
+    "tubtubs/guidelimevanilla": {
+      "default_branch": "master",
+      "sha": "bd87cdb5fc9c3bd125afdb6da5819b5e92f2dec5",
+      "branches": {
+        "master": "bd87cdb5fc9c3bd125afdb6da5819b5e92f2dec5"
+      }
+    },
+    "tubtubs/modernspellbook": {
+      "default_branch": "master",
+      "sha": "88afad31729657175d1710c259d9e55081331920",
+      "branches": {
+        "master": "88afad31729657175d1710c259d9e55081331920"
+      }
+    },
+    "tubtubs/namechangescript": {
+      "default_branch": "main",
+      "sha": "6f9915267b6822b4bf7278e9435d9d8a929548a6",
+      "branches": {
+        "main": "6f9915267b6822b4bf7278e9435d9d8a929548a6"
+      }
+    },
+    "tubtubs/panda": {
+      "default_branch": "main",
+      "sha": "a328bbc165db8e8e4fe113d751db74b5d227f96b",
+      "branches": {
+        "main": "a328bbc165db8e8e4fe113d751db74b5d227f96b"
+      }
+    },
+    "tubtubs/pizzaslices": {
+      "default_branch": "main",
+      "sha": "59bcdda1e70a7f3f93362fbe4d0778f6c3e9c867",
+      "branches": {
+        "main": "59bcdda1e70a7f3f93362fbe4d0778f6c3e9c867"
+      }
+    },
+    "tubtubs/rinse": {
+      "default_branch": "master",
+      "sha": "23c5643b37cd3f90554d074bc2ca6e0364a55f3f",
+      "branches": {
+        "master": "23c5643b37cd3f90554d074bc2ca6e0364a55f3f"
+      }
+    },
+    "tubtubs/vanilla-tweaks": {
+      "default_branch": "master",
+      "sha": "1e18414f8f3535d3436d3dc6a7351d4ea74b50b4",
+      "branches": {
+        "master": "1e18414f8f3535d3436d3dc6a7351d4ea74b50b4"
+      }
+    },
+    "tubtubs/vanillastoryline": {
+      "default_branch": "master",
+      "sha": "47bf6bbd174db51623a1b6bb27879f08e04dc390",
+      "branches": {
+        "master": "47bf6bbd174db51623a1b6bb27879f08e04dc390"
+      }
+    },
+    "turinpt/bossalert": {
+      "default_branch": "master",
+      "sha": "aead2112b0ef4792975124c384196149e8baeec7",
+      "branches": {
+        "master": "aead2112b0ef4792975124c384196149e8baeec7"
+      }
+    },
+    "turinpt/cmap": {
+      "default_branch": "master",
+      "sha": "3849500c58db047a5455c8e7fa48ce48e80e221b",
+      "branches": {
+        "master": "3849500c58db047a5455c8e7fa48ce48e80e221b"
+      }
+    },
+    "turinpt/fubar_dpsmate": {
+      "default_branch": "master",
+      "sha": "5f9b405c9b956580a25b08b471b38e9b717a405a",
+      "branches": {
+        "master": "5f9b405c9b956580a25b08b471b38e9b717a405a"
+      }
+    },
+    "turinpt/lhcp": {
+      "default_branch": "master",
+      "sha": "175d68371684b5d73d7cd26eda487791cb825ddf",
+      "branches": {
+        "master": "175d68371684b5d73d7cd26eda487791cb825ddf"
+      }
+    },
+    "tusam3/aux_merchant_prices": {
+      "default_branch": "master",
+      "sha": "dc3b12d9f6ed4b37df78fdd84721552d00f5025e",
+      "branches": {
+        "master": "dc3b12d9f6ed4b37df78fdd84721552d00f5025e"
+      },
+      "latest_tag": "1"
+    },
+    "tuxpainter/shaguplates": {
+      "default_branch": "ash-bashdev",
+      "sha": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b",
+      "branches": {
+        "ash-bashdev": "9b2ebdf486864fea61a0bb8a5506cc88983ce37b"
+      }
+    },
+    "twapegg/gudaplates": {
+      "default_branch": "main",
+      "sha": "7a00258f97a92d4fcfcc7ef062745fd9ac9bf533",
+      "branches": {
+        "main": "7a00258f97a92d4fcfcc7ef062745fd9ac9bf533"
+      },
+      "latest_tag": "1.3.5"
+    },
+    "twapegg/pfquest": {
+      "default_branch": "main",
+      "sha": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379",
+      "branches": {
+        "main": "6b7085f0d8c49f833c2ff54fc97ae07dccc83379"
+      },
+      "latest_tag": "8.0.0"
+    },
+    "twapegg/tankalyze": {
+      "default_branch": "master",
+      "sha": "c5a1d327e05c7db8206b376b1353a597c720441c",
+      "branches": {
+        "master": "c5a1d327e05c7db8206b376b1353a597c720441c"
+      }
+    },
+    "twisniowski/supercleveroidmacros": {
+      "default_branch": "main",
+      "sha": "7335e71e5ea53a553b4fdf0e3a800367e48c8960",
+      "branches": {
+        "main": "7335e71e5ea53a553b4fdf0e3a800367e48c8960"
+      }
+    },
+    "twothe/improvedignore": {
+      "default_branch": "master",
+      "sha": "8fa195448453e881607e95bb8f8d4fc96bece6b8",
+      "branches": {
+        "master": "8fa195448453e881607e95bb8f8d4fc96bece6b8"
+      },
+      "latest_tag": "1.2"
+    },
+    "twothe/worldfilter": {
+      "default_branch": "master",
+      "sha": "005252265b55cd6bfb2bcc6cfddd4eb64612077b",
+      "branches": {
+        "master": "005252265b55cd6bfb2bcc6cfddd4eb64612077b"
+      }
+    },
+    "txuscolchonero/gatherer": {
+      "default_branch": "master",
+      "sha": "bf4cccdaf8dde5be933cc28c8c40379f8fdc56a6",
+      "branches": {
+        "master": "bf4cccdaf8dde5be933cc28c8c40379f8fdc56a6"
+      }
+    },
+    "txuscolchonero/onebuttonhunter": {
+      "default_branch": "master",
+      "sha": "f1f5b440014059df63042df8584abc3bac809bfe",
+      "branches": {
+        "master": "f1f5b440014059df63042df8584abc3bac809bfe"
+      },
+      "latest_tag": "b1"
+    },
+    "txuscolchonero/reciperadar-vanilla": {
+      "default_branch": "master",
+      "sha": "db200dae1f2d349e8f3fba83188e3950c73307af",
+      "branches": {
+        "master": "db200dae1f2d349e8f3fba83188e3950c73307af"
+      },
+      "latest_tag": "v1.15"
+    },
+    "tylkaw/raidorganizer": {
+      "default_branch": "master",
+      "sha": "747b977e6830ea2b7d152f4d2f0e04599e2c4e36",
+      "branches": {
+        "master": "747b977e6830ea2b7d152f4d2f0e04599e2c4e36"
+      },
+      "latest_tag": "v0.9.910"
+    },
+    "tyllyn/octo-rested": {
+      "default_branch": "master",
+      "sha": "cb65cf5b42133196f11f7474668b3171559b8fac",
+      "branches": {
+        "master": "cb65cf5b42133196f11f7474668b3171559b8fac"
+      }
+    },
+    "uc9089/buffblock-tw": {
+      "default_branch": "master",
+      "sha": "503697db9a7047479049577f0c0c200ddf529539",
+      "branches": {
+        "master": "503697db9a7047479049577f0c0c200ddf529539"
+      }
+    },
+    "uc9089/distancedisplay": {
+      "default_branch": "main",
+      "sha": "0f7fb5167387a37fc8e0150f88f42d597849eb38",
+      "branches": {
+        "main": "0f7fb5167387a37fc8e0150f88f42d597849eb38"
+      }
+    },
+    "uc9089/healersmate": {
+      "default_branch": "main",
+      "sha": "91a97eca12969b29bc4ebec13302debdea542bab",
+      "branches": {
+        "main": "91a97eca12969b29bc4ebec13302debdea542bab"
+      }
+    },
+    "uc9089/puppeteer": {
+      "default_branch": "main",
+      "sha": "d8768073072c303bf084a9597a9a6c81ddddfe0d",
+      "branches": {
+        "main": "d8768073072c303bf084a9597a9a6c81ddddfe0d"
+      }
+    },
+    "unclemilky/libramswap": {
+      "default_branch": "main",
+      "sha": "ac6048d78d15130e500c6c872b3aaf38dde13335",
+      "branches": {
+        "main": "ac6048d78d15130e500c6c872b3aaf38dde13335"
+      }
+    },
+    "undercityaddons-vanilla/macrott-v": {
+      "default_branch": "master",
+      "sha": "d9d173bda041771f17566353a012c67180331702",
+      "branches": {
+        "master": "d9d173bda041771f17566353a012c67180331702"
+      },
+      "latest_tag": "v1.1.0"
+    },
+    "unemployedwaifu/cleveroidmacros": {
+      "default_branch": "main",
+      "sha": "9456c483dd21a77028aa6afc5952e8ef190426bf",
+      "branches": {
+        "main": "9456c483dd21a77028aa6afc5952e8ef190426bf"
+      }
+    },
+    "ungweliant/shagunotify_ungweui": {
+      "default_branch": "master",
+      "sha": "1d46565e39d93db7df3c6f82e4840a4665c6daec",
+      "branches": {
+        "master": "1d46565e39d93db7df3c6f82e4840a4665c6daec"
+      }
+    },
+    "unknauwn/xckmasterlootadvanced": {
+      "default_branch": "Classic",
+      "sha": "1c4234df9cb13d5f6b16aab6bccae46ad0c7fb13",
+      "branches": {
+        "Classic": "1c4234df9cb13d5f6b16aab6bccae46ad0c7fb13"
+      },
+      "latest_tag": "3.7_classic"
+    },
+    "unknauwn/xtranqmanager": {
+      "default_branch": "Classic",
+      "sha": "5c468099500350e0938da703479cb276784dac57",
+      "branches": {
+        "Classic": "5c468099500350e0938da703479cb276784dac57"
+      },
+      "latest_tag": "3.0_classic"
+    },
+    "unknauwn/xtraunitframe": {
+      "default_branch": "master",
+      "sha": "46121e25c1c72ea012de28658a29fe83a443a862",
+      "branches": {
+        "master": "46121e25c1c72ea012de28658a29fe83a443a862"
+      },
+      "latest_tag": "4.0"
+    },
+    "uranreactor/octochatcolors": {
+      "default_branch": "main",
+      "sha": "72af27c6e14768af3f0018d75fdf7082254cede3",
+      "branches": {
+        "main": "72af27c6e14768af3f0018d75fdf7082254cede3"
+      }
+    },
+    "urarchieeminy/puppeteer": {
+      "default_branch": "main",
+      "sha": "c190322baee43cf3b33db91076f52c1662ee5cee",
+      "branches": {
+        "main": "c190322baee43cf3b33db91076f52c1662ee5cee"
+      }
+    },
+    "uss-enterprise-guild/1701-captainslog": {
+      "default_branch": "master",
+      "sha": "292c945dd1a35606f1ad35055ba2920295684760",
+      "branches": {
+        "master": "292c945dd1a35606f1ad35055ba2920295684760"
+      }
+    },
+    "uss-enterprise-guild/aux-addon": {
+      "default_branch": "master",
+      "sha": "4761752630c3214076f28a83d09fecdcb05bedfa",
+      "branches": {
+        "master": "4761752630c3214076f28a83d09fecdcb05bedfa"
+      }
+    },
+    "uss-enterprise-guild/cursive": {
+      "default_branch": "master",
+      "sha": "a0c99691b7aa8928996d0f8b913494b2aa06c863",
+      "branches": {
+        "master": "a0c99691b7aa8928996d0f8b913494b2aa06c863"
+      }
+    },
+    "uss-enterprise-guild/pfquest-turtle": {
+      "default_branch": "master",
+      "sha": "4c6f8d0a659bc7fc80867d51823b0dc967146087",
+      "branches": {
+        "master": "4c6f8d0a659bc7fc80867d51823b0dc967146087"
+      }
+    },
+    "uss-enterprise-guild/shagutweaks": {
+      "default_branch": "master",
+      "sha": "12bb66452a3b9c2cc17b0bcdd41373839469a03f",
+      "branches": {
+        "master": "12bb66452a3b9c2cc17b0bcdd41373839469a03f"
+      }
+    },
+    "uss-enterprise-guild/statcompare": {
+      "default_branch": "master",
+      "sha": "7f37fa33e5e5f431f883605ae7da3e47b5cfc838",
+      "branches": {
+        "master": "7f37fa33e5e5f431f883605ae7da3e47b5cfc838"
+      }
+    },
+    "utensile/distancedisplay": {
+      "default_branch": "main",
+      "sha": "dbc41068aa55e72e852ce108e7a2e8ad1a49ab8c",
+      "branches": {
+        "main": "dbc41068aa55e72e852ce108e7a2e8ad1a49ab8c"
+      }
+    },
+    "utensile/turtlemail": {
+      "default_branch": "master",
+      "sha": "2b40c45433cab27c1adbb6f674d1b90b505db059",
+      "branches": {
+        "master": "2b40c45433cab27c1adbb6f674d1b90b505db059"
+      }
+    },
+    "vaaslite/turtleroleplayinghelper": {
+      "default_branch": "main",
+      "sha": "07ae5a6de1a0426c2efb085cd45044f910e4067f",
+      "branches": {
+        "main": "07ae5a6de1a0426c2efb085cd45044f910e4067f"
+      }
+    },
+    "vakos1/hattrick": {
+      "default_branch": "main",
+      "sha": "fd14ab1622f2beb2c8af16ee2400752494f4a599",
+      "branches": {
+        "main": "fd14ab1622f2beb2c8af16ee2400752494f4a599"
+      }
+    },
+    "vakos1/ignite-status": {
+      "default_branch": "main",
+      "sha": "643d58cec868c1e4265653b44d8b277779709c30",
+      "branches": {
+        "main": "643d58cec868c1e4265653b44d8b277779709c30"
+      }
+    },
+    "vakos1/snowkoban": {
+      "default_branch": "main",
+      "sha": "1236a4c68e3cf5e0e58f003bec0621cb910591cf",
+      "branches": {
+        "main": "1236a4c68e3cf5e0e58f003bec0621cb910591cf"
+      }
+    },
+    "vakos1/superinspect": {
+      "default_branch": "main",
+      "sha": "3fc7e1dcd44d5bf8772ca89e5af6b643672c1a7c",
+      "branches": {
+        "main": "3fc7e1dcd44d5bf8772ca89e5af6b643672c1a7c"
+      }
+    },
+    "valiusha90/autoturnin": {
+      "default_branch": "main",
+      "sha": "9c8c0c08863cab9860b79205ffea1358b65aae29",
+      "branches": {
+        "main": "9c8c0c08863cab9860b79205ffea1358b65aae29"
+      }
+    },
+    "valiusha90/questshell": {
+      "default_branch": "main",
+      "sha": "2c18024c288f48b524175aab1ec1803db5154d60",
+      "branches": {
+        "main": "2c18024c288f48b524175aab1ec1803db5154d60"
+      }
+    },
+    "valnaut/artisan": {
+      "default_branch": "main",
+      "sha": "cd2089bb15240a764dfc9d68b0755166c0f2a7d2",
+      "branches": {
+        "main": "cd2089bb15240a764dfc9d68b0755166c0f2a7d2"
+      }
+    },
+    "vaniron/tourguide-turtle": {
+      "default_branch": "master",
+      "sha": "90d3837e3f1f3a97d9cd446696598b8207cc0de4",
+      "branches": {
+        "master": "90d3837e3f1f3a97d9cd446696598b8207cc0de4"
+      },
+      "latest_tag": "1.3"
+    },
+    "vargv666/casthistorytracker": {
+      "default_branch": "main",
+      "sha": "20a70661983bb25510bbf9202b842dba65186e77",
+      "branches": {
+        "main": "20a70661983bb25510bbf9202b842dba65186e77"
+      }
+    },
+    "vargv666/cursive": {
+      "default_branch": "master",
+      "sha": "e4269c043c445bd6b2c0d5fe63ba80207f17bea6",
+      "branches": {
+        "master": "e4269c043c445bd6b2c0d5fe63ba80207f17bea6"
+      }
+    },
+    "vargv666/goblinbrainwashinghelper": {
+      "default_branch": "master",
+      "sha": "09157f672e826c7d26090ef93ecee66d958f69bf",
+      "branches": {
+        "master": "09157f672e826c7d26090ef93ecee66d958f69bf"
+      }
+    },
+    "vargv666/instancetimers": {
+      "default_branch": "master",
+      "sha": "5d4e5535c92aeed47e06e7ee143263931401d96c",
+      "branches": {
+        "master": "5d4e5535c92aeed47e06e7ee143263931401d96c"
+      }
+    },
+    "vargv666/lazyres": {
+      "default_branch": "master",
+      "sha": "ffed45c8d6912aef7cb8e2531745928edce54af9",
+      "branches": {
+        "master": "ffed45c8d6912aef7cb8e2531745928edce54af9"
+      }
+    },
+    "vargv666/lootblare": {
+      "default_branch": "master",
+      "sha": "2ae4a170794da724020acc7fe8cb4408b9d29648",
+      "branches": {
+        "master": "2ae4a170794da724020acc7fe8cb4408b9d29648"
+      }
+    },
+    "vargv666/manaminder": {
+      "default_branch": "master",
+      "sha": "ababafd952ef3d4b293c0dd9b64f2cc272fc477a",
+      "branches": {
+        "master": "ababafd952ef3d4b293c0dd9b64f2cc272fc477a"
+      }
+    },
+    "vargv666/modui": {
+      "default_branch": "main",
+      "sha": "380bca707ebb05f06f580924ea281a36b553dfd2",
+      "branches": {
+        "main": "380bca707ebb05f06f580924ea281a36b553dfd2"
+      }
+    },
+    "vargv666/specialtalent": {
+      "default_branch": "main",
+      "sha": "12266488dc31939b1fa3845808f52a8cce1782ab",
+      "branches": {
+        "main": "12266488dc31939b1fa3845808f52a8cce1782ab"
+      }
+    },
+    "vargv666/wow-vanilla-pvpwarn": {
+      "default_branch": "master",
+      "sha": "9b26bb247e34209ec73d3858443738ace551c3f6",
+      "branches": {
+        "master": "9b26bb247e34209ec73d3858443738ace551c3f6"
+      }
+    },
+    "vargv666/zui": {
+      "default_branch": "master",
+      "sha": "56da9bb7d9a24fdae1db351ea97f920370b8f140",
+      "branches": {
+        "master": "56da9bb7d9a24fdae1db351ea97f920370b8f140"
+      }
+    },
+    "vashin1/debufffilter": {
+      "default_branch": "master",
+      "sha": "9cf04734166fe087770354ecbd55643c894a83eb",
+      "branches": {
+        "master": "9cf04734166fe087770354ecbd55643c894a83eb"
+      }
+    },
+    "vashin1/syncedui": {
+      "default_branch": "master",
+      "sha": "3793fb4c6ae341635eeab54df264fb5f3ed05b04",
+      "branches": {
+        "master": "3793fb4c6ae341635eeab54df264fb5f3ed05b04"
+      }
+    },
+    "vatichild/guda": {
+      "default_branch": "main",
+      "sha": "5eba9adcc2767ca40f2f71b1c74a7f84822edef7",
+      "branches": {
+        "main": "5eba9adcc2767ca40f2f71b1c74a7f84822edef7"
+      },
+      "latest_tag": "2.3.2"
+    },
+    "vatichild/guda-plates": {
+      "default_branch": "main",
+      "sha": "e5204a4e8035257bbdb66234eab0494231443d5c",
+      "branches": {
+        "main": "e5204a4e8035257bbdb66234eab0494231443d5c"
+      },
+      "latest_tag": "1.3.5"
+    },
+    "vatichild/gudaplates": {
+      "default_branch": "main",
+      "sha": "e5204a4e8035257bbdb66234eab0494231443d5c",
+      "branches": {
+        "main": "e5204a4e8035257bbdb66234eab0494231443d5c"
+      },
+      "latest_tag": "1.3.5"
+    },
+    "vegeta1k95/modernspellbook": {
+      "default_branch": "master",
+      "sha": "88afad31729657175d1710c259d9e55081331920",
+      "branches": {
+        "master": "88afad31729657175d1710c259d9e55081331920"
+      }
+    },
+    "vempz/tourguidevanilla": {
+      "default_branch": "master",
+      "sha": "6cda6009c824ec24d652b9fd3f2c6b26c86a3eb2",
+      "branches": {
+        "master": "6cda6009c824ec24d652b9fd3f2c6b26c86a3eb2"
+      },
+      "latest_tag": "1.0.6-beta"
+    },
+    "verge20/ezpoison": {
+      "default_branch": "main",
+      "sha": "fe029554048f4581a4bbf217adce00be9e4ff826",
+      "branches": {
+        "main": "fe029554048f4581a4bbf217adce00be9e4ff826"
+      }
+    },
+    "verge20/rinse": {
+      "default_branch": "master",
+      "sha": "2c830e52a7b5c5bac26657cd00c32f18645daede",
+      "branches": {
+        "master": "2c830e52a7b5c5bac26657cd00c32f18645daede"
+      }
+    },
+    "veritania/puppeteer": {
+      "default_branch": "main",
+      "sha": "7fa9db6cc1032852733c0dbf77693c881719dbfd",
+      "branches": {
+        "main": "7fa9db6cc1032852733c0dbf77693c881719dbfd"
+      }
+    },
+    "vill8/pfquest-octo": {
+      "default_branch": "master",
+      "sha": "b0f70e9b2e74276391083ae88c6a72eca849975a",
+      "branches": {
+        "master": "b0f70e9b2e74276391083ae88c6a72eca849975a"
+      }
+    },
+    "vini-sousa/mastertradeskills-vanilla": {
+      "default_branch": "master",
+      "sha": "8ffeef5fc15a138d4c143d718b897cbce47ba2ca",
+      "branches": {
+        "master": "8ffeef5fc15a138d4c143d718b897cbce47ba2ca"
+      }
+    },
+    "violetrainbows/roid-macros": {
+      "default_branch": "master",
+      "sha": "3be5487a1198added98b90d4c40dce552547ad1b",
+      "branches": {
+        "master": "3be5487a1198added98b90d4c40dce552547ad1b"
+      }
+    },
+    "voidmenull/debufftimers": {
+      "default_branch": "master",
+      "sha": "9da80d56175f4772e6f3c59798eec19aea61bed0",
+      "branches": {
+        "master": "9da80d56175f4772e6f3c59798eec19aea61bed0"
+      }
+    },
+    "voidmenull/gamonkilltimer": {
+      "default_branch": "master",
+      "sha": "202d8eab385cefd84103ba194cc6de7b219a9743",
+      "branches": {
+        "master": "202d8eab385cefd84103ba194cc6de7b219a9743"
+      }
+    },
+    "voidmenull/vanillahealingassignments": {
+      "default_branch": "master",
+      "sha": "1d3077c586e71463864faadfc8b8e5b50eeaa769",
+      "branches": {
+        "master": "1d3077c586e71463864faadfc8b8e5b50eeaa769"
+      }
+    },
+    "voidmenull/wholist_fix": {
+      "default_branch": "master",
+      "sha": "07ccd926719160dd6461895eef66148ba0e7fde0",
+      "branches": {
+        "master": "07ccd926719160dd6461895eef66148ba0e7fde0"
+      }
+    },
+    "vortigern11/selffound": {
+      "default_branch": "main",
+      "sha": "fadf4c12dd9d9653c76cd9f6773d0e90cdb0c729",
+      "branches": {
+        "main": "fadf4c12dd9d9653c76cd9f6773d0e90cdb0c729"
+      }
+    },
+    "voxan-dev/shardcap": {
+      "default_branch": "main",
+      "sha": "17579924332f0f5ef6ae2519160ccf941389fb3a",
+      "branches": {
+        "main": "17579924332f0f5ef6ae2519160ccf941389fb3a"
+      }
+    },
+    "waelelechi/vanilla-wow-addons": {
+      "default_branch": "master",
+      "sha": "8f6feb94325135c090a891e5d81f0f760c4371e8",
+      "branches": {
+        "master": "8f6feb94325135c090a891e5d81f0f760c4371e8"
+      }
+    },
+    "waldnercharles/cursive": {
+      "default_branch": "master",
+      "sha": "ef47b8b34ff49b882450f8271b9bbd5fddf4bd54",
+      "branches": {
+        "master": "ef47b8b34ff49b882450f8271b9bbd5fddf4bd54"
+      }
+    },
+    "wanliqiaoxi/pfui-rainbowhealthbar": {
+      "default_branch": "main",
+      "sha": "b119b56718c091d2d20d9e2fa1d8d2f0d88c32ad",
+      "branches": {
+        "main": "b119b56718c091d2d20d9e2fa1d8d2f0d88c32ad"
+      },
+      "latest_tag": "v1.1.1"
+    },
+    "wanliqiaoxi/shagudps": {
+      "default_branch": "master",
+      "sha": "b6170c70c2448ad2c6d598981be26b724cdd599c",
+      "branches": {
+        "master": "b6170c70c2448ad2c6d598981be26b724cdd599c"
+      }
+    },
+    "wardz/focusframe": {
+      "default_branch": "master",
+      "sha": "e438b7efb358b20d3f1950b5b42910f1d20e6f75",
+      "branches": {
+        "master": "e438b7efb358b20d3f1950b5b42910f1d20e6f75"
+      },
+      "latest_tag": "1.04"
+    },
+    "wardz/focusframe_targetcastbar": {
+      "default_branch": "master",
+      "sha": "44fa7fb810aacf17a8cc0f05b8bd6de3bf5f8c4e",
+      "branches": {
+        "master": "44fa7fb810aacf17a8cc0f05b8bd6de3bf5f8c4e"
+      },
+      "latest_tag": "v1.0.0"
+    },
+    "warlockbugs/impulse-booster": {
+      "default_branch": "master",
+      "sha": "79eb07d55179526a842d300300ffa20b40390e3a",
+      "branches": {
+        "master": "79eb07d55179526a842d300300ffa20b40390e3a"
+      },
+      "latest_tag": "v3.1-final"
+    },
+    "wasdcabb/sortbags-vanilla": {
+      "default_branch": "master",
+      "sha": "1b59767ca41749e70d72f2991c27054beebcdfcd",
+      "branches": {
+        "master": "1b59767ca41749e70d72f2991c27054beebcdfcd"
+      }
+    },
+    "waverion/unitxp_sp3_addon": {
+      "default_branch": "main",
+      "sha": "6263fd66ff0e21f0aff63ebae3358e0e543387ca",
+      "branches": {
+        "main": "6263fd66ff0e21f0aff63ebae3358e0e543387ca"
+      }
+    },
+    "wayoff333/cursive": {
+      "default_branch": "master",
+      "sha": "fb83abb6f563682e33075fc7f35cb404723616da",
+      "branches": {
+        "master": "fb83abb6f563682e33075fc7f35cb404723616da"
+      },
+      "latest_tag": "1.3"
+    },
+    "wayoff333/turtlecalendar": {
+      "default_branch": "main",
+      "sha": "5e546506f104a61babfa5514f1c5aa521066ad71",
+      "branches": {
+        "main": "5e546506f104a61babfa5514f1c5aa521066ad71"
+      },
+      "latest_tag": "1.7"
+    },
+    "wbb1977/chattimestamps": {
+      "default_branch": "master",
+      "sha": "ea11be079d5a61adf429973ded0ad8beda8c485e",
+      "branches": {
+        "master": "ea11be079d5a61adf429973ded0ad8beda8c485e"
+      },
+      "latest_tag": "1.6a"
+    },
+    "wbb1977/cleanplayerframe": {
+      "default_branch": "master",
+      "sha": "234eb6d89bb24adb956dcececa590d664cc6b558",
+      "branches": {
+        "master": "234eb6d89bb24adb956dcececa590d664cc6b558"
+      },
+      "latest_tag": "11200"
+    },
+    "wbb1977/corpseinfo": {
+      "default_branch": "master",
+      "sha": "493c18b6d6822b38cc9f030778970fc10be45e61",
+      "branches": {
+        "master": "493c18b6d6822b38cc9f030778970fc10be45e61"
+      },
+      "latest_tag": "v15"
+    },
+    "wbb1977/fishinfo2": {
+      "default_branch": "master",
+      "sha": "acc91a08bbb7c13ce7b6c2d0b96ec05ed90c3f6f",
+      "branches": {
+        "master": "acc91a08bbb7c13ce7b6c2d0b96ec05ed90c3f6f"
+      },
+      "latest_tag": "v10"
+    },
+    "wbb1977/perfectshot": {
+      "default_branch": "master",
+      "sha": "36e21f5ffb007f258b70b6874802a2f73576bd6c",
+      "branches": {
+        "master": "36e21f5ffb007f258b70b6874802a2f73576bd6c"
+      },
+      "latest_tag": "v10"
+    },
+    "wdrx70xn/roll-for-vanilla": {
+      "default_branch": "master",
+      "sha": "05b964006ec4b9dd35decc0581fd84ddf78cb343",
+      "branches": {
+        "master": "05b964006ec4b9dd35decc0581fd84ddf78cb343"
+      },
+      "latest_tag": "v4.6.5"
+    },
+    "webdkpthroaway/webdkp_elysium": {
+      "default_branch": "master",
+      "sha": "4b84ffa13168d2b1e10955d6a8cdeea023c596e1",
+      "branches": {
+        "master": "4b84ffa13168d2b1e10955d6a8cdeea023c596e1"
+      }
+    },
+    "weirdpuppy94/rallyhelper": {
+      "default_branch": "main",
+      "sha": "e38cb75f0cbee12bcf413e23787d94b5927e8daa",
+      "branches": {
+        "main": "e38cb75f0cbee12bcf413e23787d94b5927e8daa"
+      },
+      "latest_tag": "RallyHelperv1.4.7"
+    },
+    "whitealion/flyout_items": {
+      "default_branch": "main",
+      "sha": "a2a1021a7a48ef00c75279ebecfb8abfb7b47f42",
+      "branches": {
+        "main": "a2a1021a7a48ef00c75279ebecfb8abfb7b47f42"
+      }
+    },
+    "whtmst/adf": {
+      "default_branch": "master",
+      "sha": "2d9051dc46023a32bc88d6343edda4ad159f08ae",
+      "branches": {
+        "master": "2d9051dc46023a32bc88d6343edda4ad159f08ae"
+      }
+    },
+    "whtmst/akkio_consume_helper": {
+      "default_branch": "main",
+      "sha": "34dcbec42f82323f429e1ec477c628a65b0e31cd",
+      "branches": {
+        "main": "34dcbec42f82323f429e1ec477c628a65b0e31cd"
+      }
+    },
+    "whtmst/consumesmanager": {
+      "default_branch": "main",
+      "sha": "f6c8e17c583f4a6d0b9d78f29720731f55072fd9",
+      "branches": {
+        "main": "f6c8e17c583f4a6d0b9d78f29720731f55072fd9"
+      }
+    },
+    "whtmst/decursive": {
+      "default_branch": "master",
+      "sha": "bc6df9e9b5e3f643b3857d5b9fba8127ab4f8163",
+      "branches": {
+        "master": "bc6df9e9b5e3f643b3857d5b9fba8127ab4f8163"
+      }
+    },
+    "whtmst/difficultbulletinboard": {
+      "default_branch": "master",
+      "sha": "361aad842797547aec25550ba68a0e4ec8789272",
+      "branches": {
+        "master": "361aad842797547aec25550ba68a0e4ec8789272"
+      }
+    },
+    "whtmst/gentlegc": {
+      "default_branch": "master",
+      "sha": "a41404979d9919ebb781e02ea6a493ad604ef2cc",
+      "branches": {
+        "master": "a41404979d9919ebb781e02ea6a493ad604ef2cc"
+      }
+    },
+    "whtmst/lern2spell": {
+      "default_branch": "master",
+      "sha": "eb66f354a363b29c7140edd857ea4cbd01b3d8f5",
+      "branches": {
+        "master": "eb66f354a363b29c7140edd857ea4cbd01b3d8f5"
+      }
+    },
+    "whtmst/minimapbuttonframe-vanilla": {
+      "default_branch": "master",
+      "sha": "0923f9e4128c6fcdc97df448c7665ca71bca2a18",
+      "branches": {
+        "master": "0923f9e4128c6fcdc97df448c7665ca71bca2a18"
+      }
+    },
+    "whtmst/modernmapmarkers": {
+      "default_branch": "main",
+      "sha": "603b107cf550271048bcecdc850e9f74c4520188",
+      "branches": {
+        "main": "603b107cf550271048bcecdc850e9f74c4520188"
+      }
+    },
+    "whtmst/pfui-bettertotems": {
+      "default_branch": "main",
+      "sha": "4bcb23338570476c97db89590a70d102b0438b09",
+      "branches": {
+        "main": "4bcb23338570476c97db89590a70d102b0438b09"
+      }
+    },
+    "whtmst/puppeteer": {
+      "default_branch": "main",
+      "sha": "1d1a7938bc37aae4cb8f3e6e8db02bb2e0814f98",
+      "branches": {
+        "main": "1d1a7938bc37aae4cb8f3e6e8db02bb2e0814f98"
+      }
+    },
+    "whtmst/rinse": {
+      "default_branch": "master",
+      "sha": "3503370e8e8b6d30ab20a40926bcf57f96d95160",
+      "branches": {
+        "master": "3503370e8e8b6d30ab20a40926bcf57f96d95160"
+      }
+    },
+    "whtmst/roll-for-vanilla": {
+      "default_branch": "master",
+      "sha": "05b964006ec4b9dd35decc0581fd84ddf78cb343",
+      "branches": {
+        "master": "05b964006ec4b9dd35decc0581fd84ddf78cb343"
+      }
+    },
+    "whtmst/shagukill": {
+      "default_branch": "master",
+      "sha": "498e2db84d2d666717d04538641add7ebca967cd",
+      "branches": {
+        "master": "498e2db84d2d666717d04538641add7ebca967cd"
+      }
+    },
+    "whtmst/shaguscan": {
+      "default_branch": "master",
+      "sha": "8d5b3f6fb6cc49863ade987fbbb26c31e46d7080",
+      "branches": {
+        "master": "8d5b3f6fb6cc49863ade987fbbb26c31e46d7080"
+      }
+    },
+    "whtmst/simpleauras": {
+      "default_branch": "main",
+      "sha": "f53724b76ea581593d49dc6c4ec437b529638650",
+      "branches": {
+        "main": "f53724b76ea581593d49dc6c4ec437b529638650"
+      }
+    },
+    "whtmst/superignore": {
+      "default_branch": "master",
+      "sha": "495527c3a6a979bc66438312fe98100da30fbd53",
+      "branches": {
+        "master": "495527c3a6a979bc66438312fe98100da30fbd53"
+      }
+    },
+    "whtmst/superinspect": {
+      "default_branch": "main",
+      "sha": "3fc7e1dcd44d5bf8772ca89e5af6b643672c1a7c",
+      "branches": {
+        "main": "3fc7e1dcd44d5bf8772ca89e5af6b643672c1a7c"
+      }
+    },
+    "whtmst/t-oom": {
+      "default_branch": "main",
+      "sha": "3b4d7c1b2529bde2f447f9d1ce63a3ff7384eaa4",
+      "branches": {
+        "main": "3b4d7c1b2529bde2f447f9d1ce63a3ff7384eaa4"
+      }
+    },
+    "whtmst/t-restedxp": {
+      "default_branch": "main",
+      "sha": "5eaf92fdd9f437751e0e405c34b235fc0f5b962d",
+      "branches": {
+        "main": "5eaf92fdd9f437751e0e405c34b235fc0f5b962d"
+      }
+    },
+    "whtmst/t-vamp": {
+      "default_branch": "master",
+      "sha": "63727b656e13aaad818fd7dee77002a261684416",
+      "branches": {
+        "master": "63727b656e13aaad818fd7dee77002a261684416"
+      }
+    },
+    "whtmst/tradechat": {
+      "default_branch": "master",
+      "sha": "ef76057e10220d8138955c3e027a238d3b3825d9",
+      "branches": {
+        "master": "ef76057e10220d8138955c3e027a238d3b3825d9"
+      }
+    },
+    "whtmst/turtlemail": {
+      "default_branch": "master",
+      "sha": "322429e143db1f1f00afe0d1074678a844bf8c7c",
+      "branches": {
+        "master": "322429e143db1f1f00afe0d1074678a844bf8c7c"
+      }
+    },
+    "whtmst/wim": {
+      "default_branch": "master",
+      "sha": "d93427a07c1101b24e977dc36bac453e34687500",
+      "branches": {
+        "master": "d93427a07c1101b24e977dc36bac453e34687500"
+      }
+    },
+    "whtmst/youvegotredonyou": {
+      "default_branch": "master",
+      "sha": "b61805c0da7b8cbef410af95b703d217b7e56d55",
+      "branches": {
+        "master": "b61805c0da7b8cbef410af95b703d217b7e56d55"
+      }
+    },
+    "wierdthing/consumesmanager": {
+      "default_branch": "main",
+      "sha": "817c50a34b6d2d135365c3b4077ea0c8ffc7f67a",
+      "branches": {
+        "main": "817c50a34b6d2d135365c3b4077ea0c8ffc7f67a"
+      }
+    },
+    "wierdthing/ezpoison": {
+      "default_branch": "main",
+      "sha": "eb0184efaed84992dd652b2ad82a49679177d6f6",
+      "branches": {
+        "main": "eb0184efaed84992dd652b2ad82a49679177d6f6"
+      }
+    },
+    "wierdthing/nugenergy": {
+      "default_branch": "master",
+      "sha": "ecf0d4a8f3a5bb08e9d1741d9d9014420e24cda7",
+      "branches": {
+        "master": "ecf0d4a8f3a5bb08e9d1741d9d9014420e24cda7"
+      },
+      "latest_tag": "11.0.2"
+    },
+    "wierdthing/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "fefde810f979bfbcbdccfbe30472de3a68701652",
+      "branches": {
+        "master": "fefde810f979bfbcbdccfbe30472de3a68701652"
+      }
+    },
+    "wierdthing/roguefocus": {
+      "default_branch": "master",
+      "sha": "3f77792a2ec64da38fcf32c290692bf6f7c15a47",
+      "branches": {
+        "master": "3f77792a2ec64da38fcf32c290692bf6f7c15a47"
+      }
+    },
+    "wierdthing/twbuypoisons": {
+      "default_branch": "master",
+      "sha": "194fa10b8216c73a795ab393a71b815bd464989f",
+      "branches": {
+        "master": "194fa10b8216c73a795ab393a71b815bd464989f"
+      }
+    },
+    "wiggen94/dialogui": {
+      "default_branch": "main",
+      "sha": "b0632607d01382f1eadfa222cebdb9f430660342",
+      "branches": {
+        "main": "b0632607d01382f1eadfa222cebdb9f430660342"
+      }
+    },
+    "wiggen94/lootmonitor": {
+      "default_branch": "main",
+      "sha": "551ec4b89c747b1a87e85b818021867c57fef358",
+      "branches": {
+        "main": "551ec4b89c747b1a87e85b818021867c57fef358"
+      }
+    },
+    "wiggen94/rangecolor": {
+      "default_branch": "master",
+      "sha": "52b22ed292c0675726bfa55a4bdcfd9c9c9aa7d4",
+      "branches": {
+        "master": "52b22ed292c0675726bfa55a4bdcfd9c9c9aa7d4"
+      }
+    },
+    "wigmox/consoleexperienceclassic": {
+      "default_branch": "main",
+      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
+      "branches": {
+        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
+      },
+      "latest_tag": "v0.15.0"
+    },
+    "wigmox/dragonflightui-reforged": {
+      "default_branch": "main",
+      "sha": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8",
+      "branches": {
+        "main": "2a8d2ffb3d9262f0d2af2071b9b47ef27f76f7f8"
+      },
+      "latest_tag": "1.3.4"
+    },
+    "willierpt/difficultbulletinboard": {
+      "default_branch": "master",
+      "sha": "5c66d874ba4d9527819749c12f9ea940d9700948",
+      "branches": {
+        "master": "5c66d874ba4d9527819749c12f9ea940d9700948"
+      }
+    },
+    "windowskar/reckcounter-fix": {
+      "default_branch": "master",
+      "sha": "758bd956d91e2dab7ea9eb70979445a1ffe51314",
+      "branches": {
+        "master": "758bd956d91e2dab7ea9eb70979445a1ffe51314"
+      },
+      "latest_tag": "Release"
+    },
+    "woblight/macrotextstop": {
+      "default_branch": "master",
+      "sha": "13e32571bce73afebfc505f81ccaaacde4ebfdd7",
+      "branches": {
+        "master": "13e32571bce73afebfc505f81ccaaacde4ebfdd7"
+      }
+    },
+    "wormuz/decursive": {
+      "default_branch": "master",
+      "sha": "54d015b83256ea2b28e802097696a592c6fb7ba4",
+      "branches": {
+        "master": "54d015b83256ea2b28e802097696a592c6fb7ba4"
+      }
+    },
+    "wormuz/groupfinder": {
+      "default_branch": "main",
+      "sha": "0af1a4869d19cf809a54350693e6cf0a6be989ee",
+      "branches": {
+        "main": "0af1a4869d19cf809a54350693e6cf0a6be989ee"
+      }
+    },
+    "wormuz/outfitter": {
+      "default_branch": "master",
+      "sha": "7e24cae8b93ca9f57440855e6b470c610b825109",
+      "branches": {
+        "master": "7e24cae8b93ca9f57440855e6b470c610b825109"
+      }
+    },
+    "wouatwouat/tomtom": {
+      "default_branch": "master",
+      "sha": "b87129dfe74141e77d5e0be4d4ede4cacbb6ef17",
+      "branches": {
+        "master": "b87129dfe74141e77d5e0be4d4ede4cacbb6ef17"
+      }
+    },
+    "wouterbink/autoshot": {
+      "default_branch": "master",
+      "sha": "0a8b53551bda2bd1fd76c532b1f558d0bf6b30bb",
+      "branches": {
+        "master": "0a8b53551bda2bd1fd76c532b1f558d0bf6b30bb"
+      }
+    },
+    "wouterbink/shamanfix": {
+      "default_branch": "master",
+      "sha": "bb5931afb798f4820b36e8b0efdbbc2fe5c6d654",
+      "branches": {
+        "master": "bb5931afb798f4820b36e8b0efdbbc2fe5c6d654"
+      }
+    },
+    "wow-br/blizzplates": {
+      "default_branch": "master",
+      "sha": "8aa50c0fe0d50aabeab39472abebb3f5f241672b",
+      "branches": {
+        "master": "8aa50c0fe0d50aabeab39472abebb3f5f241672b"
+      }
+    },
+    "wowshub/consoleexperienceclassic": {
+      "default_branch": "main",
+      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
+      "branches": {
+        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
+      }
+    },
+    "wurmschwanz/blizznameplatesplus": {
+      "default_branch": "main",
+      "sha": "4fb662bbd67ccda645c779f045fc917ff99006cc",
+      "branches": {
+        "main": "4fb662bbd67ccda645c779f045fc917ff99006cc"
+      }
+    },
+    "wurmschwanz/nicedamage-1.12": {
+      "default_branch": "main",
+      "sha": "bda369919efcfc1313eb0471fd63a5ffe81ab58a",
+      "branches": {
+        "main": "bda369919efcfc1313eb0471fd63a5ffe81ab58a"
+      },
+      "latest_tag": "v2.1.1"
+    },
+    "wyfyhdzbsb-lang/nugenergy": {
+      "default_branch": "master",
+      "sha": "5340b74bdf5b014176fc9c7bc544d93e35ca3a58",
+      "branches": {
+        "master": "5340b74bdf5b014176fc9c7bc544d93e35ca3a58"
+      }
+    },
+    "xalzul/dwarvenizer-1.12": {
+      "default_branch": "master",
+      "sha": "2b28d2a62a61f3d4a5251ef34a541a868d25acb0",
+      "branches": {
+        "master": "2b28d2a62a61f3d4a5251ef34a541a868d25acb0"
+      }
+    },
+    "xalzul/roleplayinghelper-1.12": {
+      "default_branch": "master",
+      "sha": "8962fbdfc55fc02bdda4614dd899c2d658e174c5",
+      "branches": {
+        "master": "8962fbdfc55fc02bdda4614dd899c2d658e174c5"
+      }
+    },
+    "xcornelius/censusplusturtle": {
+      "default_branch": "main",
+      "sha": "6dae25fad5fcf038083ded230c380cc56b142d3a",
+      "branches": {
+        "main": "6dae25fad5fcf038083ded230c380cc56b142d3a"
+      }
+    },
+    "xcornelius/zorlen": {
+      "default_branch": "main",
+      "sha": "4b844640315ac422ccffbde114c59cea6918a551",
+      "branches": {
+        "main": "4b844640315ac422ccffbde114c59cea6918a551"
+      }
+    },
+    "xerik444x/pfquest-turtle-es": {
+      "default_branch": "master",
+      "sha": "1f40881b742e4d819784e61b11e8c55f00d74eaa",
+      "branches": {
+        "master": "1f40881b742e4d819784e61b11e8c55f00d74eaa"
+      }
+    },
+    "xeropresence/outfitter": {
+      "default_branch": "master",
+      "sha": "449c6a8cdd1f466a34825b5ea486dfbe7d469a9c",
+      "branches": {
+        "master": "449c6a8cdd1f466a34825b5ea486dfbe7d469a9c"
+      }
+    },
+    "xhwsd/consoleexperienceclassic": {
+      "default_branch": "main",
+      "sha": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0",
+      "branches": {
+        "main": "c2f2dfc555ff4bc2ec625281e813b4eb7a080aa0"
+      }
+    },
+    "xian55/fullsack": {
+      "default_branch": "master",
+      "sha": "697c1da2639fbadf1fd63263fbc5b724ba93200b",
+      "branches": {
+        "master": "697c1da2639fbadf1fd63263fbc5b724ba93200b"
+      }
+    },
+    "xian55/shaguchat": {
+      "default_branch": "master",
+      "sha": "01c37853c5e714b218837d24932c316f68b2728f",
+      "branches": {
+        "master": "01c37853c5e714b218837d24932c316f68b2728f"
+      }
+    },
+    "xian55/zorlen": {
+      "default_branch": "main",
+      "sha": "3d3b72313d02d8a10b9b908946c918ff5dc7cefc",
+      "branches": {
+        "main": "3d3b72313d02d8a10b9b908946c918ff5dc7cefc"
+      }
+    },
+    "xiao-ma-cookiemx/modernmapmarkers-": {
+      "default_branch": "main",
+      "sha": "a95e8d39d3ea7143896873e245e621847b1a5ef2",
+      "branches": {
+        "main": "a95e8d39d3ea7143896873e245e621847b1a5ef2"
+      },
+      "latest_tag": "1.3"
+    },
+    "xinleibird/cooldowntimers": {
+      "default_branch": "master",
+      "sha": "6b85a5f452204384b94bd984fc551689822c3229",
+      "branches": {
+        "master": "6b85a5f452204384b94bd984fc551689822c3229"
+      }
+    },
+    "xinleibird/egnar": {
+      "default_branch": "master",
+      "sha": "9d288d4fae8a787aa7317a8e3da9aa29f12506e6",
+      "branches": {
+        "master": "9d288d4fae8a787aa7317a8e3da9aa29f12506e6"
+      }
+    },
+    "xinleibird/nugcombobar": {
+      "default_branch": "master",
+      "sha": "96638740c04f0532bf098a262006115bf2baeb7d",
+      "branches": {
+        "master": "96638740c04f0532bf098a262006115bf2baeb7d"
+      }
+    },
+    "xinleibird/picopoisons": {
+      "default_branch": "master",
+      "sha": "937e93c4d8a4ed41a2e8a67b25c44e39949669d3",
+      "branches": {
+        "master": "937e93c4d8a4ed41a2e8a67b25c44e39949669d3"
+      }
+    },
+    "xinleibird/shagudps": {
+      "default_branch": "master",
+      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
+      "branches": {
+        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
+      }
+    },
+    "xinleibird/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "117727d849cb94bd46078c47f40aa9bc064bbb19",
+      "branches": {
+        "master": "117727d849cb94bd46078c47f40aa9bc064bbb19"
+      }
+    },
+    "xinleibird/simpleauras": {
+      "default_branch": "main",
+      "sha": "f53724b76ea581593d49dc6c4ec437b529638650",
+      "branches": {
+        "main": "f53724b76ea581593d49dc6c4ec437b529638650"
+      }
+    },
+    "xinleibird/timemanager": {
+      "default_branch": "master",
+      "sha": "3ed3f1279de1b473f1c72022af8271d16c40c139",
+      "branches": {
+        "master": "3ed3f1279de1b473f1c72022af8271d16c40c139"
+      }
+    },
+    "xleone1/quiver": {
+      "default_branch": "main",
+      "sha": "109108a10dc94a3905b26158c783623d5e426cc6",
+      "branches": {
+        "main": "109108a10dc94a3905b26158c783623d5e426cc6"
+      },
+      "latest_tag": "v3.1.4"
+    },
+    "xleone1/threat": {
+      "default_branch": "master",
+      "sha": "72168120a25e4cc47c131e301778ced9e9c1db13",
+      "branches": {
+        "master": "72168120a25e4cc47c131e301778ced9e9c1db13"
+      }
+    },
+    "xniko/kallyoautoshot": {
+      "default_branch": "master",
+      "sha": "ee23361084583e26de4afff6685206ba9dcc3d7e",
+      "branches": {
+        "master": "ee23361084583e26de4afff6685206ba9dcc3d7e"
+      }
+    },
+    "xorann/grimreaper": {
+      "default_branch": "master",
+      "sha": "18d52e0660dcd217b8717d457717832ce829b39b",
+      "branches": {
+        "master": "18d52e0660dcd217b8717d457717832ce829b39b"
+      }
+    },
+    "xorann/svt": {
+      "default_branch": "master",
+      "sha": "578170b325e3a6e7e3fb805f07521c73f8a9c636",
+      "branches": {
+        "master": "578170b325e3a6e7e3fb805f07521c73f8a9c636"
+      }
+    },
+    "xorann/tankheal": {
+      "default_branch": "master",
+      "sha": "c5642faca9d7f81ddc98e927781445f3f32d1691",
+      "branches": {
+        "master": "c5642faca9d7f81ddc98e927781445f3f32d1691"
+      }
+    },
+    "yamayaml/bossmechanicshelper": {
+      "default_branch": "main",
+      "sha": "11c79323862865d6a110dbb3c40016a1714b84cd",
+      "branches": {
+        "main": "11c79323862865d6a110dbb3c40016a1714b84cd"
+      }
+    },
+    "yamayaml/twtrans": {
+      "default_branch": "main",
+      "sha": "1bcef7f3f2631cf3a13bbf63cd91da14a7b6f06c",
+      "branches": {
+        "main": "1bcef7f3f2631cf3a13bbf63cd91da14a7b6f06c"
+      }
+    },
+    "yangliang2016/turtlehonorspyenhanced": {
+      "default_branch": "master",
+      "sha": "703707d384418f4935db926f12362c03df271e6f",
+      "branches": {
+        "master": "703707d384418f4935db926f12362c03df271e6f"
+      }
+    },
+    "yani9o/lockport": {
+      "default_branch": "main",
+      "sha": "928e898521da69c950a8b1874f9aa905d0ba2c36",
+      "branches": {
+        "main": "928e898521da69c950a8b1874f9aa905d0ba2c36"
+      }
+    },
+    "yani9o/modifiedpowerauras": {
+      "default_branch": "master",
+      "sha": "40725d500c138b73b0638818587280c3962369ed",
+      "branches": {
+        "master": "40725d500c138b73b0638818587280c3962369ed"
+      }
+    },
+    "yani9o/pfui-eliteoverlay": {
+      "default_branch": "master",
+      "sha": "aca68921e9b08139bf48e7762a46e737b9cf0ba0",
+      "branches": {
+        "master": "aca68921e9b08139bf48e7762a46e737b9cf0ba0"
+      }
+    },
+    "yani9o/pfui-turtle": {
+      "default_branch": "master",
+      "sha": "815873bea7c18d039ddeddab241f2484627b2903",
+      "branches": {
+        "master": "815873bea7c18d039ddeddab241f2484627b2903"
+      }
+    },
+    "yani9o/shagudps": {
+      "default_branch": "master",
+      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
+      "branches": {
+        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
+      }
+    },
+    "yani9o/shagutweaks-extras": {
+      "default_branch": "master",
+      "sha": "e5140e52fb974e29d554a0c8867f317d24c5285d",
+      "branches": {
+        "master": "e5140e52fb974e29d554a0c8867f317d24c5285d"
+      }
+    },
+    "yani9o/simpleauras": {
+      "default_branch": "main",
+      "sha": "84f95b068abbf8a8347b502548efaf054ea89a9c",
+      "branches": {
+        "main": "84f95b068abbf8a8347b502548efaf054ea89a9c"
+      }
+    },
+    "yani9o/specialtalent": {
+      "default_branch": "main",
+      "sha": "12266488dc31939b1fa3845808f52a8cce1782ab",
+      "branches": {
+        "main": "12266488dc31939b1fa3845808f52a8cce1782ab"
+      }
+    },
+    "yogo1212/healbot-classic": {
+      "default_branch": "master",
+      "sha": "6c78b6801556e52be829548b1305b2f4a53141e2",
+      "branches": {
+        "master": "6c78b6801556e52be829548b1305b2f4a53141e2"
+      }
+    },
+    "yutsuku/betterbabelfish": {
+      "default_branch": "master",
+      "sha": "5fb2a05e826edd8895505317595bb86843a025c6",
+      "branches": {
+        "master": "5fb2a05e826edd8895505317595bb86843a025c6"
+      }
+    },
+    "yutsuku/betterscoreframe": {
+      "default_branch": "master",
+      "sha": "b28ef19635417ff6e1351fb631ae5e756132f014",
+      "branches": {
+        "master": "b28ef19635417ff6e1351fb631ae5e756132f014"
+      }
+    },
+    "yutsuku/bgreport": {
+      "default_branch": "master",
+      "sha": "11d5db68c06e913ff211deb79fe447b262acb561",
+      "branches": {
+        "master": "11d5db68c06e913ff211deb79fe447b262acb561"
+      }
+    },
+    "yutsuku/ct_unitframes": {
+      "default_branch": "master",
+      "sha": "a4366d256807816703612fb8d3668c72031289de",
+      "branches": {
+        "master": "a4366d256807816703612fb8d3668c72031289de"
+      }
+    },
+    "yutsuku/dpepgp": {
+      "default_branch": "master",
+      "sha": "aadc9f40cc0d567922df8d6a9deebe5decdf8dc4",
+      "branches": {
+        "master": "aadc9f40cc0d567922df8d6a9deebe5decdf8dc4"
+      }
+    },
+    "yutsuku/ez-epgp": {
+      "default_branch": "master",
+      "sha": "db3732bb13605f920bab5d9d28aeea8a18626aff",
+      "branches": {
+        "master": "db3732bb13605f920bab5d9d28aeea8a18626aff"
+      }
+    },
+    "yutsuku/gamepad": {
+      "default_branch": "master",
+      "sha": "3986144052b8aed0a006fe7944b5022cfdba83c7",
+      "branches": {
+        "master": "3986144052b8aed0a006fe7944b5022cfdba83c7"
+      }
+    },
+    "yutsuku/guildsearch": {
+      "default_branch": "master",
+      "sha": "e78dfbae6dc06600590e9d581288514ca5df3242",
+      "branches": {
+        "master": "e78dfbae6dc06600590e9d581288514ca5df3242"
+      }
+    },
+    "yutsuku/hawkenplates": {
+      "default_branch": "master",
+      "sha": "91a53b63ad2139f3903f07a5170172766e8a1ce1",
+      "branches": {
+        "master": "91a53b63ad2139f3903f07a5170172766e8a1ce1"
+      }
+    },
+    "yutsuku/lvbm": {
+      "default_branch": "master",
+      "sha": "84c4311a9c3d6b4af24c94079d6d157705444bf4",
+      "branches": {
+        "master": "84c4311a9c3d6b4af24c94079d6d157705444bf4"
+      }
+    },
+    "yutsuku/mapofscars": {
+      "default_branch": "master",
+      "sha": "57733c84d3a1ce23ef213edcfb052ae77ece7ccf",
+      "branches": {
+        "master": "57733c84d3a1ce23ef213edcfb052ae77ece7ccf"
+      }
+    },
+    "yutsuku/masterlute": {
+      "default_branch": "master",
+      "sha": "94a5ce43e99b952b3dd6b74f910d8efa3e1d2015",
+      "branches": {
+        "master": "94a5ce43e99b952b3dd6b74f910d8efa3e1d2015"
+      }
+    },
+    "yutsuku/seethungroups": {
+      "default_branch": "master",
+      "sha": "1dcbc2c4f5c85bd9058717d452965909c5e8493c",
+      "branches": {
+        "master": "1dcbc2c4f5c85bd9058717d452965909c5e8493c"
+      }
+    },
+    "yutsuku/spamsentry": {
+      "default_branch": "master",
+      "sha": "9651753920f1d8b07448c6e1f41754f87189ac79",
+      "branches": {
+        "master": "9651753920f1d8b07448c6e1f41754f87189ac79"
+      }
+    },
+    "yutsuku/stealtoverlay": {
+      "default_branch": "master",
+      "sha": "5a8405d6083adeca04883461465e0e9128790615",
+      "branches": {
+        "master": "5a8405d6083adeca04883461465e0e9128790615"
+      },
+      "latest_tag": "1.1"
+    },
+    "yutsuku/uitweaks": {
+      "default_branch": "master",
+      "sha": "4c5dbd523e787ef66efa3f482e2adb38a82f367d",
+      "branches": {
+        "master": "4c5dbd523e787ef66efa3f482e2adb38a82f367d"
+      }
+    },
+    "yutsuku/voidbattle": {
+      "default_branch": "master",
+      "sha": "0548bf3bb02a007ca031cce3d6c10d36b775603f",
+      "branches": {
+        "master": "0548bf3bb02a007ca031cce3d6c10d36b775603f"
+      }
+    },
+    "yutsuku/whokicksnow": {
+      "default_branch": "master",
+      "sha": "cdebe08fd20d8057fc3ca787bdd1fe250b6cdb64",
+      "branches": {
+        "master": "cdebe08fd20d8057fc3ca787bdd1fe250b6cdb64"
+      }
+    },
+    "zaazbb/lootatmouse": {
+      "default_branch": "master",
+      "sha": "2c9602b633ff62cb129bec9c24683cff2e3c9208",
+      "branches": {
+        "master": "2c9602b633ff62cb129bec9c24683cff2e3c9208"
+      }
+    },
+    "zaicopx/tourguidevanilla": {
+      "default_branch": "master",
+      "sha": "e61f87fb014326b4004652d0bf6d465d24e932c6",
+      "branches": {
+        "master": "e61f87fb014326b4004652d0bf6d465d24e932c6"
+      }
+    },
+    "zaicopx/zui": {
+      "default_branch": "master",
+      "sha": "b3742ef6a6c6db8fbf35e0cb4c8ca32048ef2b16",
+      "branches": {
+        "master": "b3742ef6a6c6db8fbf35e0cb4c8ca32048ef2b16"
+      }
+    },
+    "zanthor/cursive": {
+      "default_branch": "master",
+      "sha": "7277850f149efd3a9bc343a1e52eb496702dc64f",
+      "branches": {
+        "master": "7277850f149efd3a9bc343a1e52eb496702dc64f"
+      }
+    },
+    "zanthor/libramswap": {
+      "default_branch": "main",
+      "sha": "263c8c28d0a3656bb44b113c005adf2fc7cfb570",
+      "branches": {
+        "main": "263c8c28d0a3656bb44b113c005adf2fc7cfb570"
+      }
+    },
+    "zanthor/lootblare": {
+      "default_branch": "main",
+      "sha": "686e2940186e33ae680e0635a5eda56a493e40ba",
+      "branches": {
+        "main": "686e2940186e33ae680e0635a5eda56a493e40ba"
+      }
+    },
+    "zanthor/og-raidhelper": {
+      "default_branch": "main",
+      "sha": "bfed882bfc7714df6d5086fc60e8a1ced6373278",
+      "branches": {
+        "main": "bfed882bfc7714df6d5086fc60e8a1ced6373278"
+      }
+    },
+    "zanthor/outfitter": {
+      "default_branch": "master",
+      "sha": "07bf4ab4132519585287d0b45b2dbeb4e94152eb",
+      "branches": {
+        "master": "07bf4ab4132519585287d0b45b2dbeb4e94152eb"
+      }
+    },
+    "zanthor/puppeteer": {
+      "default_branch": "main",
+      "sha": "2211d8285e97d1488525088c13ddaed8d8e278b6",
+      "branches": {
+        "main": "2211d8285e97d1488525088c13ddaed8d8e278b6"
+      }
+    },
+    "zanthor/rabuffs": {
+      "default_branch": "master",
+      "sha": "417db2d5581d400a237c5df2a1b97755322a8765",
+      "branches": {
+        "master": "417db2d5581d400a237c5df2a1b97755322a8765"
+      }
+    },
+    "zanthor/simpleauras": {
+      "default_branch": "main",
+      "sha": "7193d563792b20a74e0c2743190d219fa21cfbc2",
+      "branches": {
+        "main": "7193d563792b20a74e0c2743190d219fa21cfbc2"
+      }
+    },
+    "zanthor/tactica": {
+      "default_branch": "main",
+      "sha": "0094aef193ba8c816ff83d38bb77cd6fbbe9b8d7",
+      "branches": {
+        "main": "0094aef193ba8c816ff83d38bb77cd6fbbe9b8d7"
+      }
+    },
+    "zarant/guidecreator": {
+      "default_branch": "master",
+      "sha": "36d92e3e9ec730991e8e65ca11d8310751d6142e",
+      "branches": {
+        "master": "36d92e3e9ec730991e8e65ca11d8310751d6142e"
+      }
+    },
+    "zebouski/adf": {
+      "default_branch": "master",
+      "sha": "f1da671b1c05ef4f94d0ef4d9cf4988006629044",
+      "branches": {
+        "master": "f1da671b1c05ef4f94d0ef4d9cf4988006629044"
+      }
+    },
+    "zebouski/mopgeartooltips": {
+      "default_branch": "master",
+      "sha": "fc9000fab3f5576db2740169652caaa79674fe1f",
+      "branches": {
+        "master": "fc9000fab3f5576db2740169652caaa79674fe1f"
+      }
+    },
+    "zedorff/lockassignment": {
+      "default_branch": "main",
+      "sha": "68b448250b826b7791dfc020d469128c77ea03d8",
+      "branches": {
+        "main": "68b448250b826b7791dfc020d469128c77ea03d8"
+      }
+    },
+    "zedorff/messagebox": {
+      "default_branch": "main",
+      "sha": "0c63f1d624782163349a1100e46bc604f4117a32",
+      "branches": {
+        "main": "0c63f1d624782163349a1100e46bc604f4117a32"
+      }
+    },
+    "zedris/pfui-addonskinner": {
+      "default_branch": "main",
+      "sha": "86e8962b94af6bc057b3c697553ec67577569c4c",
+      "branches": {
+        "main": "86e8962b94af6bc057b3c697553ec67577569c4c"
+      }
+    },
+    "zedris/zui": {
+      "default_branch": "master",
+      "sha": "d984370471ab64ede453ea9549fa3d64099dfd09",
+      "branches": {
+        "master": "d984370471ab64ede453ea9549fa3d64099dfd09"
+      }
+    },
+    "zensociety/bossdeathtimer": {
+      "default_branch": "main",
+      "sha": "bb74a18ca2ccfa4afe9a6ec3617cea937a3cdc7a",
+      "branches": {
+        "main": "bb74a18ca2ccfa4afe9a6ec3617cea937a3cdc7a"
+      },
+      "latest_tag": "v0.01"
+    },
+    "zensociety/lager": {
+      "default_branch": "main",
+      "sha": "19beb37b087acf8f92559d9485ff6902ac9b2803",
+      "branches": {
+        "main": "19beb37b087acf8f92559d9485ff6902ac9b2803"
+      }
+    },
+    "zensociety/roundrobinhood": {
+      "default_branch": "main",
+      "sha": "df93c2b0966e07b25e5daa3d671c7d9246a719c5",
+      "branches": {
+        "main": "df93c2b0966e07b25e5daa3d671c7d9246a719c5"
+      },
+      "latest_tag": "v0.02"
+    },
+    "zensociety/threatlogger": {
+      "default_branch": "main",
+      "sha": "e0e7f651a4a2b6e07ccd5bfd2d592f62bc33f1bf",
+      "branches": {
+        "main": "e0e7f651a4a2b6e07ccd5bfd2d592f62bc33f1bf"
+      }
+    },
+    "zensociety/whisperprofile": {
+      "default_branch": "main",
+      "sha": "da7f2437b43fa2693dc2d4b6aacc789c7fafc372",
+      "branches": {
+        "main": "da7f2437b43fa2693dc2d4b6aacc789c7fafc372"
+      }
+    },
+    "zepheo/rabuffs": {
+      "default_branch": "master",
+      "sha": "95eed1f4823f34ff7a85fa4bccaf688fb2385045",
+      "branches": {
+        "master": "95eed1f4823f34ff7a85fa4bccaf688fb2385045"
+      }
+    },
+    "zerf/auctionlink": {
+      "default_branch": "master",
+      "sha": "a4f2092848244ebef4ee2f57c3ca32775af934a0",
+      "branches": {
+        "master": "a4f2092848244ebef4ee2f57c3ca32775af934a0"
+      },
+      "latest_tag": "v2.0.1"
+    },
+    "zerf/blacklist": {
+      "default_branch": "master",
+      "sha": "9a066c287d0f923a61beb601f2bec3e8eb9f648c",
+      "branches": {
+        "master": "9a066c287d0f923a61beb601f2bec3e8eb9f648c"
+      }
+    },
+    "zerf/renewspam": {
+      "default_branch": "master",
+      "sha": "f819bb16eb9d4bad5f4669949de8b71059b2c1ae",
+      "branches": {
+        "master": "f819bb16eb9d4bad5f4669949de8b71059b2c1ae"
+      }
+    },
+    "zerf/sw_stats-vanilla": {
+      "default_branch": "master",
+      "sha": "c000f0ddf31f5bfaa1511c5b15af7c56f24beb4f",
+      "branches": {
+        "master": "c000f0ddf31f5bfaa1511c5b15af7c56f24beb4f"
+      }
+    },
+    "zerger3/vanilla-wow-addons": {
+      "default_branch": "master",
+      "sha": "8f6feb94325135c090a891e5d81f0f760c4371e8",
+      "branches": {
+        "master": "8f6feb94325135c090a891e5d81f0f760c4371e8"
+      }
+    },
+    "zetone/enemyframes": {
+      "default_branch": "master",
+      "sha": "7a6591617b038e52153ee0eb5dba73c74978b887",
+      "branches": {
+        "master": "7a6591617b038e52153ee0eb5dba73c74978b887"
+      }
+    },
+    "zetone/reagentcounter": {
+      "default_branch": "master",
+      "sha": "a634c6e8e0091df2444d6b78b9c4e827d9766c95",
+      "branches": {
+        "master": "a634c6e8e0091df2444d6b78b9c4e827d9766c95"
+      }
+    },
+    "zhaoyu89730105/lazyscript": {
+      "default_branch": "master",
+      "sha": "97e277bd060924da418becb945e321b54065ad4e",
+      "branches": {
+        "master": "97e277bd060924da418becb945e321b54065ad4e"
+      }
+    },
+    "zhinj/rabuffs": {
+      "default_branch": "master",
+      "sha": "9a5597f427c1e2a9872c84b58b79a8c0beb9c551",
+      "branches": {
+        "master": "9a5597f427c1e2a9872c84b58b79a8c0beb9c551"
+      }
+    },
+    "ziims/puppeteer": {
+      "default_branch": "main",
+      "sha": "96396fdefee7fe1451b5899c900359cbf3562f6a",
+      "branches": {
+        "main": "96396fdefee7fe1451b5899c900359cbf3562f6a"
+      }
+    },
+    "ziims/targetframebuff": {
+      "default_branch": "master",
+      "sha": "9ad8acbe28661b72e60185399ee79f67835fa72d",
+      "branches": {
+        "master": "9ad8acbe28661b72e60185399ee79f67835fa72d"
+      }
+    },
+    "ziin/shagutweaks": {
+      "default_branch": "master",
+      "sha": "61122caa8cc747c658d601258310f0433cbb071b",
+      "branches": {
+        "master": "61122caa8cc747c658d601258310f0433cbb071b"
+      }
+    },
+    "zimengle/lazyscript": {
+      "default_branch": "master",
+      "sha": "bf53d9c73d73963c99f944f128235ec285a639e4",
+      "branches": {
+        "master": "bf53d9c73d73963c99f944f128235ec285a639e4"
+      }
+    },
+    "zirtox1992/combat": {
+      "default_branch": "main",
+      "sha": "d118c5b259fc925e086c00f5f4db5a77273e6894",
+      "branches": {
+        "main": "d118c5b259fc925e086c00f5f4db5a77273e6894"
+      }
+    },
+    "zirtox1992/hideerrorframe": {
+      "default_branch": "main",
+      "sha": "c65a36f01ab69c35779313f1b91ef8432c972fc6",
+      "branches": {
+        "main": "c65a36f01ab69c35779313f1b91ef8432c972fc6"
+      }
+    },
+    "zirtox1992/modui": {
+      "default_branch": "main",
+      "sha": "380bca707ebb05f06f580924ea281a36b553dfd2",
+      "branches": {
+        "main": "380bca707ebb05f06f580924ea281a36b553dfd2"
+      }
+    },
+    "zirtox1992/namechangescript": {
+      "default_branch": "main",
+      "sha": "6f9915267b6822b4bf7278e9435d9d8a929548a6",
+      "branches": {
+        "main": "6f9915267b6822b4bf7278e9435d9d8a929548a6"
+      }
+    },
+    "zirtox1992/showchests": {
+      "default_branch": "main",
+      "sha": "844065c7334d4eb97d78167dab6db2729f214e7d",
+      "branches": {
+        "main": "844065c7334d4eb97d78167dab6db2729f214e7d"
+      }
+    },
+    "ziyassa/lazyspell": {
+      "default_branch": "master",
+      "sha": "1af9fc538bf010116290b3399ca67b9b2b95043f",
+      "branches": {
+        "master": "1af9fc538bf010116290b3399ca67b9b2b95043f"
+      }
+    },
+    "zmarotrix/altoholic_vanilla": {
+      "default_branch": "master",
+      "sha": "a72a7f276882e619bda67793840479446b1382e5",
+      "branches": {
+        "master": "a72a7f276882e619bda67793840479446b1382e5"
+      }
+    },
+    "zmarotrix/battlemusic": {
+      "default_branch": "main",
+      "sha": "82e9e93785e34741387da6aa4ae564c48a310ac2",
+      "branches": {
+        "main": "82e9e93785e34741387da6aa4ae564c48a310ac2"
+      }
+    },
+    "zmarotrix/blacklist": {
+      "default_branch": "master",
+      "sha": "1bcaa2cea91f82170fb1f9a308c753d237ed00c1",
+      "branches": {
+        "master": "1bcaa2cea91f82170fb1f9a308c753d237ed00c1"
+      }
+    },
+    "zmarotrix/druidmanabar": {
+      "default_branch": "master",
+      "sha": "58ad3aa7fe09da1a3959cdfba6abb85afebbcfbc",
+      "branches": {
+        "master": "58ad3aa7fe09da1a3959cdfba6abb85afebbcfbc"
+      }
+    },
+    "zmarotrix/smarthealer": {
+      "default_branch": "master",
+      "sha": "e97889a080370ee5a7d8988965ff4b508e4301e1",
+      "branches": {
+        "master": "e97889a080370ee5a7d8988965ff4b508e4301e1"
+      }
+    },
+    "zomgits/hunterswissknife": {
+      "default_branch": "master",
+      "sha": "f9713c88020a4fe6e24600e1458a82897710e108",
+      "branches": {
+        "master": "f9713c88020a4fe6e24600e1458a82897710e108"
+      },
+      "latest_tag": "v1.1"
+    },
+    "zygmuntbuszyk/z-z-guide-creator": {
+      "default_branch": "master",
+      "sha": "c047acb662fd6a65cedd01062ece1fd0fcfc0a61",
+      "branches": {
+        "master": "c047acb662fd6a65cedd01062ece1fd0fcfc0a61"
+      }
+    },
+    "zythdr/pageturner": {
+      "default_branch": "main",
+      "sha": "0e51751babef4abf5a66397c66620c7c73420738",
+      "branches": {
+        "main": "0e51751babef4abf5a66397c66620c7c73420738"
+      }
+    },
+    "zythdr/vpeddler": {
+      "default_branch": "main",
+      "sha": "08a8916743e3ee39c6bde5488d0f187521e1e60e",
+      "branches": {
+        "main": "08a8916743e3ee39c6bde5488d0f187521e1e60e"
+      },
+      "latest_tag": "v1.3"
+    },
+    "zyyysxd/shagudps": {
+      "default_branch": "master",
+      "sha": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312",
+      "branches": {
+        "master": "79c25e60f9ab3f314d69bec3d3edcbf965b7c312"
+      }
     }
   }
 }

--- a/ichalaunch/data/addon_tips.json.sig
+++ b/ichalaunch/data/addon_tips.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "wtedTUhGRs9Vqih/pBNqu++IbPsppoX8qBQiKy91C7JChQXQ9tc4dmGLeB4RX964d83WsNkGsajarRM/RWhdDg==",
+  "sig": "MT+wWKO3PQaAZhtsNjrNtrk5PLxwGX7mg3E0RdyHB5b95V+ESBTZ2GFAr/tlEmKn4Roui31d417wEFhxtM5oAw==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "cfdbe2d8c3ca42d26af24227e049195542d9fcfbf8483b324ab5a7fa92664ba0"
+    "sha256": "b429a35b9b7833e449a94e123f6b9b6bdca06e849d227f8f77f77defca004a68"
   },
-  "attestation_sig": "vp7Jd5Ul8RuVj0muCtVhx+yw1Pcj2ZcQWz+KskQSyM4Jx2/pjVv92MfqqqPJ7KigrGMwdQNs00Xp8V/GH1BFBQ=="
+  "attestation_sig": "WHjUY4udFpyWgUAVWV3Qbghahva3bc0HLr7E4pWxTtyJ3dlzFhYckCCfhbgYBdWtmo8zastDhtbeYGerBS3YDA=="
 }

--- a/ichalaunch/data/addons.json
+++ b/ichalaunch/data/addons.json
@@ -45,6 +45,10 @@
       {
         "label": "IndieMiao",
         "repo": "https://github.com/IndieMiao/Bagshui"
+      },
+      {
+        "label": "HeartNotSmart",
+        "repo": "https://github.com/HeartNotSmart/Bagshui"
       }
     ],
     "category": "Bags",
@@ -84,8 +88,8 @@
     ],
     "release_downloads_repo": "Road-block/CooldownTimers",
     "release_downloads_state": "ok",
-    "release_downloads": 657,
-    "release_downloads_at": "2026-09-03T22:36:20Z"
+    "release_downloads": 658,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "Destroy Cursor Item",
@@ -681,8 +685,7 @@
     "release_downloads_repo": "1petru/Akkio_Consume_Helper",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
+    "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
     "name": "AutoBuff",
@@ -717,8 +720,7 @@
     "release_downloads_repo": "zmarotrix/BattleMusic",
     "release_downloads_state": "ok",
     "release_downloads": 1400,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
+    "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
     "name": "BattleScribe",
@@ -891,15 +893,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "Chronometer",
-    "repo": "",
-    "category": "Combat",
-    "description": "tracks spell effects (HoTs, DoTs, buffs, debuffs, etc.) that you cast",
-    "source": "turtle_wiki",
-    "folder": "Chronometer",
-    "installable": false
-  },
-  {
     "name": "Combat",
     "repo": "https://github.com/zirtox1992/Combat",
     "category": "Combat",
@@ -1007,41 +1000,19 @@
   },
   {
     "name": "DebuffTimers",
-    "repo": "https://github.com/Voidmenull/DebuffTimers",
+    "repo": "https://github.com/DBFBlackbull/DebuffTimers",
     "category": "Combat",
     "description": "Timer Overlays for enemy buffs and debuffs [Img1] [Img2]",
     "source": "turtle_wiki",
     "folder": "DebuffTimers",
     "forks": [
       {
-        "label": "DBFBlackbull",
-        "repo": "https://github.com/DBFBlackbull/DebuffTimers"
-      },
-      {
-        "label": "laytya",
-        "repo": "https://github.com/laytya/DebuffTimers"
+        "label": "Voidmenull",
+        "repo": "https://github.com/Voidmenull/DebuffTimers"
       }
     ],
     "release_downloads_repo": "Voidmenull/DebuffTimers",
     "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "DispelBorder",
-    "repo": "https://github.com/wardz/DispelBorder",
-    "category": "Combat",
-    "description": "Shows highlight border around enemy magic buffs [Img1]",
-    "source": "turtle_wiki",
-    "folder": "DispelBorder",
-    "forks": [
-      {
-        "label": "Macumbafeh",
-        "repo": "https://github.com/Macumbafeh/DispelBorder"
-      }
-    ],
-    "release_downloads_repo": "wardz/DispelBorder",
-    "release_downloads_state": "ok",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
@@ -1055,57 +1026,20 @@
     "forks": [
       {
         "label": "deceius",
-        "repo": "https://github.com/deceius/DoiteAuras"
-      },
-      {
-        "label": "pepopo978",
-        "repo": "https://github.com/pepopo978/DoiteAuras"
-      },
-      {
-        "label": "ayitsyaboi",
-        "repo": "https://github.com/ayitsyaboi/DoiteAuras"
-      },
-      {
-        "label": "bretharte89",
-        "repo": "https://github.com/bretharte89/DoiteAuras"
-      },
-      {
-        "label": "koraykarakus",
-        "repo": "https://github.com/koraykarakus/DoiteAuras"
-      },
-      {
-        "label": "Zedris",
-        "repo": "https://github.com/Zedris/DoiteAuras"
-      },
-      {
-        "label": "mentalxgit",
-        "repo": "https://github.com/mentalxgit/DoiteAuras"
-      },
-      {
-        "label": "RavenOfSeven",
-        "repo": "https://github.com/RavenOfSeven/DoiteAuras"
-      },
-      {
-        "label": "Hippoom",
-        "repo": "https://github.com/Hippoom/DoiteAuras"
-      },
-      {
-        "label": "logicsec",
-        "repo": "https://github.com/logicsec/DoiteAuras"
-      },
-      {
-        "label": "isfir",
-        "repo": "https://github.com/isfir/DoiteAuras"
-      },
-      {
-        "label": "terradcm-code",
-        "repo": "https://github.com/terradcm-code/DoiteAuras"
+        "repo": "https://github.com/deceius/DoiteAuras",
+        "requires": [
+          "nampower"
+        ]
       }
     ],
     "release_downloads_repo": "Player-Doite/DoiteAuras",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "nampower"
+    ],
+    "recommended": true
   },
   {
     "name": "DPSMate",
@@ -1431,15 +1365,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "PallyPower-Turtle",
-    "repo": "",
-    "category": "Combat",
-    "description": "easy to use interface that allows you set your own blessings and automatically check for missing buffs",
-    "source": "turtle_wiki",
-    "folder": "PallyPower-Turtle",
-    "installable": false
-  },
-  {
     "name": "pfUI-lazyres",
     "repo": "https://github.com/liiora/pfUI-lazyres",
     "category": "Combat",
@@ -1512,15 +1437,6 @@
     "release_downloads_state": "ok",
     "release_downloads": 46,
     "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "PowerAuras",
-    "repo": "",
-    "category": "Combat",
-    "description": "This Mod was created to have a better visibility when you gain buffs, debuffs and many more",
-    "source": "turtle_wiki",
-    "folder": "PowerAuras",
-    "installable": false
   },
   {
     "name": "QuickHeal Turtle",
@@ -1847,15 +1763,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "VCB",
-    "repo": "",
-    "category": "Combat",
-    "description": "a highly customizable buff frame",
-    "source": "turtle_wiki",
-    "folder": "VCB",
-    "installable": false
-  },
-  {
     "name": "VGAntiCooldown",
     "repo": "https://github.com/firenahzku/VanguardAntiCooldown",
     "category": "Combat",
@@ -1884,15 +1791,6 @@
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "VitalWatch",
-    "repo": "",
-    "category": "Combat",
-    "description": "Alerts you to your own low or critical health or mana, or to a party member or pet's health, using any combination of a centered large font frame, emotes, sounds, and party message.",
-    "source": "turtle_wiki",
-    "folder": "vitalwatch",
-    "installable": false
   },
   {
     "name": "WarriorCombatManager",
@@ -1947,13 +1845,12 @@
     "release_downloads_repo": "Kingfisher387/AntiAfk",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
+    "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
     "name": "Antispam",
     "repo": "https://github.com/shagu/antispam",
-    "category": "Economy",
+    "category": "Social",
     "description": "Shagu addon to filter out goldsellers and Moo spammers on Turtle WoW",
     "source": "turtle_wiki",
     "turtle_custom": true,
@@ -2002,7 +1899,10 @@
     "release_downloads_state": "ok",
     "release_downloads": 18,
     "release_downloads_at": "2026-09-03T12:51:29Z",
-    "recommended": true
+    "recommended": true,
+    "requires": [
+      "classicapi"
+    ]
   },
   {
     "name": "AuctionHelper",
@@ -2049,8 +1949,8 @@
     "folder": "AutoProfit",
     "release_downloads_repo": "Road-block/AutoProfit",
     "release_downloads_state": "ok",
-    "release_downloads": 1956,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 1957,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "Aux",
@@ -2194,18 +2094,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "DiivSkins",
-    "repo": "https://github.com/McPewPew/DiivSkins",
-    "category": "Economy",
-    "description": "will \"paint\" auxiliary images onto the two dimensional pane of your user interface https://camo.githubusercontent.com/60755ac7bfafaed6595c5aba294a53bc8c58e217/68747470733a2f2f692e696d6775722e636f6d2f363936577745332e6a706",
-    "source": "turtle_wiki",
-    "folder": "DiivSkins",
-    "release_downloads_repo": "McPewPew/DiivSkins",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
     "name": "DKPAuctionBidder",
     "repo": "https://github.com/quakerzz/DKPAuctionBidder",
     "category": "Economy",
@@ -2286,15 +2174,6 @@
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "Postal Returned",
-    "repo": "",
-    "category": "Economy",
-    "description": "Improved version of Postal that Includes better mail return functionality, logging of attachments and money",
-    "source": "turtle_wiki",
-    "folder": "PostalReturned",
-    "installable": false
   },
   {
     "name": "RosterFilter",
@@ -2550,16 +2429,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "WoWAuctions",
-    "repo": "",
-    "category": "Economy",
-    "description": "Search the Turtle WoW Auction House from web (not actually an addon, just a useful resource)",
-    "source": "turtle_wiki",
-    "turtle_custom": true,
-    "folder": "www.wowauctions.net",
-    "installable": false
-  },
-  {
     "name": "WRUGS",
     "repo": "https://github.com/Daribon/WRUGS",
     "category": "Economy",
@@ -2572,21 +2441,9 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "!Toggle",
-    "repo": "https://github.com/shirsig/notoggle",
-    "category": "General",
-    "description": "Disables toggling behavior of Attack, Auto Shot and Shoot",
-    "source": "turtle_wiki",
-    "folder": "notoggle",
-    "release_downloads_repo": "shirsig/notoggle",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
     "name": "4HMHelper",
     "repo": "https://github.com/NiclasEriksen/4HMHelper",
-    "category": "General",
+    "category": "Raiding",
     "description": "Shows if you are in the safe zone, stacks you have and Zeliek chain range (/4hm).",
     "source": "turtle_wiki",
     "folder": "4HMHelper",
@@ -2598,7 +2455,7 @@
   {
     "name": "_AntInvite",
     "repo": "https://github.com/Kiiruaa/_AntInvite",
-    "category": "General",
+    "category": "Social",
     "description": "block invitation of people under level 15 [Img1]",
     "source": "turtle_wiki",
     "folder": "_AntInvite",
@@ -2608,29 +2465,9 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "aBindings",
-    "repo": "https://gitlab.com/aead/aBindings",
-    "category": "General",
-    "description": "Direct macrotext-to-key bindings",
-    "source": "turtle_wiki",
-    "folder": "aBindings"
-  },
-  {
-    "name": "Abraxas",
-    "repo": "https://github.com/xorann/Abraxas",
-    "category": "General",
-    "description": "Warlock Helper [Img1]",
-    "source": "turtle_wiki",
-    "folder": "Abraxas",
-    "release_downloads_repo": "xorann/Abraxas",
-    "release_downloads_state": "ok",
-    "release_downloads": 207,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
     "name": "Accountant",
     "repo": "https://github.com/The-Kludge-Bureau/Accountant",
-    "category": "General",
+    "category": "Economy",
     "description": "tracks your incoming / outgoing cash [Img1] https://github.com/terdong/Accountant Alt",
     "source": "turtle_wiki",
     "folder": "Accountant",
@@ -2646,29 +2483,9 @@
     "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
-    "name": "ActionButtonUtils",
-    "repo": "https://github.com/Numielle/ActionButtonUtils",
-    "category": "General",
-    "description": "Retail-like glowing for WoW 1.12 ActionButtons",
-    "source": "turtle_wiki",
-    "folder": "ActionButtonUtils",
-    "release_downloads_repo": "Numielle/ActionButtonUtils",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "ActionMirroringFrame",
-    "repo": "https://gitlab.com/woblight/actionmirroringframe",
-    "category": "General",
-    "description": "Display a frame showing used actions [Img1]",
-    "source": "turtle_wiki",
-    "folder": "actionmirroringframe"
-  },
-  {
     "name": "Aero",
     "repo": "https://github.com/gashole/Aero",
-    "category": "General",
+    "category": "UI",
     "description": "Adds animations to frames [Img1]",
     "source": "turtle_wiki",
     "folder": "Aero",
@@ -2698,13 +2515,12 @@
     "release_downloads_repo": "gbl/Altoholic_Vanilla",
     "release_downloads_state": "ok",
     "release_downloads": 0,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
+    "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
     "name": "AnnounceKick",
     "repo": "https://github.com/EinBaum/AnnounceKick",
-    "category": "General",
+    "category": "Combat",
     "description": "Very simple rogue addon that announces \"Kick\" in say chat",
     "source": "turtle_wiki",
     "folder": "AnnounceKick",
@@ -2716,7 +2532,7 @@
   {
     "name": "AntiSpamStopCast",
     "repo": "https://github.com/thepparker/AntiSpamStopCast",
-    "category": "General",
+    "category": "Combat",
     "description": "addon to prevent cancellation of fresh spell casts when mashing the button",
     "source": "turtle_wiki",
     "folder": "AntiSpamStopCast",
@@ -2728,7 +2544,7 @@
   {
     "name": "ArcaneSurgeWarning",
     "repo": "https://github.com/AllinGaming/ArcaneSurgeWarning",
-    "category": "General",
+    "category": "UI",
     "description": "provides a visual tracker for the Arcane Surge proc",
     "source": "turtle_wiki",
     "folder": "ArcaneSurgeWarning",
@@ -2754,8 +2570,7 @@
     "release_downloads_repo": "TheRealFayz/Arcanum",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
+    "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
     "name": "ArchiTotem",
@@ -2778,7 +2593,7 @@
   {
     "name": "Attack",
     "repo": "https://github.com/shirsig/attack",
-    "category": "General",
+    "category": "Combat",
     "description": "Enable attack with /attack",
     "source": "turtle_wiki",
     "folder": "attack",
@@ -2808,13 +2623,12 @@
     "release_downloads_repo": "Siventt/AttackBar-TWoW",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
-    "recommended": true
+    "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
     "name": "AuldLangSyne",
     "repo": "https://github.com/refaim/AuldLangSyne",
-    "category": "General",
+    "category": "Social",
     "description": "combines the functions of CT_PlayerNotes and FriendsFacts",
     "source": "turtle_wiki",
     "folder": "AuldLangSyne",
@@ -2831,8 +2645,7 @@
     "release_downloads_repo": "Road-block/AuldLangSyne",
     "release_downloads_state": "ok",
     "release_downloads": 304,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
-    "recommended": true
+    "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
     "name": "AutoDecline",
@@ -3119,7 +2932,7 @@
   {
     "name": "BGFlag",
     "repo": "https://github.com/Einherjarn/BGFlag",
-    "category": "General",
+    "category": "PvP",
     "description": "Small text display of the status of the Alliance and Horde flags",
     "source": "turtle_wiki",
     "folder": "BGFlag",
@@ -3131,7 +2944,7 @@
   {
     "name": "BigBrother",
     "repo": "https://github.com/jejkas/BigBrother",
-    "category": "General",
+    "category": "Social",
     "description": "addon to spy on your guild mates with! [Img1]",
     "source": "turtle_wiki",
     "folder": "BigBrother",
@@ -3155,7 +2968,7 @@
   {
     "name": "BitesCookBook",
     "repo": "https://github.com/chrisbigart/BitesCookBook",
-    "category": "General",
+    "category": "Professions",
     "description": "(Better Ingredients Tracking for Efficient Seasoning) shows you which cooking ingredients can be used to cook meals with.",
     "source": "turtle_wiki",
     "folder": "BitesCookBook",
@@ -3168,13 +2981,12 @@
     "release_downloads_repo": "DBFBlackbull/BitesCookBook",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
-    "recommended": true
+    "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
     "name": "BlackList",
     "repo": "https://github.com/matwebmasta/BlackList",
-    "category": "General",
+    "category": "Social",
     "description": "is like Ignore, except unlimited",
     "source": "turtle_wiki",
     "folder": "BlackList",
@@ -3195,8 +3007,7 @@
     "release_downloads_repo": "Zerf/BlackList",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
-    "recommended": true
+    "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
     "name": "Blockvalue",
@@ -3214,7 +3025,7 @@
   {
     "name": "Bloodrage",
     "repo": "https://github.com/muellerj/Bloodrage",
-    "category": "General",
+    "category": "Combat",
     "description": "Provide a single button to put you in the \"default\" stance and activate Bloodrage",
     "source": "turtle_wiki",
     "folder": "Bloodrage",
@@ -3238,7 +3049,7 @@
   {
     "name": "BossDeathTimer",
     "repo": "https://github.com/ZenSociety/BossDeathTimer",
-    "category": "General",
+    "category": "Raiding",
     "description": "A simple countdown timer that displays how long the boss will die.",
     "source": "turtle_wiki",
     "folder": "BossDeathTimer",
@@ -3285,7 +3096,7 @@
   {
     "name": "BSAlert TW",
     "repo": "https://github.com/FSuhas/BSAlert-TW",
-    "category": "General",
+    "category": "Combat",
     "description": "Notifies you when BattleShout is not up",
     "source": "turtle_wiki",
     "folder": "BSAlert-TW",
@@ -3543,8 +3354,8 @@
     ],
     "release_downloads_repo": "celguar/CharacterProfiler",
     "release_downloads_state": "ok",
-    "release_downloads": 134,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 135,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "ChatBar",
@@ -3633,8 +3444,8 @@
     ],
     "release_downloads_repo": "ScottHamper/chatsuey",
     "release_downloads_state": "ok",
-    "release_downloads": 5093,
-    "release_downloads_at": "2026-09-03T22:36:20Z"
+    "release_downloads": 5097,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "ChatTimestamps",
@@ -3699,8 +3510,8 @@
     "folder": "ClassicSnowFall",
     "release_downloads_repo": "Road-block/ClassicSnowFall",
     "release_downloads_state": "ok",
-    "release_downloads": 567,
-    "release_downloads_at": "2026-09-03T19:26:40Z"
+    "release_downloads": 568,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "ClassPortraits",
@@ -3829,8 +3640,7 @@
     "release_downloads_repo": "MarcelineVQ/Clique",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
+    "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
     "name": "CLog",
@@ -4134,7 +3944,8 @@
     "release_downloads_repo": "DeterminedPanda/DifficultBulletinBoard",
     "release_downloads_state": "ok",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "recommended": true
   },
   {
     "name": "DisableEscape",
@@ -4149,27 +3960,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "DiscordActionBars",
-    "repo": "",
-    "category": "General",
-    "description": "Spreads your base 120 action buttons across 10 configurable bars",
-    "source": "turtle_wiki",
-    "folder": "DiscordActionBars",
-    "installable": false
-  },
-  {
-    "name": "Distance",
-    "repo": "https://github.com/Linae-Kronos/Distance",
-    "category": "General",
-    "description": "shows how far your target is away, based on the spell ranges your class has [Img1]",
-    "source": "turtle_wiki",
-    "folder": "Distance",
-    "release_downloads_repo": "Linae-Kronos/Distance",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
     "name": "DistanceDisplay",
     "repo": "https://github.com/uc9089/DistanceDisplay",
     "category": "General",
@@ -4179,17 +3969,19 @@
     "forks": [
       {
         "label": "Utensile",
-        "repo": "https://github.com/Utensile/DistanceDisplay"
-      },
-      {
-        "label": "ErikNikolajsen",
-        "repo": "https://github.com/ErikNikolajsen/DistanceDisplay"
+        "repo": "https://github.com/Utensile/DistanceDisplay",
+        "requires": [
+          "unitxp"
+        ]
       }
     ],
     "release_downloads_repo": "uc9089/DistanceDisplay",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "unitxp"
+    ]
   },
   {
     "name": "DKPList",
@@ -4199,18 +3991,6 @@
     "source": "turtle_wiki",
     "folder": "DKPList",
     "release_downloads_repo": "quakerzz/DKPList",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "Doomed",
-    "repo": "https://github.com/EinBaum/doomed",
-    "category": "General",
-    "description": "(DOOM UI) is for fans of the classic shooter Doom [Img1]",
-    "source": "turtle_wiki",
-    "folder": "doomed",
-    "release_downloads_repo": "EinBaum/doomed",
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
@@ -4336,8 +4116,8 @@
     ],
     "release_downloads_repo": "Medeah/Egnar",
     "release_downloads_state": "ok",
-    "release_downloads": 483,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 485,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "EliteWarriorTTD",
@@ -4438,7 +4218,7 @@
   {
     "name": "ES",
     "repo": "https://github.com/Smirgeli/ES",
-    "category": "General",
+    "category": "Combat",
     "description": "Plays the loud glang sound when using execute familiar from WotLK expansion",
     "source": "turtle_wiki",
     "folder": "ES",
@@ -4449,15 +4229,15 @@
   },
   {
     "name": "ETL",
-    "repo": "https://github.com/shirsig/ETL",
+    "repo": "https://github.com/rmarc29/ETL_minute",
     "category": "General",
     "description": "Exp Per hour/time til level addon [Img1]",
     "source": "turtle_wiki",
     "folder": "ETL",
     "forks": [
       {
-        "label": "rmarc29/ETL_minute",
-        "repo": "https://github.com/rmarc29/ETL_minute"
+        "label": "shirsig",
+        "repo": "https://github.com/shirsig/ETL"
       }
     ],
     "release_downloads_repo": "shirsig/ETL",
@@ -4608,15 +4388,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "FishingBuddy",
-    "repo": "",
-    "category": "General",
-    "description": "Help with fishing related tasks",
-    "source": "turtle_wiki",
-    "folder": "FishingBuddy",
-    "installable": false
-  },
-  {
     "name": "FishingVolume",
     "repo": "https://github.com/Deffar/FishingVolume",
     "category": "General",
@@ -4659,18 +4430,12 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "Fizzwidget Hunters Helper",
+    "name": "GFW HuntersHelper",
     "repo": "https://github.com/McPewPew/GFW_HuntersHelper",
     "category": "General",
-    "description": "Tooltips and info for learning pet spells from taming.",
+    "description": "Helps you find tameable beasts to learn pet skills from",
     "source": "turtle_wiki",
     "folder": "GFW_HuntersHelper",
-    "forks": [
-      {
-        "label": "ConquistadoresTWoW",
-        "repo": "https://github.com/ConquistadoresTWoW/GFW_HuntersHelper"
-      }
-    ],
     "release_downloads_repo": "McPewPew/GFW_HuntersHelper",
     "release_downloads_state": "none",
     "release_downloads": 0,
@@ -4791,15 +4556,6 @@
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "FuBar",
-    "repo": "",
-    "category": "General",
-    "description": "A panel that modules can plug into",
-    "source": "turtle_wiki",
-    "folder": "FuBar",
-    "installable": false
   },
   {
     "name": "FuBar Population",
@@ -4934,20 +4690,8 @@
     "folder": "wow-vanilla-gearmenu",
     "release_downloads_repo": "RagedUnicorn/wow-vanilla-gearmenu",
     "release_downloads_state": "ok",
-    "release_downloads": 2671,
-    "release_downloads_at": "2026-09-03T22:36:20Z"
-  },
-  {
-    "name": "GFW HuntersHelper",
-    "repo": "https://github.com/McPewPew/GFW_HuntersHelper",
-    "category": "General",
-    "description": "Helps you find tameable beasts to learn pet skills from",
-    "source": "turtle_wiki",
-    "folder": "GFW_HuntersHelper",
-    "release_downloads_repo": "McPewPew/GFW_HuntersHelper",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 2675,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "Ghost",
@@ -5360,15 +5104,6 @@
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "ImprovedErrorFrame",
-    "repo": "",
-    "category": "General",
-    "description": "Display errors in scroll-able/selecting frame",
-    "source": "turtle_wiki",
-    "folder": "ImprovedErrorFrame",
-    "installable": false
   },
   {
     "name": "ImprovedIgnore",
@@ -5852,6 +5587,10 @@
       {
         "label": "nanatot",
         "repo": "https://github.com/nanatot/LockPort"
+      },
+      {
+        "label": "Phaestas323",
+        "repo": "https://github.com/Phaestas323/LockPort"
       }
     ],
     "release_downloads_repo": "seacrabsam/LockPort",
@@ -6459,27 +6198,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "NotGrid",
-    "repo": "",
-    "category": "General",
-    "description": "It's pretty much grid and it works",
-    "source": "turtle_wiki",
-    "folder": "NotGrid",
-    "installable": false
-  },
-  {
-    "name": "NoToggle",
-    "repo": "https://github.com/shirsig/notoggle",
-    "category": "General",
-    "description": "Disables toggling behavior of Attack, Auto Shot and Shoot",
-    "source": "turtle_wiki",
-    "folder": "notoggle",
-    "release_downloads_repo": "shirsig/notoggle",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
     "name": "NugComboBar",
     "repo": "https://github.com/rgd87/NugComboBar",
     "category": "General",
@@ -6502,8 +6220,8 @@
     ],
     "release_downloads_repo": "rgd87/NugComboBar",
     "release_downloads_state": "ok",
-    "release_downloads": 110,
-    "release_downloads_at": "2026-09-03T12:51:29Z"
+    "release_downloads": 114,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "NugEnergy",
@@ -6810,7 +6528,7 @@
   {
     "name": "pfUI-fonts",
     "repo": "https://github.com/Gescht/pfUI-fonts",
-    "category": "General",
+    "category": "UI",
     "description": "A font package for pfUI, providing additional fonts from the google font project. [Img1]",
     "source": "turtle_wiki",
     "folder": "pfUI-fonts",
@@ -6829,7 +6547,7 @@
   {
     "name": "pfUI-turtle",
     "repo": "https://github.com/dsidirop/pfUI-turtle",
-    "category": "General",
+    "category": "UI",
     "description": "A small extension that fixes some issues that arise from Turtle's custom UI, class and item changes [img1]",
     "source": "turtle_wiki",
     "folder": "pfUI-turtle",
@@ -7015,26 +6733,19 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "Quartz3",
+    "name": "Quartz",
     "repo": "https://github.com/laytya/Quartz",
-    "category": "General",
-    "description": "Quartz is a modular approach to a casting bar addon. Ported to vanilla.",
+    "category": "UI",
+    "description": "Modular casting bar",
     "source": "turtle_wiki",
     "folder": "Quartz",
-    "forks": [
-      {
-        "label": "Timanaku",
-        "repo": "https://github.com/Timanaku/Quartz"
-      },
-      {
-        "label": "razzeee",
-        "repo": "https://github.com/razzeee/Quartz"
-      }
-    ],
     "release_downloads_repo": "laytya/Quartz",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "QuickChat",
@@ -7283,8 +6994,8 @@
     ],
     "release_downloads_repo": "Steelbash/RestBar",
     "release_downloads_state": "ok",
-    "release_downloads": 469,
-    "release_downloads_at": "2026-09-03T12:51:29Z"
+    "release_downloads": 470,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "Rested",
@@ -7422,8 +7133,8 @@
     ],
     "release_downloads_repo": "jsb/RingMenu",
     "release_downloads_state": "ok",
-    "release_downloads": 838,
-    "release_downloads_at": "2026-09-03T12:51:29Z"
+    "release_downloads": 839,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "ROAR-Guild",
@@ -8466,8 +8177,8 @@
     ],
     "release_downloads_repo": "EinBaum/SP_Overpower",
     "release_downloads_state": "ok",
-    "release_downloads": 1526,
-    "release_downloads_at": "2026-09-03T12:51:29Z"
+    "release_downloads": 1528,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "SP_Revenge",
@@ -8522,18 +8233,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "Speed-o-meter",
-    "repo": "https://github.com/tomek7667/speed-o-meter",
-    "category": "General",
-    "description": "Adds the best speed measuring frame",
-    "source": "turtle_wiki",
-    "folder": "speed-o-meter",
-    "release_downloads_repo": "tomek7667/speed-o-meter",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
     "name": "Speedometer",
     "repo": "https://github.com/tomek7667/speed-o-meter",
     "category": "General",
@@ -8556,15 +8255,6 @@
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "Spy",
-    "repo": "",
-    "category": "General",
-    "description": "Detects and alerts you to the presence of nearby enemy players.",
-    "source": "turtle_wiki",
-    "folder": "Spy",
-    "installable": false
   },
   {
     "name": "StealthOverlay",
@@ -8715,15 +8405,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "SuperMacro",
-    "repo": "",
-    "category": "General",
-    "description": "provides a very much improved interface for macros [Vid1]",
-    "source": "turtle_wiki",
-    "folder": "SuperMacro",
-    "installable": false
-  },
-  {
     "name": "SVT",
     "repo": "https://github.com/xorann/SVT",
     "category": "General",
@@ -8845,8 +8526,7 @@
     "release_downloads_repo": "Otari98/TankHelper",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
+    "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
     "name": "TimeManager",
@@ -9380,15 +9060,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "Unitscan",
-    "repo": "",
-    "category": "General",
-    "description": "automatically scans for characters by name and alerts you upon finding one [Img1]",
-    "source": "turtle_wiki",
-    "folder": "Unitscan",
-    "installable": false
-  },
-  {
     "name": "Vamper",
     "repo": "https://github.com/MarcelineVQ/Vamper",
     "category": "General",
@@ -9501,15 +9172,6 @@
     "release_downloads_state": "ok",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "VanillaStoryline Transparent Patch",
-    "repo": "",
-    "category": "General",
-    "description": "Removes paper backgrounds [Img1]",
-    "source": "turtle_wiki",
-    "folder": "870",
-    "installable": false
   },
   {
     "name": "VF WarriorAddon",
@@ -9998,22 +9660,12 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "HCFilter",
+    "name": "TurtleHCFilter",
     "repo": "https://github.com/trumpetx/TurtleHCFilter",
     "category": "Hardcore",
-    "description": "Filter the HC chan messages and redirect them to a chatframe of choice",
+    "description": "Place HC Chat in a preferred window; modify the chat prefix; filter out WTS/T/LFM/G messages that are too far from your level.",
     "source": "turtle_wiki",
     "folder": "TurtleHCFilter",
-    "forks": [
-      {
-        "label": "leperidot",
-        "repo": "https://github.com/leperidot/TurtleHCFilter"
-      },
-      {
-        "label": "dingleshu",
-        "repo": "https://github.com/dingleshu/TurtleHCFilter"
-      }
-    ],
     "release_downloads_repo": "trumpetx/TurtleHCFilter",
     "release_downloads_state": "none",
     "release_downloads": 0,
@@ -10062,18 +9714,6 @@
     "source": "turtle_wiki",
     "folder": "TurtleHardcoreChatTamer",
     "release_downloads_repo": "refaim/TurtleHardcoreChatTamer",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "TurtleHCFilter",
-    "repo": "https://github.com/trumpetx/TurtleHCFilter",
-    "category": "Hardcore",
-    "description": "Place HC Chat in a preferred window; modify the chat prefix; filter out WTS/T/LFM/G messages that are too far from your level.",
-    "source": "turtle_wiki",
-    "folder": "TurtleHCFilter",
-    "release_downloads_repo": "trumpetx/TurtleHCFilter",
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
@@ -10521,8 +10161,8 @@
     ],
     "release_downloads_repo": "laytya/MinimapButtonFrame-vanilla",
     "release_downloads_state": "ok",
-    "release_downloads": 2353,
-    "release_downloads_at": "2026-09-03T12:51:29Z"
+    "release_downloads": 2360,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "PingoMatic",
@@ -10685,8 +10325,9 @@
     ],
     "release_downloads_repo": "Shellyoung/AdvancedTradeSkillWindow2",
     "release_downloads_state": "ok",
-    "release_downloads": 159,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 161,
+    "release_downloads_at": "2026-09-06T08:38:49Z",
+    "recommended": true
   },
   {
     "name": "Artisan",
@@ -10723,15 +10364,6 @@
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "BattleMusic Lore Friendly Music Pack",
-    "repo": "",
-    "category": "Professions",
-    "description": "Adds over 30 different Warcraft combat tunes.",
-    "source": "turtle_wiki",
-    "folder": "869",
-    "installable": false
   },
   {
     "name": "Better Character Panel",
@@ -11023,8 +10655,8 @@
     ],
     "release_downloads_repo": "laytya/Mendeleev",
     "release_downloads_state": "ok",
-    "release_downloads": 238,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 240,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "MissingCrafts",
@@ -11136,8 +10768,8 @@
     "folder": "ProfessionLevels",
     "release_downloads_repo": "gregdeichler/ProfessionLevels",
     "release_downloads_state": "ok",
-    "release_downloads": 1,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 3,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "Profession query",
@@ -11187,7 +10819,6 @@
         "repo": ""
       }
     ],
-    "recommended": true,
     "release_downloads_repo": "greendam/TheoryCraft-Turtle",
     "release_downloads_state": "none",
     "release_downloads": 0,
@@ -11462,15 +11093,6 @@
     "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
-    "name": "Quickcall",
-    "repo": "",
-    "category": "PvP",
-    "description": "Battleground PvP Addon for Arathi Basin.",
-    "source": "turtle_wiki",
-    "folder": "Quickcall",
-    "installable": false
-  },
-  {
     "name": "Sentry",
     "repo": "https://github.com/shirsig/sentry",
     "category": "PvP",
@@ -11577,16 +11199,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "AtlasQuest Turtle",
-    "repo": "",
-    "category": "Questing",
-    "description": "see a list of vanilla and TurtleWOW quests related to each dungeon.",
-    "source": "turtle_wiki",
-    "turtle_custom": true,
-    "folder": "AtlasQuestTurtle",
-    "installable": false
-  },
-  {
     "name": "AutoBar",
     "repo": "https://github.com/Bestoriop/AutoBar",
     "category": "Questing",
@@ -11603,8 +11215,7 @@
     "release_downloads_repo": "laytya/AutoBar-for-Turtle-WoW",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
-    "recommended": true
+    "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
     "name": "AutoConfirm",
@@ -11657,8 +11268,8 @@
     "folder": "AutoQuest",
     "release_downloads_repo": "MickeyPickey/AutoQuest",
     "release_downloads_state": "ok",
-    "release_downloads": 292,
-    "release_downloads_at": "2026-09-03T12:51:29Z"
+    "release_downloads": 295,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "AutoTurnIn",
@@ -11835,8 +11446,8 @@
     ],
     "release_downloads_repo": "JeromeM/GuidelimeVanilla",
     "release_downloads_state": "ok",
-    "release_downloads": 274,
-    "release_downloads_at": "2026-09-03T12:51:29Z"
+    "release_downloads": 275,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "HardcoreAlarms",
@@ -11845,15 +11456,6 @@
     "description": "Configurable Alarms for Low HP, out of breath, dangerous quests and enemies. Primarily for hardcore characters.",
     "source": "turtle_wiki",
     "folder": "HardcoreAlarms"
-  },
-  {
-    "name": "LazyPig",
-    "repo": "",
-    "category": "Questing",
-    "description": "An addon for lazy people. Helps automate dismounting, repetitive quests, NPC interactions, and interface actions. [Vid1]",
-    "source": "turtle_wiki",
-    "folder": "LazyPig",
-    "installable": false
   },
   {
     "name": "LootCrestReminder",
@@ -11912,20 +11514,27 @@
     ],
     "release_downloads_repo": "Cliencer/pfExtend",
     "release_downloads_state": "ok",
-    "release_downloads": 14,
-    "release_downloads_at": "2026-09-03T19:26:40Z"
+    "release_downloads": 18,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "pfQuest",
-    "repo": "https://github.com/The-Kludge-Bureau/pfQuest",
+    "repo": "https://github.com/rivi-s/pfQuest",
     "category": "Questing",
     "description": "A lightweight quest helper and ingame database https://github.com/The-Kludge-Bureau/pfQuest Alt [Img1]",
     "source": "turtle_wiki",
     "folder": "pfQuest",
     "forks": [
       {
+        "label": "The-Kludge-Bureau",
+        "repo": "https://github.com/The-Kludge-Bureau/pfQuest"
+      },
+      {
         "label": "brues-code",
-        "repo": "https://github.com/brues-code/pfQuest"
+        "repo": "https://github.com/brues-code/pfQuest",
+        "requires": [
+          "classicapi"
+        ]
       },
       {
         "label": "liruqi",
@@ -11969,13 +11578,21 @@
       },
       {
         "label": "roby-brok",
-        "repo": "https://github.com/roby-brok/pfQuest"
+        "repo": "https://github.com/roby-brok/pfQuest",
+        "requires": [
+          "classicapi"
+        ]
+      },
+      {
+        "label": "shagu",
+        "repo": "https://github.com/shagu/pfQuest"
       }
     ],
     "release_downloads_repo": "The-Kludge-Bureau/pfQuest",
     "release_downloads_state": "ok",
-    "release_downloads": 7083,
-    "release_downloads_at": "2026-09-03T22:36:20Z"
+    "release_downloads": 7200,
+    "release_downloads_at": "2026-09-06T08:38:49Z",
+    "recommended": true
   },
   {
     "name": "pfQuest-icons",
@@ -12013,13 +11630,17 @@
   },
   {
     "name": "pfQuest-turtle",
-    "repo": "https://gitlab.com/Taroven/pfQuest-turtle",
+    "repo": "https://github.com/rivi-s/pfQuest-turtle",
     "category": "Questing",
     "description": "A TurtleWoW DB extension for pfQuest. You need base pfQuest for this to work!",
     "source": "turtle_wiki",
     "turtle_custom": true,
     "folder": "pfQuest-turtle",
     "forks": [
+      {
+        "label": "Taroven",
+        "repo": "https://gitlab.com/Taroven/pfQuest-turtle"
+      },
       {
         "label": "The-Kludge-Bureau",
         "repo": "https://github.com/The-Kludge-Bureau/pfQuest-turtle"
@@ -12068,18 +11689,12 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "Quest Immersion",
+    "name": "Immersive Dialog UI",
     "repo": "https://github.com/moiian/ImmersiveDialogUI",
-    "category": "Questing",
-    "description": "Immersive Dialog UI. A enhanced conversation addon with a focus on immersion and customization.File:Flightmap addon.png",
+    "category": "UI",
+    "description": "A enhanced conversation addon with a focus on immersion and customization.",
     "source": "turtle_wiki",
     "folder": "ImmersiveDialogUI",
-    "forks": [
-      {
-        "label": "Or0bas",
-        "repo": "https://github.com/Or0bas/ImmersiveDialogUI"
-      }
-    ],
     "release_downloads_repo": "moiian/ImmersiveDialogUI",
     "release_downloads_state": "none",
     "release_downloads": 0,
@@ -12272,15 +11887,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "TomTomVanilla",
-    "repo": "",
-    "category": "Questing",
-    "description": "a mix of the Legion TomTom and QuestieArrow",
-    "source": "turtle_wiki",
-    "folder": "TomTomVanilla",
-    "installable": false
-  },
-  {
     "name": "TourGuide Professions",
     "repo": "https://github.com/cralor/TourGuide_Professions",
     "category": "Questing",
@@ -12299,15 +11905,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "TourGuide Turtle",
-    "repo": "",
-    "category": "Questing",
-    "description": "Power Leveling guide framework",
-    "source": "turtle_wiki",
-    "folder": "TourGuideTurtle",
-    "installable": false
-  },
-  {
     "name": "TriviaBot Turtle",
     "repo": "https://github.com/greendam/TriviaBot-TurtleWow",
     "category": "Questing",
@@ -12324,8 +11921,7 @@
     "release_downloads_repo": "greendam/TriviaBot-TurtleWow",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
+    "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
     "name": "TurtlesEpoch",
@@ -12367,15 +11963,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "WoW-Voiceover",
-    "repo": "",
-    "category": "Questing",
-    "description": "Adds AI generated voice acting to NPC dialogue and quests",
-    "source": "turtle_wiki",
-    "folder": "WoW-Voiceover",
-    "installable": false
-  },
-  {
     "name": "XToLevel-Classic",
     "repo": "https://github.com/jayparry/XToLevel-Classic",
     "category": "Questing",
@@ -12386,24 +11973,6 @@
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "Atlas Turtle",
-    "repo": "",
-    "category": "Raiding",
-    "description": "View maps of dungeons and raids",
-    "source": "turtle_wiki",
-    "folder": "AtlasTurtle",
-    "installable": false
-  },
-  {
-    "name": "AtlasLoot Turtle",
-    "repo": "",
-    "category": "Raiding",
-    "description": "Browse loot tables for Dungeons and Raids",
-    "source": "turtle_wiki",
-    "folder": "AtlasLootTurtle",
-    "installable": false
   },
   {
     "name": "AtlasLoot-GearFilter",
@@ -12441,8 +12010,7 @@
     "release_downloads_repo": "balakethelock/AutoMasterLooter",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
-    "recommended": true
+    "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
     "name": "Automaton",
@@ -12468,17 +12036,7 @@
     "release_downloads_repo": "balakethelock/bananabar",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
-    "recommended": true
-  },
-  {
-    "name": "BigTimer",
-    "repo": "",
-    "category": "Raiding",
-    "description": "No more macros for BigWigs pull timers, and readychecks.",
-    "source": "turtle_wiki",
-    "folder": "BigTimer",
-    "installable": false
+    "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
     "name": "BigWigs",
@@ -12649,26 +12207,20 @@
   {
     "name": "DamageMeters",
     "repo": "https://github.com/dogmax/DamageMeters",
-    "category": "Raiding",
+    "category": "Combat",
     "description": "Track damage. You can output the stats in \"say\", \"party\", \"raid\" etc.",
     "source": "turtle_wiki",
     "folder": "DamageMeters",
-    "forks": [
-      {
-        "label": "RavenOfSeven",
-        "repo": "https://github.com/RavenOfSeven/DamageMeters"
-      }
-    ],
     "release_downloads_repo": "dogmax/DamageMeters",
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "DBM",
+    "name": "LVBM",
     "repo": "https://github.com/yutsuku/LVBM",
     "category": "Raiding",
-    "description": "Deadly Boss Mods was known as La Vendetta Boss Mods (LVBM) back in Vanilla WoW, it's a stand-alone boss mod for raid groups playing in the end-game content.",
+    "description": "(La Vendetta Boss Mods) is a stand-alone boss mod for raid groups playing in the end-game content, you might be familiar with later versions of this known as DBM (Deadly Boss Mods)",
     "source": "turtle_wiki",
     "folder": "LVBM",
     "release_downloads_repo": "yutsuku/LVBM",
@@ -12679,7 +12231,7 @@
   {
     "name": "DevilsHunters",
     "repo": "https://github.com/jejkas/DevilsHunters",
-    "category": "Raiding",
+    "category": "General",
     "description": "creates a BigWigs timer when a Devilsaur dies and tries to pick the correct location",
     "source": "turtle_wiki",
     "folder": "DevilsHunters",
@@ -12722,18 +12274,6 @@
     "release_downloads_repo": "isitLoVe/EPGPexport",
     "release_downloads_state": "ok",
     "release_downloads": 7,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "ExoRaidSetup",
-    "repo": "https://github.com/0ldi/ExoRaidSetup",
-    "category": "Raiding",
-    "description": "allows a raid to share graphical representations of boss pulls",
-    "source": "turtle_wiki",
-    "folder": "ExoRaidSetup",
-    "release_downloads_repo": "0ldi/ExoRaidSetup",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
@@ -12839,15 +12379,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "KLHThreatMeter (KTM)",
-    "repo": "",
-    "category": "Raiding",
-    "description": "Threat meter. This version of KTM uses the TWThreat API when available, and the 1.12 threat guessing code otherwise.",
-    "source": "turtle_wiki",
-    "folder": "KLHThreatMeter(KTM)",
-    "installable": false
-  },
-  {
     "name": "LazyRes",
     "repo": "https://github.com/BlackHaste/LazyRes",
     "category": "Raiding",
@@ -12904,15 +12435,6 @@
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "Loot Hog",
-    "repo": "",
-    "category": "Raiding",
-    "description": "Detects and tracks rolls which are made with '/random' or '/roll' and sorts them, allowing raid leaders to announce roll winners quickly and easily.",
-    "source": "turtle_wiki",
-    "folder": "info12031-LootHog.html",
-    "installable": false
   },
   {
     "name": "LootAtMouse",
@@ -13052,18 +12574,6 @@
     "release_downloads_repo": "Road-block/LootTracker",
     "release_downloads_state": "ok",
     "release_downloads": 121,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "LVBM",
-    "repo": "https://github.com/yutsuku/LVBM",
-    "category": "Raiding",
-    "description": "(La Vendetta Boss Mods) is a stand-alone boss mod for raid groups playing in the end-game content, you might be familiar with later versions of this known as DBM (Deadly Boss Mods)",
-    "source": "turtle_wiki",
-    "folder": "LVBM",
-    "release_downloads_repo": "yutsuku/LVBM",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
@@ -13251,15 +12761,6 @@
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "oRA2",
-    "repo": "",
-    "category": "Raiding",
-    "description": "a lightweight alternative for CTRaidAssist [Img1]",
-    "source": "turtle_wiki",
-    "folder": "oRA2",
-    "installable": false
   },
   {
     "name": "Paladin Salva Remover",
@@ -13592,8 +13093,8 @@
     ],
     "release_downloads_repo": "obszczymucha/roll-for-vanilla",
     "release_downloads_state": "ok",
-    "release_downloads": 3759,
-    "release_downloads_at": "2026-09-03T22:36:20Z"
+    "release_downloads": 3766,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "RoundRobinhood",
@@ -13744,8 +13245,8 @@
     ],
     "release_downloads_repo": "Road-block/SimpleRaidTargetIcons",
     "release_downloads_state": "ok",
-    "release_downloads": 519,
-    "release_downloads_at": "2026-08-28T08:25:16Z"
+    "release_downloads": 520,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "SmartBuff",
@@ -14124,8 +13625,8 @@
     "folder": "XLoot_AddOns",
     "release_downloads_repo": "Road-block/XLoot_AddOns",
     "release_downloads_state": "ok",
-    "release_downloads": 1577,
-    "release_downloads_at": "2026-09-03T12:51:29Z"
+    "release_downloads": 1580,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "XtraUnitFrame",
@@ -14287,12 +13788,16 @@
   },
   {
     "name": "aDF",
-    "repo": "https://github.com/MarcelineVQ/aDF",
-    "category": "SuperWoW",
+    "repo": "https://github.com/DanKirichenko/aDF",
+    "category": "UI",
     "description": "adds a small HUD that standardizes critical info about your target's defences, including Armor, Resists, and specific debuffs [Img1] https://github.com/Autignem/aDF Alt",
     "source": "turtle_wiki",
     "folder": "aDF",
     "forks": [
+      {
+        "label": "MarcelineVQ",
+        "repo": "https://github.com/MarcelineVQ/aDF"
+      },
       {
         "label": "Zebouski",
         "repo": "https://github.com/Zebouski/aDF"
@@ -14312,63 +13817,97 @@
       {
         "label": "melbaa",
         "repo": "https://github.com/melbaa/aDF"
+      },
+      {
+        "label": "jrc13245",
+        "repo": "https://github.com/jrc13245/aDF"
+      },
+      {
+        "label": "Abstr4ctz",
+        "repo": "https://github.com/Abstr4ctz/aDF"
+      },
+      {
+        "label": "asyncwithsky",
+        "repo": "https://github.com/asyncwithsky/aDF"
       }
     ],
     "release_downloads_repo": "MarcelineVQ/aDF",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
+    "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
     "name": "AutoLock",
     "repo": "https://github.com/DavidBecht/AutoLock",
-    "category": "SuperWoW",
+    "category": "Combat",
     "description": "Priority-based spell rotation addon for Warlocks.",
     "source": "turtle_wiki",
     "folder": "AutoLock",
     "release_downloads_repo": "DavidBecht/AutoLock",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow",
+      "nampower"
+    ]
   },
   {
     "name": "AutoMarker",
     "repo": "https://github.com/MarcelineVQ/AutoMarker",
-    "category": "SuperWoW",
+    "category": "General",
     "description": "Automatically mark raid mobs.",
     "source": "turtle_wiki",
     "folder": "AutoMarker",
     "forks": [
       {
         "label": "JeSmyrna/Stonewall-Inn---AutoMarker",
-        "repo": "https://github.com/JeSmyrna/Stonewall-Inn---AutoMarker"
+        "repo": "https://github.com/JeSmyrna/Stonewall-Inn---AutoMarker",
+        "requires": [
+          "superwow",
+          "nampower"
+        ]
       },
       {
         "label": "TheRealFayz",
-        "repo": "https://github.com/TheRealFayz/AutoMarker"
+        "repo": "https://github.com/TheRealFayz/AutoMarker",
+        "requires": [
+          "superwow",
+          "nampower"
+        ]
       },
       {
         "label": "jrc13245",
-        "repo": "https://github.com/jrc13245/AutoMarker"
+        "repo": "https://github.com/jrc13245/AutoMarker",
+        "requires": [
+          "superwow",
+          "nampower"
+        ]
       }
     ],
     "release_downloads_repo": "MarcelineVQ/AutoMarker",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow",
+      "nampower"
+    ]
   },
   {
     "name": "Cursive",
     "repo": "https://github.com/pepopo978/Cursive",
-    "category": "SuperWoW",
+    "category": "Combat",
     "description": "Curse tracker and multi curse assistant",
     "source": "turtle_wiki",
     "folder": "Cursive",
     "forks": [
       {
         "label": "Wayoff333",
-        "repo": "https://github.com/Wayoff333/Cursive"
+        "repo": "https://github.com/Wayoff333/Cursive",
+        "requires": [
+          "nampower"
+        ]
       },
       {
         "label": "Taeko-ar/Cursive-3.3.5a",
@@ -14376,7 +13915,10 @@
       },
       {
         "label": "razzeee",
-        "repo": "https://github.com/razzeee/Cursive"
+        "repo": "https://github.com/razzeee/Cursive",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "bretharte89",
@@ -14470,24 +14012,30 @@
     "release_downloads_repo": "pepopo978/Cursive",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "nampower"
+    ]
   },
   {
     "name": "Cursive-raid",
     "repo": "https://github.com/Kirchlive/cursive-raid",
-    "category": "SuperWoW",
+    "category": "Raiding",
     "description": "Real-time debuff tracking, live armor monitoring, and full raid visibility.",
     "source": "turtle_wiki",
     "folder": "cursive-raid",
     "release_downloads_repo": "Kirchlive/cursive-raid",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "Decursive",
     "repo": "https://github.com/MarcelineVQ/Decursive",
-    "category": "SuperWoW",
+    "category": "Combat",
     "description": "This is a cleaning mod. Its job it to help a class that can remove debuffs, do it with ease.",
     "source": "turtle_wiki",
     "folder": "Decursive",
@@ -14541,190 +14089,204 @@
   {
     "name": "DruidManaBar",
     "repo": "https://github.com/gashole/DruidManaBar",
-    "category": "SuperWoW",
+    "category": "UI",
     "description": "Displays a mana bar when shapeshifted [Img1]",
     "source": "turtle_wiki",
     "folder": "DruidManaBar",
     "forks": [
       {
         "label": "zmarotrix",
-        "repo": "https://github.com/zmarotrix/DruidManaBar"
+        "repo": "https://github.com/zmarotrix/DruidManaBar",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "kluy18",
-        "repo": "https://github.com/kluy18/DruidManaBar"
+        "repo": "https://github.com/kluy18/DruidManaBar",
+        "requires": [
+          "superwow"
+        ]
       }
     ],
     "release_downloads_repo": "gashole/DruidManaBar",
     "release_downloads_state": "ok",
-    "release_downloads": 94,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads": 95,
+    "release_downloads_at": "2026-09-06T08:38:49Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "FastTOT",
     "repo": "https://github.com/OldManAlpha/FastTOT",
-    "category": "SuperWoW",
+    "category": "UI",
     "description": "Massively increases performance of Target Of Target frame",
     "source": "turtle_wiki",
     "folder": "FastTOT",
-    "forks": [
-      {
-        "label": "bretharte89",
-        "repo": "https://github.com/bretharte89/FastTOT"
-      }
-    ],
     "release_downloads_repo": "OldManAlpha/FastTOT",
     "release_downloads_state": "ok",
     "release_downloads": 20,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
+    "release_downloads_at": "2026-09-02T05:51:38Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "Friend-O-Tron",
     "repo": "https://github.com/refaim/Friend-O-Tron",
-    "category": "SuperWoW",
+    "category": "Social",
     "description": "Synchronizes your friends list across all your characters and accounts (with SuperWoW) on the same realm.",
     "source": "turtle_wiki",
     "folder": "Friend-O-Tron",
-    "forks": [
-      {
-        "label": "freadblangks",
-        "repo": "https://github.com/freadblangks/Friend-O-Tron"
-      }
-    ],
     "release_downloads_repo": "refaim/Friend-O-Tron",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "GCDisplay",
     "repo": "https://github.com/MrDoufuru/GCDisplay",
-    "category": "SuperWoW",
+    "category": "Combat",
     "description": "Displays your GCD, with the last spell that triggers it, as a circle reducing its size.",
     "source": "turtle_wiki",
     "folder": "GCDisplay",
-    "forks": [
-      {
-        "label": "bretharte89",
-        "repo": "https://github.com/bretharte89/GCDisplay"
-      }
-    ],
     "release_downloads_repo": "MrDoufuru/GCDisplay",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "IWinEnhanced",
-    "repo": "https://github.com/Profiler781/IWinEnhanced",
-    "category": "SuperWoW",
+    "repo": "https://github.com/Noravar/IWinEnhanced",
+    "category": "Combat",
     "description": "1-button rotation macros for Turtle Druids, Paladins and Warriors.",
     "source": "turtle_wiki",
     "folder": "IWinEnhanced",
     "forks": [
       {
-        "label": "Noravar",
-        "repo": "https://github.com/Noravar/IWinEnhanced"
-      },
-      {
-        "label": "bretharte89",
-        "repo": "https://github.com/bretharte89/IWinEnhanced"
+        "label": "Profiler781",
+        "repo": "https://github.com/Profiler781/IWinEnhanced",
+        "requires": [
+          "superwow",
+          "nampower",
+          "unitxp"
+        ]
       },
       {
         "label": "jrc13245",
-        "repo": "https://github.com/jrc13245/IWinEnhanced"
+        "repo": "https://github.com/jrc13245/IWinEnhanced",
+        "requires": [
+          "superwow",
+          "nampower",
+          "unitxp"
+        ]
       },
       {
         "label": "Bapiop",
-        "repo": "https://github.com/Bapiop/IWinEnhanced"
-      },
-      {
-        "label": "Gensoo",
-        "repo": "https://github.com/Gensoo/IWinEnhanced"
+        "repo": "https://github.com/Bapiop/IWinEnhanced",
+        "requires": [
+          "superwow",
+          "nampower",
+          "unitxp"
+        ]
       }
     ],
     "release_downloads_repo": "Profiler781/IWinEnhanced",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow",
+      "nampower",
+      "unitxp"
+    ]
   },
   {
     "name": "JankyPlates",
     "repo": "https://github.com/Ageous27/JankyPlates",
-    "category": "SuperWoW",
+    "category": "UI",
     "description": "Colors enemy name plates based on players threat.",
     "source": "turtle_wiki",
     "folder": "JankyPlates",
     "release_downloads_repo": "Ageous27/JankyPlates",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "Lateral",
     "repo": "https://github.com/Carravan/Lateral",
-    "category": "SuperWoW",
+    "category": "UI",
     "description": "Rogue Rotation and T3.5 Proc Tracking",
     "source": "turtle_wiki",
     "folder": "Lateral",
     "release_downloads_repo": "Carravan/Lateral",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "nampower"
+    ]
   },
   {
     "name": "MageHud",
-    "repo": "https://github.com/pepopo978/MageHud",
-    "category": "SuperWoW",
+    "repo": "https://github.com/CommanderSouza/MageHud",
+    "category": "UI",
     "description": "Display remaining mage shields for ice barrier/mana shield/protection pots and more.",
     "source": "turtle_wiki",
     "folder": "MageHud",
     "forks": [
       {
-        "label": "CommanderSouza",
-        "repo": "https://github.com/CommanderSouza/MageHud"
-      },
-      {
-        "label": "bugRanger",
-        "repo": "https://github.com/bugRanger/MageHud"
-      },
-      {
-        "label": "Monomode/TurtleWow--MageHud",
-        "repo": "https://github.com/Monomode/TurtleWow--MageHud"
-      },
-      {
-        "label": "tubtubs",
-        "repo": "https://github.com/tubtubs/MageHud"
+        "label": "pepopo978",
+        "repo": "https://github.com/pepopo978/MageHud",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "laytya",
-        "repo": "https://github.com/laytya/MageHud"
+        "repo": "https://github.com/laytya/MageHud",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "shikulja",
-        "repo": "https://github.com/shikulja/MageHud"
-      },
-      {
-        "label": "jilinge2/ArcHud2",
-        "repo": "https://github.com/jilinge2/ArcHud2"
+        "repo": "https://github.com/shikulja/MageHud",
+        "requires": [
+          "superwow"
+        ]
       }
     ],
     "release_downloads_repo": "pepopo978/MageHud",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "MonkeySpeed",
-    "repo": "https://github.com/TrangOul/MonkeySpeed",
-    "category": "SuperWoW",
+    "repo": "https://github.com/DrOmida/MonkeySpeed",
+    "category": "General",
     "description": "Adds a simple movable speedometer displaying speed as a percentage of run speed.",
     "source": "turtle_wiki",
     "folder": "MonkeySpeed",
     "forks": [
       {
-        "label": "DrOmida",
-        "repo": "https://github.com/DrOmida/MonkeySpeed"
+        "label": "TrangOul",
+        "repo": "https://github.com/TrangOul/MonkeySpeed"
       }
     ],
     "release_downloads_repo": "TrangOul/MonkeySpeed",
@@ -14735,44 +14297,47 @@
   {
     "name": "oCB [SuperWoW",
     "repo": "https://github.com/Shellyoung/oCB-SuperWoW",
-    "category": "SuperWoW",
+    "category": "UI",
     "description": "] - (Otravi Casting Bar) Quartz Like castbar with SuperWoW support [Image].",
     "source": "turtle_wiki",
     "folder": "oCB",
     "release_downloads_repo": "Shellyoung/oCB-SuperWoW",
     "release_downloads_state": "ok",
     "release_downloads": 139,
-    "release_downloads_at": "2026-09-03T12:51:29Z"
+    "release_downloads_at": "2026-09-03T12:51:29Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "Overhead",
     "repo": "https://github.com/Otari98/Overhead",
-    "category": "SuperWoW",
+    "category": "UI",
     "description": "Simple and lightweight overlapping nameplates with cast bars and class colors",
     "source": "turtle_wiki",
     "folder": "Overhead",
-    "forks": [
-      {
-        "label": "AmonRA",
-        "repo": "https://github.com/AmonRA/Overhead"
-      }
-    ],
     "release_downloads_repo": "Otari98/Overhead",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "pfUI-bettertotems",
     "repo": "https://github.com/roby-brok/pfUI-bettertotems",
-    "category": "SuperWoW",
+    "category": "UI",
     "description": "External module for pfUI providing some extra features to totems [Img1]",
     "source": "turtle_wiki",
     "folder": "pfUI-bettertotems",
     "forks": [
       {
         "label": "Bombg",
-        "repo": "https://github.com/Bombg/pfUI-bettertotems"
+        "repo": "https://github.com/Bombg/pfUI-bettertotems",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "RavenOfSeven",
@@ -14791,12 +14356,14 @@
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z",
-    "recommended": true
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "Puppeteer",
     "repo": "https://github.com/OldManAlpha/Puppeteer",
-    "category": "SuperWoW",
+    "category": "UI",
     "description": "Unit frames addon for healers or any class/spec, an alternative to modern WoW's VuhDo, Cell, or Healbot",
     "source": "turtle_wiki",
     "folder": "Puppeteer",
@@ -14868,25 +14435,13 @@
     ],
     "release_downloads_repo": "OldManAlpha/Puppeteer",
     "release_downloads_state": "ok",
-    "release_downloads": 281,
-    "release_downloads_at": "2026-09-03T19:26:40Z"
-  },
-  {
-    "name": "Quartz",
-    "repo": "https://github.com/laytya/Quartz",
-    "category": "SuperWoW",
-    "description": "Modular casting bar",
-    "source": "turtle_wiki",
-    "folder": "Quartz",
-    "release_downloads_repo": "laytya/Quartz",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads": 286,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "QuickTurtleDBLookUp",
     "repo": "https://github.com/Taeko-ar/QuickTurtleDBLookUp",
-    "category": "SuperWoW",
+    "category": "General",
     "description": "Quick NPC search in the Turtle WoW database",
     "source": "turtle_wiki",
     "turtle_custom": true,
@@ -14899,7 +14454,7 @@
   {
     "name": "Rinse",
     "repo": "https://github.com/Otari98/Rinse",
-    "category": "SuperWoW",
+    "category": "Combat",
     "description": "This addon is very similar to Decursive, it helps with removing debuffs from friendly units",
     "source": "turtle_wiki",
     "folder": "Rinse",
@@ -14910,50 +14465,30 @@
       },
       {
         "label": "Dauls/Rinse-V-",
-        "repo": "https://github.com/Dauls/Rinse-V-"
+        "repo": "https://github.com/Dauls/Rinse-V-",
+        "requires": []
       },
       {
         "label": "EVANnnn1996",
-        "repo": "https://github.com/EVANnnn1996/Rinse"
-      },
-      {
-        "label": "al3xc1985",
-        "repo": "https://github.com/al3xc1985/Rinse"
-      },
-      {
-        "label": "tubtubs",
-        "repo": "https://github.com/tubtubs/Rinse"
+        "repo": "https://github.com/EVANnnn1996/Rinse",
+        "requires": []
       },
       {
         "label": "verge20",
         "repo": "https://github.com/verge20/Rinse"
-      },
-      {
-        "label": "Mats391",
-        "repo": "https://github.com/Mats391/Rinse"
-      },
-      {
-        "label": "whtmst",
-        "repo": "https://github.com/whtmst/Rinse"
-      },
-      {
-        "label": "Nikki1993",
-        "repo": "https://github.com/Nikki1993/Rinse"
-      },
-      {
-        "label": "Paenthy",
-        "repo": "https://github.com/Paenthy/Rinse"
       }
     ],
     "release_downloads_repo": "Otari98/Rinse",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [],
+    "recommended": true
   },
   {
     "name": "ShaguDPS",
-    "repo": "https://github.com/shagu/ShaguDPS",
-    "category": "SuperWoW",
+    "repo": "https://github.com/DCV-2142/ShaguDPS",
+    "category": "Combat",
     "description": "A very small and lightweight damage meter [Img1] [Img2]",
     "source": "turtle_wiki",
     "folder": "ShaguDPS",
@@ -14963,20 +14498,16 @@
         "repo": "https://github.com/Emyrk/ShaguDPS"
       },
       {
+        "label": "shagu",
+        "repo": "https://github.com/shagu/ShaguDPS"
+      },
+      {
         "label": "Nelethor",
         "repo": "https://github.com/Nelethor/ShaguDPS"
       },
       {
-        "label": "EVANnnn1996",
-        "repo": "https://github.com/EVANnnn1996/ShaguDPS"
-      },
-      {
         "label": "96Rex",
         "repo": "https://github.com/96Rex/ShaguDPS"
-      },
-      {
-        "label": "DCV-2142",
-        "repo": "https://github.com/DCV-2142/ShaguDPS"
       },
       {
         "label": "deceius",
@@ -15003,68 +14534,8 @@
         "repo": "https://github.com/Arthur-Helias/ShaguDPS"
       },
       {
-        "label": "Macumbafeh",
-        "repo": "https://github.com/Macumbafeh/ShaguDPS"
-      },
-      {
         "label": "Otari98",
         "repo": "https://github.com/Otari98/ShaguDPS"
-      },
-      {
-        "label": "AmonRA",
-        "repo": "https://github.com/AmonRA/ShaguDPS"
-      },
-      {
-        "label": "dwbclz",
-        "repo": "https://github.com/dwbclz/ShaguDPS"
-      },
-      {
-        "label": "jiangxt316",
-        "repo": "https://github.com/jiangxt316/ShaguDPS"
-      },
-      {
-        "label": "Sandworlds-MMO",
-        "repo": "https://github.com/Sandworlds-MMO/ShaguDPS"
-      },
-      {
-        "label": "ShigemuneKurogane",
-        "repo": "https://github.com/ShigemuneKurogane/ShaguDPS"
-      },
-      {
-        "label": "xinleibird",
-        "repo": "https://github.com/xinleibird/ShaguDPS"
-      },
-      {
-        "label": "yani9o",
-        "repo": "https://github.com/yani9o/ShaguDPS"
-      },
-      {
-        "label": "zyyysxd",
-        "repo": "https://github.com/zyyysxd/ShaguDPS"
-      },
-      {
-        "label": "dbulatovicx32",
-        "repo": "https://github.com/dbulatovicx32/ShaguDPS"
-      },
-      {
-        "label": "CommanderSouza",
-        "repo": "https://github.com/CommanderSouza/ShaguDPS"
-      },
-      {
-        "label": "Beardedrasta",
-        "repo": "https://github.com/Beardedrasta/ShaguDPS"
-      },
-      {
-        "label": "tperraut",
-        "repo": "https://github.com/tperraut/ShaguDPS"
-      },
-      {
-        "label": "WanLiQiaoXi",
-        "repo": "https://github.com/WanLiQiaoXi/ShaguDPS"
-      },
-      {
-        "label": "empty1021",
-        "repo": "https://github.com/empty1021/ShaguDPS"
       }
     ],
     "release_downloads_repo": "shagu/ShaguDPS",
@@ -15075,7 +14546,7 @@
   {
     "name": "ShaguPlates",
     "repo": "https://github.com/shagu/ShaguPlates",
-    "category": "SuperWoW",
+    "category": "UI",
     "description": "modifies and extends the default nameplates [Img1] TidyPlates-Edit",
     "source": "turtle_wiki",
     "folder": "ShaguPlates",
@@ -15086,7 +14557,10 @@
       },
       {
         "label": "MarcelineVQ/ShaguPlatesX",
-        "repo": "https://github.com/MarcelineVQ/ShaguPlatesX"
+        "repo": "https://github.com/MarcelineVQ/ShaguPlatesX",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "paokkerkir",
@@ -15167,6 +14641,10 @@
       {
         "label": "skllskll",
         "repo": "https://github.com/skllskll/ShaguPlates"
+      },
+      {
+        "label": "MalcolmDahling",
+        "repo": "https://github.com/MalcolmDahling/ShaguPlatesX"
       }
     ],
     "release_downloads_repo": "shagu/ShaguPlates",
@@ -15176,74 +14654,82 @@
   },
   {
     "name": "ShaguScan",
-    "repo": "https://github.com/shagu/ShaguScan",
-    "category": "SuperWoW",
+    "repo": "https://github.com/helix-dev0/ShaguScan",
+    "category": "General",
     "description": "Tracks and filters nearby players and npcs",
     "source": "turtle_wiki",
     "folder": "ShaguScan",
     "forks": [
       {
-        "label": "The-Kludge-Bureau",
-        "repo": "https://github.com/The-Kludge-Bureau/ShaguScan"
-      },
-      {
-        "label": "helix-dev0",
-        "repo": "https://github.com/helix-dev0/ShaguScan"
+        "label": "shagu",
+        "repo": "https://github.com/shagu/ShaguScan",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "qrospars/ShaguScanLongRange",
-        "repo": "https://github.com/qrospars/ShaguScanLongRange"
+        "repo": "https://github.com/qrospars/ShaguScanLongRange",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "TheRealFayz",
-        "repo": "https://github.com/TheRealFayz/ShaguScan"
+        "repo": "https://github.com/TheRealFayz/ShaguScan",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "whtmst",
-        "repo": "https://github.com/whtmst/ShaguScan"
+        "repo": "https://github.com/whtmst/ShaguScan",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "kaneha",
-        "repo": "https://github.com/kaneha/ShaguScan"
-      },
-      {
-        "label": "AmonRA",
-        "repo": "https://github.com/AmonRA/ShaguScan"
-      },
-      {
-        "label": "dwbclz",
-        "repo": "https://github.com/dwbclz/ShaguScan"
-      },
-      {
-        "label": "jiangxt316",
-        "repo": "https://github.com/jiangxt316/ShaguScan"
-      },
-      {
-        "label": "max-bruhn",
-        "repo": "https://github.com/max-bruhn/ShaguScan"
+        "repo": "https://github.com/kaneha/ShaguScan",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "JembaWoW",
-        "repo": "https://github.com/JembaWoW/ShaguScan"
+        "repo": "https://github.com/JembaWoW/ShaguScan",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "shikulja",
-        "repo": "https://github.com/shikulja/ShaguScan"
+        "repo": "https://github.com/shikulja/ShaguScan",
+        "requires": [
+          "superwow"
+        ]
       }
     ],
     "release_downloads_repo": "shagu/ShaguScan",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "ShaguTweaks",
-    "repo": "https://github.com/shagu/ShaguTweaks",
-    "category": "SuperWoW",
+    "repo": "https://github.com/Dusk-92/ShaguTweaks-ClassicAPI",
+    "category": "UI",
     "description": "A small AddOn for those who don't want to use any AddOns at all. [Img1]",
     "source": "turtle_wiki",
     "folder": "ShaguTweaks",
     "forks": [
+      {
+        "label": "shagu",
+        "repo": "https://github.com/shagu/ShaguTweaks"
+      },
       {
         "label": "paokkerkir",
         "repo": "https://github.com/paokkerkir/ShaguTweaks"
@@ -15265,136 +14751,12 @@
         "repo": "https://github.com/USS-Enterprise-Guild/ShaguTweaks"
       },
       {
-        "label": "Sandworlds-MMO",
-        "repo": "https://github.com/Sandworlds-MMO/ShaguTweaks"
-      },
-      {
-        "label": "hellowind777",
-        "repo": "https://github.com/hellowind777/ShaguTweaks"
-      },
-      {
-        "label": "balakethelock",
-        "repo": "https://github.com/balakethelock/ShaguTweaks"
-      },
-      {
-        "label": "refaim",
-        "repo": "https://github.com/refaim/ShaguTweaks"
-      },
-      {
-        "label": "KarstenBade",
-        "repo": "https://github.com/KarstenBade/ShaguTweaks"
-      },
-      {
         "label": "ziin",
         "repo": "https://github.com/ziin/ShaguTweaks"
       },
       {
-        "label": "wow-br",
-        "repo": "https://github.com/wow-br/ShaguTweaks"
-      },
-      {
-        "label": "lich906",
-        "repo": "https://github.com/lich906/ShaguTweaks"
-      },
-      {
         "label": "DBFBlackbull",
         "repo": "https://github.com/DBFBlackbull/ShaguTweaks"
-      },
-      {
-        "label": "flyinbed",
-        "repo": "https://github.com/flyinbed/ShaguTweaks"
-      },
-      {
-        "label": "gashole",
-        "repo": "https://github.com/gashole/ShaguTweaks"
-      },
-      {
-        "label": "AmonRA",
-        "repo": "https://github.com/AmonRA/ShaguTweaks"
-      },
-      {
-        "label": "dwbclz",
-        "repo": "https://github.com/dwbclz/ShaguTweaks"
-      },
-      {
-        "label": "jiangxt316",
-        "repo": "https://github.com/jiangxt316/ShaguTweaks"
-      },
-      {
-        "label": "jilinge2",
-        "repo": "https://github.com/jilinge2/ShaguTweaks"
-      },
-      {
-        "label": "nidski-wow",
-        "repo": "https://github.com/nidski-wow/ShaguTweaks"
-      },
-      {
-        "label": "panzier32564-cmd",
-        "repo": "https://github.com/panzier32564-cmd/ShaguTweaks"
-      },
-      {
-        "label": "RavenOfSeven",
-        "repo": "https://github.com/RavenOfSeven/ShaguTweaks"
-      },
-      {
-        "label": "ShigemuneKurogane",
-        "repo": "https://github.com/ShigemuneKurogane/ShaguTweaks"
-      },
-      {
-        "label": "yani9o",
-        "repo": "https://github.com/yani9o/ShaguTweaks"
-      },
-      {
-        "label": "zyyysxd",
-        "repo": "https://github.com/zyyysxd/ShaguTweaks"
-      },
-      {
-        "label": "Macumbafeh",
-        "repo": "https://github.com/Macumbafeh/ShaguTweaks"
-      },
-      {
-        "label": "alchem1ster",
-        "repo": "https://github.com/alchem1ster/ShaguTweaks"
-      },
-      {
-        "label": "Paenthy",
-        "repo": "https://github.com/Paenthy/ShaguTweaks"
-      },
-      {
-        "label": "Deadliftchic",
-        "repo": "https://github.com/Deadliftchic/ShaguTweaks"
-      },
-      {
-        "label": "DeicPro",
-        "repo": "https://github.com/DeicPro/ShaguTweaks"
-      },
-      {
-        "label": "OmegaZeroXIII",
-        "repo": "https://github.com/OmegaZeroXIII/ShaguTweaks"
-      },
-      {
-        "label": "Txuscolchonero",
-        "repo": "https://github.com/Txuscolchonero/ShaguTweaks"
-      },
-      {
-        "label": "waverion",
-        "repo": "https://github.com/waverion/ShaguTweaks"
-      },
-      {
-        "label": "JembaWoW",
-        "repo": "https://github.com/JembaWoW/ShaguTweaks"
-      },
-      {
-        "label": "likesc",
-        "repo": "https://github.com/likesc/ShaguTweaks"
-      },
-      {
-        "label": "IfElseThen",
-        "repo": "https://github.com/IfElseThen/ShaguTweaks"
-      },
-      {
-        "label": "Chad90b",
-        "repo": "https://github.com/Chad90b/ShaguTweaks"
       },
       {
         "label": "brightLee1983",
@@ -15404,12 +14766,16 @@
     "release_downloads_repo": "shagu/ShaguTweaks",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "recommended": true,
+    "requires": [
+      "classicapi"
+    ]
   },
   {
     "name": "SimpleActionSets",
     "repo": "https://github.com/KarstenBade/SimpleActionSets",
-    "category": "SuperWoW",
+    "category": "UI",
     "description": "Save action bars as sets that can be swapped out.",
     "source": "turtle_wiki",
     "folder": "SimpleActionSets",
@@ -15443,34 +14809,46 @@
   },
   {
     "name": "SoloRaidTargetIcons",
-    "repo": "https://github.com/refaim/SoloRaidTargetIcons",
-    "category": "SuperWoW",
+    "repo": "https://github.com/jrc13245/SoloRaidTargetIcons",
+    "category": "General",
     "description": "Enables raid target icons through the default Blizzard UI while not in a group",
     "source": "turtle_wiki",
     "folder": "SoloRaidTargetIcons",
     "forks": [
       {
-        "label": "jrc13245",
-        "repo": "https://github.com/jrc13245/SoloRaidTargetIcons"
+        "label": "refaim",
+        "repo": "https://github.com/refaim/SoloRaidTargetIcons",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "Arcitec",
-        "repo": "https://github.com/Arcitec/SoloRaidTargetIcons"
+        "repo": "https://github.com/Arcitec/SoloRaidTargetIcons",
+        "requires": [
+          "superwow"
+        ]
       },
       {
         "label": "Chad90b",
-        "repo": "https://github.com/Chad90b/SoloRaidTargetIcons"
+        "repo": "https://github.com/Chad90b/SoloRaidTargetIcons",
+        "requires": [
+          "superwow"
+        ]
       }
     ],
     "release_downloads_repo": "refaim/SoloRaidTargetIcons",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "Sorgis Raid Marks",
     "repo": "https://github.com/sorgis-sorgis/sorgis_raid_marks",
-    "category": "SuperWoW",
+    "category": "Raiding",
     "description": "Raid mark targeting and assigning, improved fork making use of superwow",
     "source": "turtle_wiki",
     "folder": "sorgis_raid_marks",
@@ -15490,104 +14868,19 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "SP SwingTimer",
-    "repo": "https://github.com/MarcelineVQ/SP_SwingTimer",
-    "category": "SuperWoW",
-    "description": "Auto-Attack Swing Timer",
-    "source": "turtle_wiki",
-    "folder": "SP_SwingTimer",
-    "forks": [
-      {
-        "label": "al3xc1985",
-        "repo": "https://github.com/al3xc1985/SP_SwingTimer"
-      },
-      {
-        "label": "bretharte89",
-        "repo": "https://github.com/bretharte89/SP_SwingTimer"
-      },
-      {
-        "label": "TheoIX",
-        "repo": "https://github.com/TheoIX/SP_SwingTimer"
-      },
-      {
-        "label": "Leyki",
-        "repo": "https://github.com/Leyki/SP_SwingTimer"
-      },
-      {
-        "label": "Otari98",
-        "repo": "https://github.com/Otari98/SP_SwingTimer"
-      },
-      {
-        "label": "zanthor",
-        "repo": "https://github.com/zanthor/SP_SwingTimer"
-      },
-      {
-        "label": "Thrunk112",
-        "repo": "https://github.com/Thrunk112/SP_SwingTimer"
-      }
-    ],
-    "release_downloads_repo": "MarcelineVQ/SP_SwingTimer",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "SP_SwingTimer",
-    "repo": "https://github.com/balakethelock/SP_SwingTimer",
-    "category": "SuperWoW",
-    "description": "Warrior Swing Timer [Img1]",
-    "source": "turtle_wiki",
-    "folder": "SP_SwingTimer",
-    "forks": [
-      {
-        "label": "BahamutxD",
-        "repo": "https://github.com/BahamutxD/SP_SwingTimer"
-      },
-      {
-        "label": "Profiler781",
-        "repo": "https://github.com/Profiler781/SP_SwingTimer"
-      },
-      {
-        "label": "flyinbed",
-        "repo": "https://github.com/flyinbed/SP_SwingTimer"
-      },
-      {
-        "label": "kluy18",
-        "repo": "https://github.com/kluy18/SP_SwingTimer"
-      },
-      {
-        "label": "tperraut",
-        "repo": "https://github.com/tperraut/SP_SwingTimer"
-      }
-    ],
-    "release_downloads_repo": "balakethelock/SP_SwingTimer",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "SpiritLinker",
-    "repo": "https://github.com/MarcelineVQ/SpiritLinker",
-    "category": "SuperWoW",
-    "description": "Information bar for using Spirit Link",
-    "source": "turtle_wiki",
-    "folder": "SpiritLinker",
-    "release_downloads_repo": "MarcelineVQ/SpiritLinker",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
     "name": "SunderNP",
     "repo": "https://github.com/perks/SunderNP",
-    "category": "SuperWoW",
+    "category": "UI",
     "description": "Adds a sunder count to the right of your Nameplates",
     "source": "turtle_wiki",
     "folder": "SunderNP",
     "release_downloads_repo": "perks/SunderNP",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "SuperAPI",
@@ -15598,22 +14891,20 @@
     "folder": "SuperAPI",
     "forks": [
       {
-        "label": "laytya",
-        "repo": "https://github.com/laytya/SuperAPI"
-      },
-      {
-        "label": "Otari98",
-        "repo": "https://github.com/Otari98/SuperAPI"
-      },
-      {
         "label": "EVANnnn1996",
-        "repo": "https://github.com/EVANnnn1996/SuperAPI"
+        "repo": "https://github.com/EVANnnn1996/SuperAPI",
+        "requires": [
+          "superwow"
+        ]
       }
     ],
     "release_downloads_repo": "balakethelock/SuperAPI",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "SuperAPI Castlib",
@@ -15625,45 +14916,71 @@
     "forks": [
       {
         "label": "balakethelock",
-        "repo": "https://github.com/balakethelock/SuperAPI_Castlib"
+        "repo": "https://github.com/balakethelock/SuperAPI_Castlib",
+        "requires": [
+          "superwow"
+        ]
       }
     ],
     "release_downloads_repo": "Gescht/SuperAPI_Castlib",
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "SuperCleveRoid Macros",
     "repo": "https://github.com/brues-code/SuperCleveRoidMacros",
-    "category": "SuperWoW",
+    "category": "Combat",
     "description": "Enhance macros with dynamic tooltips, conditional execution, and extended syntax",
     "source": "turtle_wiki",
     "folder": "SuperCleveRoidMacros",
     "forks": [
       {
         "label": "jrc13245",
-        "repo": "https://github.com/jrc13245/SuperCleveRoidMacros"
+        "repo": "https://github.com/jrc13245/SuperCleveRoidMacros",
+        "requires": [
+          "nampower",
+          "unitxp"
+        ]
       },
       {
         "label": "eqomdx",
-        "repo": "https://github.com/eqomdx/SuperCleveRoidMacros"
+        "repo": "https://github.com/eqomdx/SuperCleveRoidMacros",
+        "requires": [
+          "nampower",
+          "unitxp"
+        ]
       },
       {
         "label": "twisniowski",
-        "repo": "https://github.com/twisniowski/SuperCleveRoidMacros"
+        "repo": "https://github.com/twisniowski/SuperCleveRoidMacros",
+        "requires": [
+          "nampower",
+          "unitxp"
+        ]
       },
       {
         "label": "Hippoom",
-        "repo": "https://github.com/Hippoom/SuperCleveRoidMacros"
+        "repo": "https://github.com/Hippoom/SuperCleveRoidMacros",
+        "requires": [
+          "nampower",
+          "unitxp"
+        ]
       }
     ],
     "release_downloads_repo": "brues-code/SuperCleveRoidMacros",
     "release_downloads_state": "ok",
-    "release_downloads": 76,
-    "release_downloads_at": "2026-09-03T19:26:40Z",
-    "recommended": true
+    "release_downloads": 82,
+    "release_downloads_at": "2026-09-06T08:38:49Z",
+    "recommended": true,
+    "requires": [
+      "classicapi",
+      "nampower",
+      "unitxp"
+    ]
   },
   {
     "name": "SuperLazyScript",
@@ -15679,108 +14996,81 @@
   },
   {
     "name": "SuperTotem",
-    "repo": "https://github.com/elboaf/SuperTotem",
-    "category": "SuperWoW",
+    "repo": "https://github.com/akzkak/SuperTotem",
+    "category": "UI",
     "description": "A Shaman totem and shield manager",
     "source": "turtle_wiki",
     "folder": "SuperTotem",
     "forks": [
       {
-        "label": "akzkak",
-        "repo": "https://github.com/akzkak/SuperTotem"
-      },
-      {
-        "label": "bretharte89",
-        "repo": "https://github.com/bretharte89/SuperTotem"
+        "label": "elboaf",
+        "repo": "https://github.com/elboaf/SuperTotem",
+        "requires": [
+          "superwow"
+        ]
       }
     ],
     "release_downloads_repo": "elboaf/SuperTotem",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "SuperWowCombatLogger",
     "repo": "https://github.com/pepopo978/SuperWowCombatLogger",
-    "category": "SuperWoW",
+    "category": "Raiding",
     "description": "Improved combatlogger for TurtleWoW (for LegacyPlayers/Monkeylogs)",
     "source": "turtle_wiki",
     "turtle_custom": true,
     "folder": "SuperWowCombatLogger",
     "forks": [
       {
-        "label": "Thaodan",
-        "repo": "https://github.com/Thaodan/SuperWowCombatLogger"
-      },
-      {
         "label": "USS-Enterprise-Guild/1701-CaptainsLog",
-        "repo": "https://github.com/USS-Enterprise-Guild/1701-CaptainsLog"
-      },
-      {
-        "label": "bretharte89",
-        "repo": "https://github.com/bretharte89/SuperWowCombatLogger"
-      },
-      {
-        "label": "Emyrk",
-        "repo": "https://github.com/Emyrk/SuperWowCombatLogger"
-      },
-      {
-        "label": "zanthor",
-        "repo": "https://github.com/zanthor/SuperWowCombatLogger"
-      },
-      {
-        "label": "MarcelineVQ/AdvancedLogger",
-        "repo": "https://github.com/MarcelineVQ/AdvancedLogger"
-      },
-      {
-        "label": "whtmst",
-        "repo": "https://github.com/whtmst/SuperWowCombatLogger"
-      },
-      {
-        "label": "KameleonUK",
-        "repo": "https://github.com/KameleonUK/SuperWowCombatLogger"
-      },
-      {
-        "label": "DaniTot",
-        "repo": "https://github.com/DaniTot/SuperWowCombatLogger"
-      },
-      {
-        "label": "melbaa",
-        "repo": "https://github.com/melbaa/SuperWowCombatLogger"
-      },
-      {
-        "label": "vargv666",
-        "repo": "https://github.com/vargv666/SuperWowCombatLogger"
+        "repo": "https://github.com/USS-Enterprise-Guild/1701-CaptainsLog",
+        "requires": [
+          "superwow"
+        ]
       }
     ],
     "release_downloads_repo": "pepopo978/SuperWowCombatLogger",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "Tankalyze",
     "repo": "https://github.com/twapegg/Tankalyze",
-    "category": "SuperWoW",
+    "category": "Combat",
     "description": "Captures missed Taunts and some other nice to have tank additions",
     "source": "turtle_wiki",
     "folder": "Tankalyze",
     "forks": [
       {
         "label": "MarcelineVQ",
-        "repo": "https://github.com/MarcelineVQ/Tankalyze"
+        "repo": "https://github.com/MarcelineVQ/Tankalyze",
+        "requires": [
+          "superwow"
+        ]
       }
     ],
     "release_downloads_repo": "twapegg/Tankalyze",
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "TankPlates",
     "repo": "https://github.com/daemonp/TankPlates",
-    "category": "SuperWoW",
+    "category": "UI",
     "description": "Colors enemy Nameplates depending on if they're targeting the player",
     "source": "turtle_wiki",
     "folder": "TankPlates",
@@ -15810,65 +15100,49 @@
     "release_downloads_state": "ok",
     "release_downloads": 0,
     "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
+    "recommended": true,
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "Tattler",
     "repo": "https://github.com/Bang1726528/Tattler",
-    "category": "SuperWoW",
+    "category": "Social",
     "description": "Announce when certain items or spells are used",
     "source": "turtle_wiki",
     "folder": "Tattler",
     "forks": [
       {
         "label": "MarcelineVQ",
-        "repo": "https://github.com/MarcelineVQ/Tattler"
+        "repo": "https://github.com/MarcelineVQ/Tattler",
+        "requires": [
+          "superwow"
+        ]
       }
     ],
     "release_downloads_repo": "Bang1726528/Tattler",
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "TrackTarget",
     "repo": "https://github.com/MarcelineVQ/TrackTarget",
-    "category": "SuperWoW",
+    "category": "General",
     "description": "Track any friendly you target which is assistable on the Minimap",
     "source": "turtle_wiki",
     "folder": "TrackTarget",
     "release_downloads_repo": "MarcelineVQ/TrackTarget",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "Twister",
-    "repo": "https://github.com/MarcelineVQ/Twister",
-    "category": "SuperWoW",
-    "description": "Addon to totem twist automatically.",
-    "source": "turtle_wiki",
-    "folder": "Twister",
-    "forks": [
-      {
-        "label": "bretharte89",
-        "repo": "https://github.com/bretharte89/Twister"
-      }
-    ],
-    "release_downloads_repo": "MarcelineVQ/Twister",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "_Nameplates",
-    "repo": "",
-    "category": "UI",
-    "description": "sorts nameplates into friendly and hostile columns [Img1]",
-    "source": "turtle_wiki",
-    "folder": "_Nameplates",
-    "installable": false
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow"
+    ]
   },
   {
     "name": "ABreathBeneath",
@@ -15902,20 +15176,7 @@
     "release_downloads_repo": "Otari98/ActionBarProfiles",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-09-02T05:51:38Z",
-    "recommended": true
-  },
-  {
-    "name": "agUnitFramesImproved",
-    "repo": "https://github.com/satan666/ag_UnitFrames_Improved",
-    "category": "UI",
-    "description": "Customizable unit frame addon",
-    "source": "turtle_wiki",
-    "folder": "ag_UnitFrames_Improved",
-    "release_downloads_repo": "satan666/ag_UnitFrames_Improved",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
     "name": "APD",
@@ -16332,18 +15593,6 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "Immersive Dialog UI",
-    "repo": "https://github.com/moiian/ImmersiveDialogUI",
-    "category": "UI",
-    "description": "A enhanced conversation addon with a focus on immersion and customization.",
-    "source": "turtle_wiki",
-    "folder": "ImmersiveDialogUI",
-    "release_downloads_repo": "moiian/ImmersiveDialogUI",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
     "name": "Impulse-booster",
     "repo": "https://github.com/Warlockbugs/impulse-booster",
     "category": "UI",
@@ -16392,24 +15641,6 @@
     "release_downloads_state": "ok",
     "release_downloads": 129,
     "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "Kui Nameplates",
-    "repo": "",
-    "category": "UI",
-    "description": "Prettier nameplates. Backport from later WoW versions.",
-    "source": "turtle_wiki",
-    "folder": "KuiNameplates",
-    "installable": false
-  },
-  {
-    "name": "LunaUnitFrames",
-    "repo": "",
-    "category": "UI",
-    "description": "Lightweight Unit Frames in a modern look",
-    "source": "turtle_wiki",
-    "folder": "LunaUnitFrames",
-    "installable": false
   },
   {
     "name": "McgUI",
@@ -16592,7 +15823,7 @@
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z",
-    "recommended": true
+    "requires": []
   },
   {
     "name": "pfUI-autoinvite",
@@ -16636,8 +15867,7 @@
     "release_downloads_repo": "mr-rosh/pfUI-CustomMedia",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
-    "recommended": true
+    "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
     "name": "pfUI-eliteoverlay",
@@ -16976,26 +16206,25 @@
   {
     "name": "Aegis SBR",
     "repo": "https://github.com/Torchlite-bit/Aegis_SBR",
-    "category": "Aegis",
+    "category": "Combat",
     "description": "Single-button rotation for Turtle/1.18.1 — evaluates class, resources, and procs each press (requires SuperWoW + Nampower).",
     "source": "manual",
     "folder": "Aegis_SBR",
     "installable": true,
-    "forks": [
-      {
-        "label": "EirikAskheim",
-        "repo": "https://github.com/EirikAskheim/Aegis_SBR"
-      }
-    ],
     "release_downloads_repo": "Torchlite-bit/Aegis_SBR",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow",
+      "nampower",
+      "unitxp"
+    ]
   },
   {
     "name": "Aegis Courier",
     "repo": "https://github.com/Torchlite-bit/Aegis_Courier",
-    "category": "Aegis",
+    "category": "Economy",
     "description": "Mailbox companion / TurtleMail replacement with auction-mail support and optional Aegis Exchange integration.",
     "source": "manual",
     "folder": "Aegis_Courier",
@@ -17003,35 +16232,28 @@
     "release_downloads_repo": "Torchlite-bit/Aegis_Courier",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [],
+    "recommended": true
   },
   {
     "name": "Aegis Exchange",
     "repo": "https://github.com/Torchlite-bit/Aegis_Exchange",
-    "category": "Aegis",
+    "category": "Economy",
     "description": "Clean, fast auction house UI for vanilla 1.12 with pricing, craft value, and gold tracking.",
     "source": "manual",
     "folder": "Aegis_Exchange",
     "installable": true,
-    "forks": [
-      {
-        "label": "rustybelter77",
-        "repo": "https://github.com/rustybelter77/Aegis_Exchange"
-      },
-      {
-        "label": "EirikAskheim",
-        "repo": "https://github.com/EirikAskheim/Aegis_Exchange"
-      }
-    ],
     "release_downloads_repo": "Torchlite-bit/Aegis_Exchange",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "recommended": true
   },
   {
     "name": "Aegis RallyPower",
     "repo": "https://github.com/Torchlite-bit/Aegis_RallyPower",
-    "category": "Aegis",
+    "category": "Combat",
     "description": "All-class raid buff coordination — PallyPower grid for Paladins plus matching buff bars for other classes.",
     "source": "manual",
     "folder": "Aegis_RallyPower",
@@ -17039,7 +16261,12 @@
     "release_downloads_repo": "Torchlite-bit/Aegis_RallyPower",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "requires": [
+      "superwow",
+      "unitxp"
+    ],
+    "recommended": true
   },
   {
     "name": "BijouCounter",
@@ -17138,8 +16365,8 @@
     "description": "# pfQuest (turtle)\nThis AddOn is a [pfQuest](https://github.com/shagu/pfQuest) extension, which adds support for the [TurtleWoW](https://turtle-wow.org/) Private Server. In order to run this extension, the latest version of [pfQuest](https://github.com/shagu/pfQuest) is always required and only enUS-Gameclients are supported.\n\n*Notice: Issues and bugs like \"please add quest XYZ\" and all other content requests will be silently ignored. This is, because the data is not manually added, but depends on the Turtle-WoW team to release their database to a trusted person that can produce pfQuest-turtle builds.*\n\nIf you wish to contribute, please feel free to send a [Pull Requests](https://github.com/bennylava/pfQuest-turtle/pulls).\n\n## Install\n*The latest version of [pfQuest](https://shagu.org/pfQuest) is required for this module to work.*\n\n1. Download **[pfQuest-turtle](https://github.com/bennylava/pfQuest-turtle/archive/master.zip)**\n2. Unpack the Zip file\n3. Rename the folder \"pfQuest-turtle-master\" to \"pfQuest-turtle\"\n4. Copy \"pfQuest-turtle\" into Wow-Directory\\Interface\\AddOns\n5. Restart Wow",
     "release_downloads_repo": "Bennylavaa/pfQuest-turtle",
     "release_downloads_state": "ok",
-    "release_downloads": 14,
-    "release_downloads_at": "2026-09-03T19:26:40Z"
+    "release_downloads": 17,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "pfQuest-turtle",
@@ -17157,26 +16384,15 @@
   {
     "name": "pfQuest-octo",
     "repo": "https://github.com/roby-brok/pfQuest-octo",
-    "category": "General",
+    "category": "Questing",
     "source": "community",
-    "turtle_custom": true,
     "folder": "pfQuest-octo",
-    "description": "A TurtleWoW DB extension for pfQuest (Moonwhisper70%)",
-    "release_downloads_repo": "vill8/pfQuest-octo",
-    "release_downloads_state": "none",
+    "description": "# pfQuest (Octo DB)\n\nA [pfQuest](https://github.com/The-Kludge-Bureau/pfQuest) database pack for the\n[OctoWoW](https://octowow.st) server (WoW 1.12.1), maintained by **Roby_Brok**.\nPart of my [OctoWoW addon setup](https://github.com/roby-brok/octowow-addons).\n\n**None of the data here is mine.** This pack is two existing packs combined, nothing more —\nsee [Credits](#credits). It exists because running both of them at once does not work.\n\n---\n\n## Why this exists\n\npfQuest database packs assign their tables outright rather than merging into them:\n\n```lua\npfDB[\"quests\"][\"data-turtle\"] = { ... }\n```\n\nSo with `pfQuest-octo` and `pfQuest-turtle` both installed, the one whose folder sorts last\nsimply replaces the other. `pfQuest-turtle` wins on the letter *t*, and `pfQuest-octo` is parsed\nat every login and thrown away — roughly 15 MB of work for data that never gets used, and the\nquest links point at the wrong server's website.\n\nPicking one meant giving something up: the turtle pack has far more quest data, the octo pack has\nthe OctoWoW corrections and links. This pack is both, so there is nothing to choose between.\n\n## What is in it\n\nThe TurtleWoW database as the base, with the Octo pack folded in on top:\n\n| | octo pack alone | this pack |\n|---|---|---|\n| quests | 5,175 | **6,842** |\n| units | 9,928 | **11,095** |\n| objects | 15,163 | **15,857** |\n| items | 9,301 | **12,672** |\n| locales | 5 | **6** (deDE regained) |\n| corrections | 137 | **162** |\n\n`overwrites.lua` carries three things in order — the 23 records the Octo DB has that the\nTurtleWoW build lacks, then the Octo pack's 137 corrections, then the TurtleWoW pack's own 2.\nRecords come first so anything indexing into them finds them present. The generated files under\n`db/` are byte-identical to the TurtleWoW build; nothing there was hand-edited, so a future\ndatabase refresh will not silently drop any of it.\n\nQuest links point at [octowow.st/db](https://octowow.st/db).\n\nThe pack's own code changes and fixes are listed in **[CHANGES-octo.md](CHANGES-octo.md)**.\n\n## Install\n\n**Requires [pfQuest](https://github.com/The-Kludge-Bureau/pfQuest).** This is a database pack, not\na standalone addon.\n\n1. **[Download the latest release](https://github.com/roby-brok/pfQuest-octo/releases/latest)** —\n   take *Source code (zip)* at the bottom of the release page\n2. Unpack it and open the `pfQuest-octo-<version>` folder inside\n3. Copy **`pfQuest-octo`** into `Wow-Directory\\Interface\\AddOns`\n4. *Non-English clients only:* also copy the one folder matching your language —\n   `pfQuest-octo-deDE`, `-esES`, `-ptBR`, `-ruRU` or `-zhCN`\n5. Restart WoW\n\n**Copy the folders from inside the wrapper, not the wrapper itself.** The zip unpacks to a\nfolder carrying the version or branch on the end — `pfQuest-octo-1.1.0`, or\n`pfQuest-octo-master` if you grabbed it straight off the branch. Copying *that* into `AddOns`\nis the one thing that goes wrong: WoW skips a folder whose name does not match the `.toc`\ninside it, in silence, with no error and no entry in the addon list. The folders one level\ndown are already named correctly, so there is nothing to rename.\n\n**English clients need only `pfQuest-octo`.** The language folders are load-on-demand: the pack\npulls in the single one matching your client and never touches the others, so copying all of them\ncosts nothing but disk. Copying none of them is fine too — quest text simply stays English.\n\n**Remove `pfQuest-turtle` if you have it.** Its data is already included here, and leaving both\ninstalled puts you right back in the situation this pack was built to avoid.\n\n## Credits\n\nEverything here is other people's work, combined and nothing else. All of it is MIT licensed,\ncopyright Eric Mauser (Shagu), and that licence is retained in full.\n\n* **[Shagu](https://github.com/shagu)** — wrote pfQuest and the original database packs.\n* **[The Kludge Bureau](https://github.com/The-Kludge-Bureau/pfQuest-turtle)** — the TurtleWoW\n  build this pack's databa\n\n… (truncated)",
+    "turtle_custom": true,
+    "release_downloads_repo": "roby-brok/pfQuest-octo",
+    "release_downloads_state": "ok",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z",
-    "forks": [
-      {
-        "label": "vill8",
-        "repo": "https://github.com/vill8/pfQuest-octo"
-      },
-      {
-        "label": "paokkerkir",
-        "repo": "https://github.com/paokkerkir/pfQuest-octo"
-      }
-    ],
-    "recommended": true
+    "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
     "name": "pfQuest-turtle",
@@ -17342,8 +16558,8 @@
     "description": "# For TurtleWoW launcher\nClick Addons - Add new addon - paste this url there: https://github.com/vaniron/TourGuide-Turtle.git\n\n# Contact & Donations\nYou can add me on discord: **vanironcz**\n\nIf you wanna support this fork, you can do so via https://www.paypal.com/donate/?hosted_button_id=FSQQQGRSBDA58\n\n# TourGuide-Turtle\nTekkub's TourGuide Addon backported for WoW 1.12 *with tweaks for TurtleWoW*\n\nRecommended Downloads: \n\n[**TomTom-TWOW**](https://github.com/laytya/TomTom-TWOW)\n* **Arrow to navigate you to next guide point**\n* you have to disable arrow from pfQuest as its showing closest quest, not optimal path - TomTom is integrated directly to TourGuide and shoudl be used instead\n\n[**pfQuest**](https://github.com/shagu/pfQuest) + [**pfQuest-turtle**](https://github.com/shagu/pfQuest-turtle)\n* pfQuest adds many features like tracking, map icons etc.\n\n[**pfUI**](https://github.com/shagu/pfUI)\n* pfUI provides so much more, overall UI overhaul but all features can be tweaked and disabled if you dont like them\n\nOptional addon: [TourGuide_Professions](https://github.com/Lorwik/TourGuide_Professions)\n\n\n**Features**\n* Automatic detection of objective completion\n  * Detect quest accept, completion and turnin\n  * Detect travel (by foot, flight, boat and stone)\n  * Detection of flight point discovery\n  * Detection of Hearth point change\n* Conditionals based on player’s class and item possession (only tell the player to accept the quest if they have the item that starts the quest)\n* Small “lego block” style frame shows current objective, detailed tooltips on hover\n* “Use item” frame, for those annoying quests where you have to use an item on a mob before you kill it, or you have to equip something, or you have to use an item to start a quest\n* Pop out frame for detailed view of quest sequence\n* Automatic mapping of coordinates with TomTom and questgiver locations from pfQuest if installed\n\nGuides list, plus few others didnt make it into the screenshot (Plaguelands, Silithus, Winterspring), too many for one screen xD\n![image](https://github.com/user-attachments/assets/7d655a07-d8b9-48ad-b514-b95fcefb81a8)\n\n\n**Contributors**\n* Tekkub\n* Cralor\n* Road-block\n* Rsheep\n* Azgaardian\n* Kyliexx\n* laytya\n* jb6357\n* Ez-mode\n* Gescht\n* Vaniron\n* Trus3683\n* Ravenhost",
     "release_downloads_repo": "vaniron/TourGuide-Turtle",
     "release_downloads_state": "ok",
-    "release_downloads": 239,
-    "release_downloads_at": "2026-09-03T19:26:40Z"
+    "release_downloads": 244,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "TourGuideVanilla",
@@ -17479,12 +16695,16 @@
     "description": "# pfUI - OctoWoW Edition\n\n> ### About this fork\n>\n> **This fork is maintained for [OctoWoW](https://octowow.st).** Everything here was found and\n> fixed while running on that server; the fixes are not OctoWoW-specific and should apply to any\n> 1.12 client, but OctoWoW is the only place it has actually been tested.\n>\n> pfUI is the work of **[Shagu](https://github.com/shagu/pfUI)** (Eric Mauser), released under the\n> MIT licence, and this branch descends from **me0wg4ming's** Turtle WoW edition — which is why\n> parts of the documentation below still refer to Turtle WoW. All the credit belongs to them; this\n> fork only adds the fixes listed here, on top of their work.\n>\n> Note that the upstream repository this was cloned from\n> (`github.com/me0wg4ming/pfUI`) is no longer reachable, which is part of why this copy exists.\n> The full original commit history is preserved here.\n>\n> Fork maintained by **Roby_Brok**. Version bumped to **9.0.8** to distinguish it.\n>\n> ---\n>\n> #### UI scale / resolution\n>\n> - **`GetPerfectPixel` guards an unparseable `gxResolution`** (previously `768 / nil`, which killed\n>   every border on the UI).\n>\n>   ~~It also measured against `UIParent:GetEffectiveScale()` rather than the `uiScale` cvar.~~\n>   **Reverted 2026-08-10 — that was wrong.** The cvar's 1.0 cap looks like a bug but is\n>   load-bearing: the \"Huge\"/\"Large\" presets push `UIParent` to 1.42 / 1.14 via `SetScale`, and\n>   measuring that true scale makes `768 / screenheight / scale` fall below half a pixel, so border\n>   `edgeSize` rounds to zero and the borders vanish. Caught by\n>   [brues-code](https://github.com/brues-code) after the same change was merged and then reverted\n>   upstream.\n> - **`pixelperfect` loaded 55th, but sets the scale everything else is measured against.** That\n>   value is cached on first use, so every module loaded before it baked in the *previous* scale —\n>   the classic \"reload twice before it looks right\". It now loads first.\n> - The module only re-applies the scale when it actually changes, and drops the cached pixel and\n>   border sizes when it does.\n> - \"Enable UI-Scale\" now asks for a reload instead of applying live, since existing frames keep\n>   border sizes computed for the old scale.\n>\n> #### Features that silently did nothing\n>\n> pfUI runs each module inside a sandboxed environment that has `__index` but no `__newindex`, so\n> a bare global assignment inside a module never reaches `_G`. These all looked registered and\n> were not:\n>\n> | Where | What was dead |\n> |---|---|\n> | `modules/nampower.lua` | `/disenchantall`, `/dea` |\n> | `modules/superwow.lua` | `/clickthrough`, `/ct` |\n> | `modules/unitxp.lua` | `/pfunitxp`, and the battleground-pop notification |\n> | `modules/hdgraphic.lua` | `OptionsFrame_OnShow` — the extended world-detail slider never installed |\n> | `modules/raid.lua` | `GROUP_REPLACE_PARTY` |\n>\n> #### Other\n>\n> - `modules/loot.lua` — restored `local autoLoot = arg1`; `CloseLoot(not autoLoot)` was reading a\n>   nil global and always suppressing the server-side close notification.\n> - `api/ui-widgets.lua` — removed a dead fourth value in `SetHighlight`'s colour assignment.\n> - `init/skins.xml` — removed a duplicated block that loaded five Turtle WoW skins twice.\n> - Plus an earlier batch of fixes across the stutter-prone hot paths (nameplate debuff scanning,\n>   unit-frame aggro checks, throttle allocations, cooldown updates), a number of silently broken\n>   features, and a class-colour accent option.\n> - `modules/thirdparty-vanilla.lua` — [OWThreat](https://github.com/roby-brok/OWThreat) now docks\n>   into the right chat panel and takes the pfUI skin, exactly like the TWThreat it was forked\n>   from; both are driven by the same *TW/OW Threatmeter* checkboxes under *Thirdparty*.\n>\n> ---\n\n[![Version](https://img.shields.io/badge/version-9.0.8-blue.svg)](https://github.com/roby-brok/pfUI)\n[![OctoWoW](https://img.shields.io/badge/OctoWoW-supported-brightgreen.svg)](https://octowo\n\n… (truncated)",
     "release_downloads_repo": "roby-brok/pfUI",
     "release_downloads_state": "ok",
-    "release_downloads": 14,
-    "release_downloads_at": "2026-09-03T12:51:29Z",
+    "release_downloads": 19,
+    "release_downloads_at": "2026-09-06T08:38:49Z",
     "forks": [
       {
         "label": "brues-code",
-        "repo": "https://github.com/brues-code/pfUI"
+        "repo": "https://github.com/brues-code/pfUI",
+        "requires": [
+          "classicapi",
+          "nampower"
+        ]
       },
       {
         "label": "shagu",
@@ -17495,7 +16715,11 @@
         "repo": "https://github.com/IndieMiao/pfUI"
       }
     ],
-    "recommended": true
+    "recommended": true,
+    "requires": [
+      "classicapi",
+      "nampower"
+    ]
   },
   {
     "name": "pfUI",
@@ -17506,8 +16730,8 @@
     "description": "# pfUI - ClassicAPI Edition\n\n[![Octo WoW](https://img.shields.io/badge/Octo%20WoW-1.18.1-brightgreen.svg)](https://octowow.st/)\n[![ClassicAPI](https://img.shields.io/badge/ClassicAPI-Required-purple.svg)](https://github.com/brues-code/ClassicAPI)\n[![Nampower](https://img.shields.io/badge/Nampower-Required-purple.svg)](https://github.com/brues-code/nampower)\n[![SuperWoW](https://img.shields.io/badge/SuperWoW-Optional-yellow.svg)](https://github.com/balakethelock/SuperWoW)\n[![UnitXP](https://img.shields.io/badge/UnitXP__SP3-Optional-yellow.svg)](https://github.com/brues-code/UnitXP_SP3)\n\n**A pfUI fork specifically optimized for ClassicAPI on [Octo WoW](https://octowow.st/)**\n\nThis version includes significant performance improvements and DLL-enhanced features.\n\n## Installation\n1. Download **[Latest Version](https://github.com/brues-code/pfUI/releases/latest)**\n2. Unpack the Zip file\n4. Copy \"pfUI\" into Wow-Directory\\Interface\\AddOns\n5. Restart Wow\n\n## DLL Enhancements\n\nSince pfUI 6.0.0 includes integrations with client-side DLLs for enhanced functionality. These DLLs are permitted on Octo WoW:\n\n### [ClassicAPI](https://github.com/brues-code/ClassicAPI)\n\nProvides:\n- C_NamePlate - Event-driven nameplates (no more per-frame WorldFrame scanning) with real per-plate unit tokens and GUIDs\n- C_UnitAuras - Replaces over 3k lines of hand-rolled aura tracking\n- C_Spell - Replaces thousands of hardcoded spell names for each locale and powers castbar\n- Real cast bars - Actual cast/channel timing, spellID and interrupt state for any unit (C_Spell.UnitCastingInfo)\n- Focus - A genuine `focus` unit plus `/focus` and `/clearfocus` (FocusUnit / ClearFocus)\n- C_EquipmentSet - Full Equipment Manager with GUID-tracked gear sets (tells apart duplicate/enchanted items)\n- Instant Bag Sorting - C_Container.MoveItem / SwapItems instead of cursor pickup/drop\n- Sell junk in one call - C_MerchantFrame.GetNumJunkItems / SellAllJunkItems\n- Real item data - C_Item counts, quality, sell price and item info by ID\n- GUID-based targeting - Nameplates, mouseover and focus resolve by GUID, not by name text\n- Faster, safer profile sharing - Engine-side serialize/compress/base64 via C_EncodingUtil\n- C_Timer - After / NewTicker replacing hand-rolled OnUpdate throttles\n- Feign death, shapeshift and quest-item detection via real API calls\n- Mouseover Unit Frames\n- Click-casting\n- Loot Roll History (/loothistory)\n- New item highlighting\n- Plenty other functions\n\n### [Nampower](https://github.com/brues-code/nampower)\n\nProvides:\n- Spell queue indicator\n- GCD indicator\n\n### [SuperWoW](https://github.com/balakethelock/SuperWoW)\n\nProvides:\n- Tracks party/raid units on the minimap\n\n### [UnitXP_SP3](https://github.com/brues-code/UnitXP_SP3)\n\nProvides:\n- Line of Sight detection\n- Behind detection\n- Accurate distance calculations\n- OS notifications\n\nUse `/pfdll` in-game to check which DLLs are detected.\n\n## Commands\n\n    /pfui         Open the configuration GUI\n    /pfdll        Show DLL detection status (SuperWoW, Nampower, UnitXP)\n    /pfbehind     Test Behind/LOS detection on current target\n    /clickthrough Toggle clickthrough mode (or /ct)\n    /share        Open the configuration import/export dialog\n    /gm           Open the ticket Dialog\n    /rl           Reload the whole UI\n    /farm         Toggles the Farm-Mode\n    /pfcast       Same as /cast but for mouseover units\n    /focus        Creates a Focus-Frame for the current target\n    /castfocus    Same as /cast but for focus frame\n    /clearfocus   Clears the Focus-Frame\n    /swapfocus    Toggle Focus and Target-Frame\n    /pftest       Toggle pfUI Unitframe Test Mode\n    /abp          Addon Button Panel\n    /loothistory  Show Loot Roll History\n\n## Languages\npfUI supports and contains language specific code for the following gameclients.\n* English (enUS)\n* Korean (koKR)\n* French (frFR)\n* German (deDE)\n* Chinese (zhCN)\n* Spanish (esES)\n* Russian (ruRU)\n\n## Recommended Addons\n* [pfQuest](https://github.co\n\n… (truncated)",
     "release_downloads_repo": "brues-code/pfUI",
     "release_downloads_state": "ok",
-    "release_downloads": 48,
-    "release_downloads_at": "2026-09-03T22:36:20Z"
+    "release_downloads": 94,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "NiceDamage-1.12",
@@ -17518,8 +16742,8 @@
     "description": "# NiceDamage for WoW Vanilla 1.12\n\n> ## 📥 Latest Release\n>\n> **Download the latest version here:**\n>\n> https://github.com/Wurmschwanz/NiceDamage-1.12/releases/latest\n\nA lightweight enhancement of the original **NiceDamage** addon for **World of Warcraft Vanilla 1.12**.\n\nNiceDamage replaces the default floating combat text font and introduces a lightweight minimap-based font selector with themed style categories while staying true to the original philosophy: **simple, lightweight and fast.**\n\n---\n\n# ✨ Features\n\n- Lightweight combat text font replacement\n- Minimap button for quick access\n- Hierarchical font selection menu\n- Style-based font organization\n- Automatic font saving\n- Lightweight implementation\n- No measurable FPS or CPU impact\n- Compatible with WoW Vanilla 1.12\n- Compatible with pfUI\n\n---\n\n# 🎨 Available Style Categories\n\n## Blizzard\n\n- Warcraft III Style\n- Diablo Style\n- StarCraft Style\n\n## FPS\n\n- Doom Style\n- Quake Style\n- Unreal Style\n- Half-Life Style\n\n## Sci-Fi\n\n- Halo Style\n- Alien Style\n\n---\n\n# 📦 Installation\n\n1. Remove any previous `NiceDamage` and `NiceDamage_Font_*` folders from:\n\n```text\nInterface/AddOns/\n```\n\n2. Extract the archive into:\n\n```text\nInterface/AddOns/\n```\n\n3. Start World of Warcraft.\n\n4. Left-click the minimap button to open the font menu.\n\n5. Select your preferred combat text style.\n\n> **Note**\n>\n> Some WoW Vanilla 1.12 clients cache combat fonts during startup.\n>\n> After changing the selected combat font, a **full game restart** is required.\n>\n> Using `/reload` is **not** sufficient on affected clients.\n\n---\n\n# ⚡ Performance\n\nNiceDamage was designed to remain lightweight.\n\n- No permanent `OnUpdate` loops\n- No continuous background processing\n- No measurable FPS impact\n- Font changes are only processed when requested by the player\n\n---\n\n# ✅ Compatibility\n\n- WoW Vanilla 1.12\n- pfUI compatible\n- Compatible with most Vanilla private servers using the original 1.12 client\n\n---\n\n# 🚀 Roadmap\n\nThe following style categories are planned for future updates.\n\n### Retro\n\n- Arcade\n- Terminal\n- Pixel\n\n### Fantasy\n\n- Medieval\n- Ancient\n\nMore style categories and additional combat font styles will be added over time.\n\n---\n\n# ❤️ Credits\n\nOriginal **NiceDamage** addon by its original author(s).\n\nEnhanced for **WoW Vanilla 1.12** by **Wurmschwanz**.\n\nSpecial thanks to everyone who helped testing fonts and improving compatibility.",
     "release_downloads_repo": "Wurmschwanz/NiceDamage-1.12",
     "release_downloads_state": "ok",
-    "release_downloads": 118,
-    "release_downloads_at": "2026-09-03T19:26:40Z"
+    "release_downloads": 124,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "Chronometer-Turtle",
@@ -17563,7 +16787,7 @@
   {
     "name": "MikScrollingBattleText",
     "repo": "https://github.com/roby-brok/MikScrollingBattleText",
-    "category": "General",
+    "category": "UI",
     "source": "community",
     "folder": "MikScrollingBattleText",
     "description": "<html>\n\t<head>\n\t\t<title>Mik's Scrolling Battle Text Readme</title>\n\t\t<style type=\"text/css\">\n\t\t\tbody { font-size: 10pt; font-family: verdana, arial, helvetica, sans-serif; }\n\t\t\th1   { font-weight: bold; color: #004080; }\n\n\t\t\ta:link    { color: #000060; text-decoration: none; }\n\t\t\ta:visited { color: #000060; text-decoration: none; }\n\t\t\ta:hover   { text-decoration: underline; }\n\n\t\t\tdiv#HeaderBlock { background-color: #e0e0e0; border: 1px solid #000060; padding: 1ex; margin: 2em 0em 4em 0em; }\n\n\t\t\tdiv.TOCTitle      { font-weight: bold; font-size: 14pt; color: #004080; border-bottom: 1px solid #000060; }\n\t\t\tdiv.TOC           { margin: 2ex 1ex 4em 2ex; }\n\t\t\tdiv.TOCSection    { margin-bottom: 2ex; }\n\n\t\t\tdiv.SectionTitle    { margin-top: 6ex; font-weight: bold; font-size: 14pt; color: #004080; border-bottom: 1px solid #000060; }\n\t\t\tdiv.SectionBody     { margin: 2ex 0ex 2ex 2ex; }\n\t\t\tdiv.SectionBody ul  { margin-top: 1ex; }\n\n\t\t\tdiv.SectionBody a:link    { color: #002080; }\n\t\t\tdiv.SectionBody a:visited { color: #002080; }\n\t\t\tdiv.SectionBody a:hover   { text-decoration: underline; }\n\n\t\t\tdiv.SubsectionTitle { margin-top: 4ex; margin-bottom: 2ex; font-weight: bold; font-size: 110%; color: #004080; }\n\t\t\tdiv.SubsectionBody  { margin: 2ex 0ex 2ex 2ex; }\n\n\t\t\tdiv.TriggerParameter { margin-left: 2ex; }\n\n\t\t\ttd.ParameterName { font-size: 10pt; background-color: #e0e0e0; vertical-align: top; }\n\t\t\ttd.ParameterDesc { font-size: 10pt; background-color: #e0e0e0; text-align: left; }\n\n\t\t\tli.FAQListItem { margin-bottom: 6ex; }\n\t\t</style>\n\t</head>\n\t<body>\n\t\t<h1>Mik's Scrolling Battle Text</h1>\n\t\t<div id=\"HeaderBlock\">\n\t\t\tVersion: 5.7.148<br />\n\t\t\tAuthor: Mikord<br />\n\t\t\tUpdated: February 5, 2018<br />\n\t\t\tOfficial Site: <a href=\"https://wow.curseforge.com/projects/mik-scrolling-battle-text\">https://wow.curseforge.com/projects/mik-scrolling-battle-text</a><br /><br />\n\t\t\t<a href=\"#Credits\">See Credits</a>\n\t\t</div>\n\n\t\t<div class=\"SectionTitle\"><a name=\"TOC\"></a>Table of Contents:</div>\n\t\t<div class=\"TOC\">\n\t\t\t<ul>\n\t\t\t\t<li><a href=\"#WhatsNew\">What's new?</a></li>\n\t\t\t\t<li><a href=\"#Install\">Installation Instructions</a></li>\n\t\t\t\t<li><a href=\"#Description\">Description</a></li>\n\t\t\t\t<li><a href=\"#Commands\">Commands</a></li>\n\t\t\t\t<li>\n\t\t\t\t\t<a href=\"#TriggerGuide\">Trigger Guide</a>\n\t\t\t\t\t<div class=\"TOCSection\">\n\t\t\t\t\t\t<ul>\n\t\t\t\t\t\t\t<li><a href=\"#TriggerBasicConcepts\">Basic Concepts</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#TriggerMechanics\">Trigger Mechanics</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#TriggerAdvancedConcepts\">Advanced Concepts</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#ExampleTriggers\">Example Triggers</a></li>\n\t\t\t\t\t\t</ul>\n\t\t\t\t\t</div>\n\t\t\t\t</li>\n\t\t\t\t<li>\n\t\t\t\t\t<a href=\"#TriggerReference\">Trigger Reference</a>\n\t\t\t\t\t<div class=\"TOCSection\">\n\t\t\t\t\t\t<ul>\n\t\t\t\t\t\t\t<li><a href=\"#MainEvents\">Trigger Main Events</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#MainEventConditions\">Main Event Conditions</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#TriggerExceptions\">Trigger Exceptions</a></li>\n\t\t\t\t\t\t</ul>\n\t\t\t\t\t</div>\n\t\t\t\t</li>\n\t\t\t\t<li><a href=\"#SearchPatternReference\">Search Pattern Reference</a></li>\n\t\t\t\t<li>\n\t\t\t\t\t<a href=\"#FAQ\">Frequently Asked Questions</a></li>\n\t\t\t\t\t<div class=\"TOCSection\">\n\t\t\t\t\t\t<ul>\n\t\t\t\t\t\t\t<li><a href=\"#FAQFonts\">I don't like any of the fonts supplied with MSBT. How do I use my own fonts?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQFontSize\">How do I increase the font size to something larger than 38?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQSounds\">How do I add my own custom sounds?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQNewTrigger\">How do I create a new trigger?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQMutilate\">Is it possible to prevent Mutilate from being merged?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQXP\">Is is possible to disable the default Blizzard XP Text?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQVE\">How do I suppress Vampiric Embrace?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQExclusiveIcons\">I want to see skill names even when there is an icon. Is that possible?</a></li>\n\t\t\t\t\t\t\t<li><a href=\"#FAQGameDamage\">Is there a way to show the damage ab\n\n… (truncated)",
@@ -17575,9 +16799,19 @@
       {
         "label": "HOYS",
         "repo": "https://github.com/HOYS/MikScrollingBattleText"
+      },
+      {
+        "label": "brues-code",
+        "repo": "https://github.com/brues-code/Vanilla_MikScrollingBattleText",
+        "requires": [
+          "nampower"
+        ]
       }
     ],
-    "recommended": true
+    "recommended": true,
+    "requires": [
+      "nampower"
+    ]
   },
   {
     "name": "NotGrid",
@@ -17602,7 +16836,8 @@
     "release_downloads_state": "none",
     "release_downloads": 0,
     "release_downloads_at": "2026-08-26T23:44:09Z",
-    "recommended": true
+    "recommended": true,
+    "requires": []
   },
   {
     "name": "CombatLedger",
@@ -17642,34 +16877,9 @@
     "release_downloads_at": "2026-08-26T23:44:09Z"
   },
   {
-    "name": "ExAutoCSHS",
-    "repo": "https://github.com/Excinerus/ExAutoCSHS",
-    "category": "General",
-    "source": "community",
-    "turtle_custom": true,
-    "folder": "ExAutoCSHS",
-    "description": "# ExAutoCSHS\nAn Addon for TurtleWoW for automatically alternating Crusader/Holy strike to maintain maximum uptime on the Zeal / Holy Might buffs \nThis relies on CombatLog entries and internal timers, so even if you break rotation it'll manage to keep up with buffs.\n\nAdditionally it will use lower ranks of CS/HS depending on mana availability.\n\nUsage : Create a macro with:\n/AutoCS [openCS/openHS/openAuto] [moreCS/moreHS/moreAuto] [prioZeal] [exorcism]\n\n- openCS opens with Crusader Strike,\n- openHS opens with Holy Strike,\n- openAuto opens with CS if using a 2h weapon, HS is 1h [default setting],\n\n- moreCS will do 2 crusader strikes to ever holy strike,\n- moreHS will only do CS when Zeal needs a refresh  so close to 3 HS per CS (for maximum threat tanking),\n- moreAuto will do moreCS  with a 2h weapon , moreHS  with one handed weapon  [default setting],\n\n- prioZeal will priorize getting zeal to 3 stacks regardless of rest of settings then proceed following them [disabled by default],\n\n- exorcism will attempt to cast Exorcism if CS/HS is on CD and the target is valid [disabled by default]\n\n\nExample: \n\n/AutoCS openHS prioZeal \n\nwill open with HS, priorize building zeal until 3 stacks , then proceeds only doing CS when Zeal needs a refresh \nthis results most of the time in :\nHS-CS-CS-HS-CS-HS-HS-HS-CS-HS-HS-HS-CS-HS-HS-HS...\n----1-2-----3--starts doing 3 HS to CS \n\n/AutoCS openHS prioZeal exorcism\nwill do the same interwoven with exorcism : \nHS-Exorcism-CS-CS-HS-Exorcism-CS-HS-HS-Exorcism-HS-CS-HS-Exorcism-HS-HS-CS-Exorcism ...",
-    "release_downloads_repo": "Excinerus/ExAutoCSHS",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
-    "name": "ExAutoCSHS",
-    "repo": "https://github.com/kninib12a/ExAutoCSHS",
-    "category": "General",
-    "source": "community",
-    "folder": "ExAutoCSHS",
-    "description": "An Addon for automatically alternating Crusader/Holy strike to maintain maximum uptime on the buffs",
-    "release_downloads_repo": "kninib12a/ExAutoCSHS",
-    "release_downloads_state": "none",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
-  },
-  {
     "name": "BlizzNameplatesPlus",
     "repo": "https://github.com/Wurmschwanz/BlizzNameplatesPlus",
-    "category": "General",
+    "category": "UI",
     "source": "community",
     "folder": "BlizzNameplatesPlus",
     "description": "# ⚔️ Blizz Nameplates+\n\n**Blizz Nameplates+** enhances the original Blizzard nameplates for **Vanilla WoW / 1.12** while preserving their classic look.\n\nIt adds multi-target aura tracking, castbars, Crowd Control, Combo Points and useful visual options without replacing the original nameplate design.\n\n**Current version:** `v1.0.7`\n**Required:** `SuperWoW.dll` and `ClassicAPI.dll`\n\n## ✨ Features\n\n* GUID-based multi-target debuff and DoT tracking\n* Numeric aura timers and stack counters\n* Separate Crowd Control tracking with an optional dedicated row\n* Optional supported CC effects from other players\n* Enemy castbars with spell icons\n* Blizzard-style Combo Points for Rogues and Druids\n* Target Glow and Target Plate on Top\n* Health text, class colors and Tank Mode\n* Foreign-tagged mobs shown with a neutral grey healthbar\n* Adjustable nameplate scale, Y offset, aura size and non-target alpha\n* Instant target-alpha updates and clean nameplate/aura layering\n* In-game settings through the **BN+ minimap button** or `/bnp`\n\n## 🔎 New: Missing Spell / Aura Recorder\n\nMissing a spell, DoT, proc or custom-server aura? The new recorder creates one complete, copyable diagnostic report—no screenshots or manual chat commands required.\n\n1. Open the BNP settings and click **Missing Spell / Aura...**\n2. Select the affected unit.\n3. Click **Start Recording**.\n4. Apply the aura, refresh it while active, then let it expire or remove it.\n5. Click **Stop**, followed by **Copy Report**.\n6. Paste the report into your bug report or support message.\n\nThe report includes the relevant Spell IDs, aura timing, target data and refresh events. The recorder is completely inactive until **Start Recording** is pressed and stops when the window is closed.\n\n## 📦 Requirements\n\nBoth DLLs are required and must be loaded before the game starts.\n\n### SuperWoW.dll\n\nProvides the GUID, unit, combat and cast information used for multi-target tracking, castbars and nameplate identification.\n\n[Download SuperWoW](https://github.com/balakethelock/SuperWoW)\n\n### ClassicAPI.dll\n\nProvides exact nameplate resolution and more reliable aura information, including Spell IDs, durations and expiration times. It is also used for instant target-alpha updates and the recorder’s direct **Copy Report** function.\n\n[Download ClassicAPI](https://github.com/brues-code/ClassicAPI)\n\n> Keep both DLLs up to date. Without them, Blizz Nameplates+ is not supported.\n\n## 📥 Installation\n\n1. Install `SuperWoW.dll` and `ClassicAPI.dll` using the instructions supplied with those projects.\n\n2. Make sure both DLLs are enabled in your DLL loader or `dlls.txt`.\n\n3. Delete any older `BlizzNameplatesPlus` addon folder.\n\n4. Extract the new folder into `Interface\\AddOns\\`.\n\n5. Verify the final path:\n\n   `Interface\\AddOns\\BlizzNameplatesPlus\\BlizzNameplatesPlus.toc`\n\n6. Start the game through your DLL-enabled launcher and enable enemy nameplates.\n\n## ⚙️ Main Settings\n\n* **Nameplates:** Scale, Y Offset, Non-Target Alpha, Class Colors, Tank Mode and Health Text\n* **Target:** Target Glow, glow color and Target Plate on Top\n* **Auras:** Icon Size, Debuffs, Crowd Control, separate CC row and CCs from other players\n* **Castbar:** Enable/disable and adjust height\n* **Class Features:** Combo Points for Rogue and Druid\n\nChanges are applied immediately.\n\n## ❤️ Credits\n\nCreated by **Wurmschwanz**.\nThanks to everyone who tested the addon, reported bugs and supplied recorder data.",
@@ -17681,7 +16891,7 @@
   {
     "name": "Atlas",
     "repo": "https://github.com/Otari98/Atlas",
-    "category": "General",
+    "category": "Maps",
     "source": "community",
     "turtle_custom": true,
     "folder": "Atlas",
@@ -17693,7 +16903,7 @@
   },
   {
     "name": "FishingBuddy",
-    "repo": "https://github.com/SeVeN7000/FishingBuddy",
+    "repo": "https://github.com/RyanHope/FishingBuddy",
     "category": "General",
     "source": "community",
     "folder": "FishingBuddy",
@@ -17701,12 +16911,19 @@
     "release_downloads_repo": "SeVeN7000/FishingBuddy",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-26T23:44:09Z"
+    "release_downloads_at": "2026-08-26T23:44:09Z",
+    "forks": [
+      {
+        "label": "SeVeN7000",
+        "repo": "https://github.com/SeVeN7000/FishingBuddy"
+      }
+    ],
+    "recommended": true
   },
   {
     "name": "AtlasQuest",
     "repo": "https://github.com/Otari98/AtlasQuest",
-    "category": "General",
+    "category": "Questing",
     "source": "community",
     "turtle_custom": true,
     "folder": "AtlasQuest",
@@ -17803,7 +17020,7 @@
   {
     "name": "AtlasLoot",
     "repo": "https://github.com/ashigaru/AtlasLoot",
-    "category": "General",
+    "category": "Raiding",
     "source": "community",
     "turtle_custom": true,
     "folder": "AtlasLoot",
@@ -17828,19 +17045,25 @@
     "description": "A Questhelper and Database Addon for World of Warcraft: Vanilla & TBC",
     "release_downloads_repo": "shagu/pfQuest",
     "release_downloads_state": "ok",
-    "release_downloads": 228142,
-    "release_downloads_at": "2026-09-03T22:36:20Z"
+    "release_downloads": 228566,
+    "release_downloads_at": "2026-09-06T08:38:49Z"
   },
   {
     "name": "AddOnOrganizer",
-    "repo": "https://github.com/Monteo/AddOnOrganizer",
+    "repo": "https://github.com/Otari98/AddOnOrganizer",
     "category": "General",
     "source": "community",
     "folder": "AddOnOrganizer",
     "release_downloads_repo": "Monteo/AddOnOrganizer",
     "release_downloads_state": "none",
     "release_downloads": 0,
-    "release_downloads_at": "2026-08-27T23:32:15Z"
+    "release_downloads_at": "2026-08-27T23:32:15Z",
+    "forks": [
+      {
+        "label": "Monteo",
+        "repo": "https://github.com/Monteo/AddOnOrganizer"
+      }
+    ]
   },
   {
     "name": "FlightMap",
@@ -17939,25 +17162,60 @@
     "release_downloads_at": "2026-09-02T05:51:38Z"
   },
   {
-    "name": "pfQuest-octo",
-    "repo": "https://github.com/roby-brok/pfQuest-octo",
-    "category": "General",
-    "source": "community",
-    "folder": "pfQuest-octo",
-    "description": "# pfQuest (Octo DB)\n\nA [pfQuest](https://github.com/The-Kludge-Bureau/pfQuest) database pack for the\n[OctoWoW](https://octowow.st) server (WoW 1.12.1), maintained by **Roby_Brok**.\nPart of my [OctoWoW addon setup](https://github.com/roby-brok/octowow-addons).\n\n**None of the data here is mine.** This pack is two existing packs combined, nothing more —\nsee [Credits](#credits). It exists because running both of them at once does not work.\n\n---\n\n## Why this exists\n\npfQuest database packs assign their tables outright rather than merging into them:\n\n```lua\npfDB[\"quests\"][\"data-turtle\"] = { ... }\n```\n\nSo with `pfQuest-octo` and `pfQuest-turtle` both installed, the one whose folder sorts last\nsimply replaces the other. `pfQuest-turtle` wins on the letter *t*, and `pfQuest-octo` is parsed\nat every login and thrown away — roughly 15 MB of work for data that never gets used, and the\nquest links point at the wrong server's website.\n\nPicking one meant giving something up: the turtle pack has far more quest data, the octo pack has\nthe OctoWoW corrections and links. This pack is both, so there is nothing to choose between.\n\n## What is in it\n\nThe TurtleWoW database as the base, with the Octo pack folded in on top:\n\n| | octo pack alone | this pack |\n|---|---|---|\n| quests | 5,175 | **6,842** |\n| units | 9,928 | **11,095** |\n| objects | 15,163 | **15,857** |\n| items | 9,301 | **12,672** |\n| locales | 5 | **6** (deDE regained) |\n| corrections | 137 | **162** |\n\n`overwrites.lua` carries three things in order — the 23 records the Octo DB has that the\nTurtleWoW build lacks, then the Octo pack's 137 corrections, then the TurtleWoW pack's own 2.\nRecords come first so anything indexing into them finds them present. The generated files under\n`db/` are byte-identical to the TurtleWoW build; nothing there was hand-edited, so a future\ndatabase refresh will not silently drop any of it.\n\nQuest links point at [octowow.st/db](https://octowow.st/db).\n\nThe pack's own code changes and fixes are listed in **[CHANGES-octo.md](CHANGES-octo.md)**.\n\n## Install\n\n**Requires [pfQuest](https://github.com/The-Kludge-Bureau/pfQuest).** This is a database pack, not\na standalone addon.\n\n1. **[Download the latest release](https://github.com/roby-brok/pfQuest-octo/releases/latest)** —\n   take *Source code (zip)* at the bottom of the release page\n2. Unpack it and open the `pfQuest-octo-<version>` folder inside\n3. Copy **`pfQuest-octo`** into `Wow-Directory\\Interface\\AddOns`\n4. *Non-English clients only:* also copy the one folder matching your language —\n   `pfQuest-octo-deDE`, `-esES`, `-ptBR`, `-ruRU` or `-zhCN`\n5. Restart WoW\n\n**Copy the folders from inside the wrapper, not the wrapper itself.** The zip unpacks to a\nfolder carrying the version or branch on the end — `pfQuest-octo-1.1.0`, or\n`pfQuest-octo-master` if you grabbed it straight off the branch. Copying *that* into `AddOns`\nis the one thing that goes wrong: WoW skips a folder whose name does not match the `.toc`\ninside it, in silence, with no error and no entry in the addon list. The folders one level\ndown are already named correctly, so there is nothing to rename.\n\n**English clients need only `pfQuest-octo`.** The language folders are load-on-demand: the pack\npulls in the single one matching your client and never touches the others, so copying all of them\ncosts nothing but disk. Copying none of them is fine too — quest text simply stays English.\n\n**Remove `pfQuest-turtle` if you have it.** Its data is already included here, and leaving both\ninstalled puts you right back in the situation this pack was built to avoid.\n\n## Credits\n\nEverything here is other people's work, combined and nothing else. All of it is MIT licensed,\ncopyright Eric Mauser (Shagu), and that licence is retained in full.\n\n* **[Shagu](https://github.com/shagu)** — wrote pfQuest and the original database packs.\n* **[The Kludge Bureau](https://github.com/The-Kludge-Bureau/pfQuest-turtle)** — the TurtleWoW\n  build this pack's databa\n\n… (truncated)",
-    "turtle_custom": true,
-    "release_downloads_repo": "roby-brok/pfQuest-octo",
-    "release_downloads_state": "ok",
-    "release_downloads": 0,
-    "release_downloads_at": "2026-09-02T05:51:38Z"
-  },
-  {
     "name": "Caw DPS Meter",
     "repo": "https://github.com/NovaElysium/CawDPSMeter",
     "category": "Combat",
     "source": "community",
     "folder": "CawDPSMeter",
     "description": "Caw DPS Meter is a compact damage/healing/utility meter for the 1.12 client",
+    "recommended": true,
+    "release_downloads": 3,
+    "release_downloads_at": "2026-09-06T08:38:49Z",
+    "release_downloads_state": "ok",
+    "release_downloads_repo": "NovaElysium/CawDPSMeter"
+  },
+  {
+    "name": "aDF",
+    "repo": "https://github.com/MarcelineVQ/aDF",
+    "category": "SuperWoW",
+    "description": "adds a small HUD that standardizes critical info about your target's defences, including Armor, Resists, and specific debuffs [Img1] https://github.com/Autignem/aDF Alt",
+    "source": "turtle_wiki",
+    "folder": "aDF",
+    "forks": [
+      {
+        "label": "Zebouski",
+        "repo": "https://github.com/Zebouski/aDF"
+      },
+      {
+        "label": "whtmst",
+        "repo": "https://github.com/whtmst/aDF"
+      },
+      {
+        "label": "KameleonUK",
+        "repo": "https://github.com/KameleonUK/aDF"
+      },
+      {
+        "label": "pepopo978",
+        "repo": "https://github.com/pepopo978/aDF"
+      },
+      {
+        "label": "melbaa",
+        "repo": "https://github.com/melbaa/aDF"
+      }
+    ],
+    "release_downloads_repo": "MarcelineVQ/aDF",
+    "release_downloads_state": "none",
+    "release_downloads": 0,
+    "release_downloads_at": "2026-09-02T05:51:38Z",
+    "recommended": true
+  },
+  {
+    "name": "MusicExpanded",
+    "repo": "https://github.com/lightbladeninja/MusicExpanded",
+    "category": "General",
+    "source": "community",
+    "folder": "MusicExpanded",
+    "description": "This addon adds music from later expansions to vanilla wow 1.12 private servers.",
     "recommended": true
   }
 ]

--- a/ichalaunch/data/addons.json.sig
+++ b/ichalaunch/data/addons.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "R6k2nrJKfp3tta1jwJ/iu6yv/T9Iza7wpuK48oeDkcbbeXM1K1HzBxLjeZHt81OqtDFkyswcmOnt0C5ZpHG3AQ==",
+  "sig": "cJZ5Dnw29S/Bic9T0Tx+UDbRq5NBsilkXeXt82u5S0+SazuOp+z27DukMUsfTxl4HGc4NDP09jmN9hDSpJE9Aw==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "62cee0344053883b33ae64532968006e8dc64465e4aa42a12ce0b78790d9da61"
+    "sha256": "831c427f8524bec010c8c116b64a82411c90686a387151fff60b778361f5fc07"
   },
-  "attestation_sig": "TjOEKTpZt945z6APLY8fQLsTtmAi4vAMyZzYvWXmEn5qHgtamCo9jmnl5kW2/PFzkyiLr7m0qtCC5DExPXcaDg=="
+  "attestation_sig": "lKOKR5Ofe/GwmOc/ZHEYdTWTaBXuSPYOzwSr7Srt4iCTVCD72OW7t5JAhGrARoC75+C6chF3+8NBHVjrWxqjCw=="
 }


### PR DESCRIPTION
## Summary
- Sync public GitHub hop addons.json + addon_tips.json (+ matching .sig) to Gitea master after #126 review recovery.
- Exact signed pairs from Gitea/CDN; no resign.

## Test plan
- [ ] Contents API hashes match Gitea a62f0f8 / CDN
- [ ] Sidecar verify OK for both catalogs
