### PR TITLE
Sign live catalog files

### DIFF
--- a/ichalaunch/data/manifest.json
+++ b/ichalaunch/data/manifest.json
@@ -1,13 +1,13 @@
 {
   "product": "RavenLaunch",
   "schema": 1,
-  "generated_at": "2026-09-07T13:27:51Z",
-  "updated_at": "2026-09-07T13:27:51Z",
+  "generated_at": "2026-09-08T02:09:22Z",
+  "updated_at": "2026-09-08T02:09:22Z",
   "catalogs": {
-    "addons": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addons.json",
-    "addon_tips": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/addon_tips.json",
-    "home_art": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/home_art.json",
-    "mods": "https://raw.githubusercontent.com/brutaliccus/IchaLaunch/master/ichalaunch/data/mods.json",
+    "addons": "https://download.ravencraft.io/ichalaunch/data/addons.json",
+    "addon_tips": "https://download.ravencraft.io/ichalaunch/data/addon_tips.json",
+    "home_art": "https://download.ravencraft.io/ichalaunch/data/home_art.json",
+    "mods": "https://download.ravencraft.io/ichalaunch/data/mods.json",
     "client_manifest": "https://download.ravencraft.io/ichalaunch/data/client_manifest.json",
     "client_inner": "https://download.ravencraft.io/ichalaunch/data/client_inner.json"
   },
@@ -15,31 +15,30 @@
     "url": "https://download.ravencraft.io/RavenCraft.zip",
     "filename": "RavenCraft.zip",
     "sha256": "86059fa229800050bbe066e5ae19f59eb936f10a077a9581596cb879d013e565",
-    "size": 9829040584,
-    "sig_url": "https://download.ravencraft.io/RavenCraft.zip.sig"
+    "size": 9829040584
   },
   "launcher": {
     "id": "ichalaunch",
-    "url": "https://github.com/brutaliccus/IchaLaunch/releases/download/v1.6.2/IchaLaunch.exe",
-    "version": "1.6.6",
-    "sha256": "937de6f86b4fe0db4aa7b9b5b8bcff7240e0754792ab710045680bee1e6a7095",
-    "size": 55363433,
+    "url": "https://download.ravencraft.io/IchaLaunch.exe",
+    "version": "1.6.7",
+    "sha256": "b1c2617d70729446a540047577c4c536fa3604693feef6de5e36cda16c5e2331",
+    "size": 57262944,
     "platforms": {
       "windows": {
         "type": "raw",
         "url": "https://download.ravencraft.io/IchaLaunch.exe",
         "filename": "IchaLaunch.exe",
-        "sha256": "937de6f86b4fe0db4aa7b9b5b8bcff7240e0754792ab710045680bee1e6a7095",
-        "version": "1.6.6",
-        "size": 55363433
+        "sha256": "b1c2617d70729446a540047577c4c536fa3604693feef6de5e36cda16c5e2331",
+        "version": "1.6.7",
+        "size": 57262944
       },
       "linux": {
         "type": "raw",
         "url": "https://download.ravencraft.io/IchaLaunch-linux-x86_64",
         "filename": "IchaLaunch-linux-x86_64",
-        "sha256": "ea92f57f1c700987db186404df7e107e9bc45ad962a1155700d8991f5b26a1e3",
-        "version": "1.6.6",
-        "size": 67906816
+        "sha256": "9c2883a032ce731dcd3e7315f2872843131637336102945f6b49f5f1bf0c922d",
+        "version": "1.6.7",
+        "size": 69806520
       }
     },
     "downloads": {
@@ -47,25 +46,25 @@
         "type": "raw",
         "url": "https://download.ravencraft.io/IchaLaunch.exe",
         "filename": "IchaLaunch.exe",
-        "sha256": "937de6f86b4fe0db4aa7b9b5b8bcff7240e0754792ab710045680bee1e6a7095",
-        "version": "1.6.6",
-        "size": 55363433
+        "sha256": "b1c2617d70729446a540047577c4c536fa3604693feef6de5e36cda16c5e2331",
+        "version": "1.6.7",
+        "size": 57262944
       },
       "linux_appimage": {
         "type": "raw",
-        "url": "https://download.ravencraft.io/Raven_Launcher-1.6.6-x86_64.AppImage",
-        "filename": "Raven_Launcher-1.6.6-x86_64.AppImage",
-        "sha256": "96d2a6657c8cd174853373b3314d6cc748bca0124d0727d587ba015bdd05ab9f",
-        "version": "1.6.6",
-        "size": 68434424
+        "url": "https://download.ravencraft.io/Raven_Launcher-1.6.7-x86_64.AppImage",
+        "filename": "Raven_Launcher-1.6.7-x86_64.AppImage",
+        "sha256": "7593b2c95974c19d26c12e24a615e7db81e6285c266f90adfdecf415d9dd90fd",
+        "version": "1.6.7",
+        "size": 70334968
       },
       "linux_tarball": {
         "type": "raw",
-        "url": "https://download.ravencraft.io/IchaLaunch-1.6.6-linux-x86_64.tar.gz",
-        "filename": "IchaLaunch-1.6.6-linux-x86_64.tar.gz",
-        "sha256": "5ba399b96b0b662536dc532cfc7380426614dd35c52d7c432fe67f5d7acc0920",
-        "version": "1.6.6",
-        "size": 67278928
+        "url": "https://download.ravencraft.io/IchaLaunch-1.6.7-linux-x86_64.tar.gz",
+        "filename": "IchaLaunch-1.6.7-linux-x86_64.tar.gz",
+        "sha256": "570865994e3fa9e9f2a13d0de73d149bf28463c85b104476808631a056275d29",
+        "version": "1.6.7",
+        "size": 69178483
       }
     }
   },

--- a/ichalaunch/data/manifest.json.sig
+++ b/ichalaunch/data/manifest.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "NitPwkGVV/+eyYCiuRHonSMsUV2wd7ygnN9A2NFlpI9BZvmTnYCD3Qxxx6EUdsTI27GRHmbWEfqXBh6Swc5ADQ==",
+  "sig": "OpucE1S6+bGgfvHcIXPuhwqbUTjqOMBu7rMqTdAPYrTwXiWfBUPFEi5EbJZnCqQWc3rvDHAK7qt8LQoB9Lm/DA==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "c99b69997a45eb7e96b8269e9ae6c89bcc68134ea08106e1ada28fe2b9dbd344"
+    "sha256": "cd5d24486785fdc6601d6df593a8c6d5ae3a5f54b2913760050c87c6a422efbf"
   },
-  "attestation_sig": "dSTvohNXYOitxTgHHgPduF667z3owqQuBq6NaIFkI1S+KkOwr+rVV3nvkAoQ1PzLpqixhWSnM+wEoYgQrS/6AA=="
+  "attestation_sig": "2W0gsXeeQrrfIVveIVP2tIKiGfUKxaehWbvrzIeNUyPk1NEgpmUGqB0wnB46gZhujEFaJI3D/i7nXE1eZsyKBw=="
 }

--- a/ichalaunch/data/mods.json
+++ b/ichalaunch/data/mods.json
@@ -1351,17 +1351,19 @@
       ]
     },
     "source": {
-      "type": "local",
-      "path": "tools/_weirdutils/out/dpslog.dll",
+      "type": "raw",
+      "url": "https://download.ravencraft.io/ichalaunch/weirdutils/dpslog.dll",
       "filename": "dpslog.dll",
-      "bundle": "weirdutils",
+      "sha256": "abfa563505a850b1525bc16c01c9528ad3d1bc7b6640be159c00eff0ea6cab51",
+      "dest_sha256": "abfa563505a850b1525bc16c01c9528ad3d1bc7b6640be159c00eff0ea6cab51",
       "version": "0.1",
-      "build_hint": "Run: python tools/build_weirdutils.py --build-only"
+      "skip_local_override": true
     },
     "files": [
       {
         "match": "dpslog.dll",
-        "destination": "dpslog.dll"
+        "destination": "dpslog.dll",
+        "sha256": "abfa563505a850b1525bc16c01c9528ad3d1bc7b6640be159c00eff0ea6cab51"
       }
     ],
     "dlls_txt": {
@@ -1454,25 +1456,25 @@
       "type": "raw",
       "url": "https://download.ravencraft.io/IchaLaunch.exe",
       "filename": "IchaLaunch.exe",
-      "sha256": "937de6f86b4fe0db4aa7b9b5b8bcff7240e0754792ab710045680bee1e6a7095",
-      "version": "1.6.6",
-      "size": 55363433,
+      "sha256": "b1c2617d70729446a540047577c4c536fa3604693feef6de5e36cda16c5e2331",
+      "version": "1.6.7",
+      "size": 57262944,
       "platforms": {
         "windows": {
           "type": "raw",
           "url": "https://download.ravencraft.io/IchaLaunch.exe",
           "filename": "IchaLaunch.exe",
-          "sha256": "937de6f86b4fe0db4aa7b9b5b8bcff7240e0754792ab710045680bee1e6a7095",
-          "version": "1.6.6",
-          "size": 55363433
+          "sha256": "b1c2617d70729446a540047577c4c536fa3604693feef6de5e36cda16c5e2331",
+          "version": "1.6.7",
+          "size": 57262944
         },
         "linux": {
           "type": "raw",
           "url": "https://download.ravencraft.io/IchaLaunch-linux-x86_64",
           "filename": "IchaLaunch-linux-x86_64",
-          "sha256": "ea92f57f1c700987db186404df7e107e9bc45ad962a1155700d8991f5b26a1e3",
-          "version": "1.6.6",
-          "size": 67906816
+          "sha256": "9c2883a032ce731dcd3e7315f2872843131637336102945f6b49f5f1bf0c922d",
+          "version": "1.6.7",
+          "size": 69806520
         }
       },
       "downloads": {
@@ -1480,25 +1482,25 @@
           "type": "raw",
           "url": "https://download.ravencraft.io/IchaLaunch.exe",
           "filename": "IchaLaunch.exe",
-          "sha256": "937de6f86b4fe0db4aa7b9b5b8bcff7240e0754792ab710045680bee1e6a7095",
-          "version": "1.6.6",
-          "size": 55363433
+          "sha256": "b1c2617d70729446a540047577c4c536fa3604693feef6de5e36cda16c5e2331",
+          "version": "1.6.7",
+          "size": 57262944
         },
         "linux_appimage": {
           "type": "raw",
-          "url": "https://download.ravencraft.io/Raven_Launcher-1.6.6-x86_64.AppImage",
-          "filename": "Raven_Launcher-1.6.6-x86_64.AppImage",
-          "sha256": "96d2a6657c8cd174853373b3314d6cc748bca0124d0727d587ba015bdd05ab9f",
-          "version": "1.6.6",
-          "size": 68434424
+          "url": "https://download.ravencraft.io/Raven_Launcher-1.6.7-x86_64.AppImage",
+          "filename": "Raven_Launcher-1.6.7-x86_64.AppImage",
+          "sha256": "7593b2c95974c19d26c12e24a615e7db81e6285c266f90adfdecf415d9dd90fd",
+          "version": "1.6.7",
+          "size": 70334968
         },
         "linux_tarball": {
           "type": "raw",
-          "url": "https://download.ravencraft.io/IchaLaunch-1.6.6-linux-x86_64.tar.gz",
-          "filename": "IchaLaunch-1.6.6-linux-x86_64.tar.gz",
-          "sha256": "5ba399b96b0b662536dc532cfc7380426614dd35c52d7c432fe67f5d7acc0920",
-          "version": "1.6.6",
-          "size": 67278928
+          "url": "https://download.ravencraft.io/IchaLaunch-1.6.7-linux-x86_64.tar.gz",
+          "filename": "IchaLaunch-1.6.7-linux-x86_64.tar.gz",
+          "sha256": "570865994e3fa9e9f2a13d0de73d149bf28463c85b104476808631a056275d29",
+          "version": "1.6.7",
+          "size": 69178483
         }
       }
     }

--- a/ichalaunch/data/mods.json.sig
+++ b/ichalaunch/data/mods.json.sig
@@ -1,10 +1,10 @@
 {
   "key_id": "cNGIDU6hwD8nlj+kXxMr32a47pRNYPszTfH7S4p+oEk=",
-  "sig": "VXshmr7XOyPEzrKh2zGBIdNKgUwC/w0Q1CbS7uTV3N0ACYX2q9NY8KfcVOLb53r+v0wyOrb+7IwtkfsPZWW+Aw==",
+  "sig": "LGpIDV4CR7oAixVV11ZBxIKXQOO0DiJ+jwFKZ/Qw6PE+hSBLsY0sEyfqXLgdiXP/ifh4H23jb3vC1xvLZzXaAw==",
   "attestation": {
     "purpose": "ichalaunch-catalog",
     "version": "catalog",
-    "sha256": "1615924522f628223fe164d76d4054c16abdb23cce22a923ff394958836bcfe5"
+    "sha256": "54ba7a80c7b51e3092e08e875a41680dbe38204a4fb1beb85ecb3114a31b0364"
   },
-  "attestation_sig": "Io9p2ynOiFjYVrNCi3m+cd3NL0Nn3m5WzYy95o51yNcE7awp3YlteEl36hUqpE1gAtQMBLDYwgdA0T64/RUaBg=="
+  "attestation_sig": "5nhOWwyujpc1733gXRf+7br5aQvdm+fz+WNW+GNXBub5ZQDoPeB7Eh1oE46vel5p5/mwcaQ65JHqSsVicAKRCw=="
 }


### PR DESCRIPTION
## Summary
- Signed live catalog file(s) locally (`ichalaunch-catalog` purpose).
- Sidecars belong at `ichalaunch/data/<name>.sig` beside the JSON.
- Merge JSON + `.sig` together.
- Signing keys stay on the maintainer machine and never enter CI.
- After merge, publish to the CDN / update server: `python tools/publish_cdn.py --catalogs`
